### PR TITLE
Replace anchor confirmation with calibration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,15 +36,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,12 +46,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -76,12 +61,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -164,15 +143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,27 +193,6 @@ dependencies = [
  "cast",
  "itertools",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -303,18 +252,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "env_filter"
@@ -384,15 +321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,33 +365,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -495,15 +400,6 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -544,7 +440,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "libc",
 ]
 
@@ -553,15 +449,6 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -613,31 +500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,19 +510,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -677,7 +526,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "memchr",
  "unicase",
 ]
@@ -698,15 +547,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,7 +554,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -767,21 +607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -831,18 +662,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -920,43 +739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,16 +774,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1009,17 +782,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1466,14 +1228,12 @@ dependencies = [
  "env_logger",
  "fs2",
  "log",
- "postcard",
  "pulldown-cmark",
  "regex",
  "rustc-hash",
  "serde",
  "serde_json",
  "sha2",
- "sled",
  "tempfile",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src/**/*", "assets/ruleset.json", "Cargo.toml", "LICENSE", "README.m
 [features]
 default = ["translate"]
 async-transport = ["dep:tokio"]
-translate = ["dep:ureq", "dep:urlencoding", "dep:sled", "dep:postcard"]
+translate = ["dep:ureq", "dep:urlencoding"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -35,8 +35,6 @@ toml = "0.8"
 tokio = { version = "1", features = ["rt", "io-util", "time", "sync", "macros", "io-std"], optional = true }
 ureq = { version = "3", optional = true }
 urlencoding = { version = "2", optional = true }
-sled = { version = "0.34", optional = true }
-postcard = { version = "1", features = ["alloc"], optional = true }
 rustc-hash = "2.1.1"
 fs2 = "0.4"
 

--- a/assets/ruleset.json
+++ b/assets/ruleset.json
@@ -816,7 +816,8 @@
       "to": ["記憶體"],
       "type": "cross_strait",
       "context": "區分 RAM (記憶體) 與 ROM/Flash (儲存空間)",
-      "english": "memory (RAM)"
+      "english": "memory (RAM)",
+      "exceptions": ["海內存知己"]
     },
     {
       "from": "內存分配",

--- a/src/engine/s2t.rs
+++ b/src/engine/s2t.rs
@@ -72,8 +72,6 @@ impl S2TConverter {
 
     /// Convert Simplified Chinese text to Traditional Chinese (Taiwan variant).
     pub fn convert(&self, input: &str) -> String {
-        // Phase 1+2: phrase substitution + character fallback in a single pass.
-        //
         // Scan for phrase matches. Between matches (and after the last match),
         // apply character-level conversion.
         let mut out = String::with_capacity(input.len());
@@ -100,7 +98,7 @@ impl S2TConverter {
             out.push(self.convert_char(ch));
         }
 
-        // Phase 3: TW variant normalization.
+        // TW variant normalization.
         if self.tw_variant_map.is_empty() {
             return out;
         }

--- a/src/engine/translate.rs
+++ b/src/engine/translate.rs
@@ -1,44 +1,19 @@
-// Google Translate anchor-confirmation for cross-strait term verification.
+// Google Translate calibration layer for cross-strait term verification.
 //
-// Pipeline (confirm, not discover):
-//   1. Scanner finds issues with 'english' fields
-//   2. Extract sentence-context around each issue
-//   3. For each term, check sled cache first (cache hits bypass API cap)
-//   4. On cache miss, call Google Translate zh→en unless max_api_calls cap
-//      reached (serial, 200ms rate-limit between calls)
-//   5. Confirm: if English output contains the rule's 'english' anchor,
-//      the issue is a TRUE cross-strait term (Confirmed → keep severity)
-//   6. If anchor absent → Rejected → downgrade severity to Info
-//   7. If translation fails → Unknown → fail-open (keep severity)
-//
-// Latency control:
-//   - max_api_calls (default 10) caps network calls per confirm_issues() run
-//   - Cache hits are free — only cache misses count toward the cap
-//   - Worst-case: max_api_calls * ~500ms (200ms delay + ~300ms roundtrip)
-//   - transport_failed flag on ConfirmResult lets callers distinguish
-//     "sampling returned Unknown" from "sampling transport broke entirely"
-//
-// Cache design:
-//   - sled embedded key-value DB; path via dirs::cache_dir():
-//     macOS: ~/Library/Caches/zhtw-anchor-translate/translations.db/
-//     Linux: ~/.cache/zhtw-anchor-translate/translations.db/
-//   - sled creates a directory (not a file) at the DB path, with
-//     memory-mapped segment files (~512KB pre-allocated)
-//   - postcard binary serialization (compact, strongly typed)
-//   - SHA-256 keyed entries with 30-day TTL
-//   - Size-limited with random eviction at 10 MB
-//   - Lock detection for concurrent access
+// Pipeline (calibrate, not confirm):
+//   1. Scanner finds issues; some have 'english' fields from matched rules.
+//   2. Extract ±sentence context around each issue, deduplicate.
+//   3. Single google_translate_raw() call (zh→en) on a sentinel-delimited payload.
+//   4. For each issue with 'english' field, check if content-word anchors
+//      appear in the corresponding translated segment.
+//   5. Set issue.anchor_match = Some(true/false/None) as annotation.
+//   6. No severity mutation. Pure annotation. Fail-open on API failure.
 
-use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
-use crate::rules::ruleset::{Issue, Severity};
-
-// Tri-state translation outcome
+use crate::rules::ruleset::Issue;
 
 /// Errors from the Google Translate API layer.
 #[derive(Debug)]
@@ -61,267 +36,62 @@ impl fmt::Display for TranslateError {
     }
 }
 
-/// Tri-state outcome of anchor confirmation for a single term.
-#[derive(Debug, PartialEq, Eq)]
-pub enum TranslateOutcome {
-    /// English anchor found in translation — true positive.
-    Confirmed,
-    /// Translation succeeded but anchor absent — likely false positive.
-    Rejected,
-    /// Translation failed — cannot determine; fail-open (keep severity).
-    Unknown,
-}
-
-// Translation cache (sled-backed)
-
-/// Default cache path via `dirs::cache_dir()`:
-/// - macOS: `~/Library/Caches/zhtw-anchor-translate/translations.db/`
-/// - Linux: `~/.cache/zhtw-anchor-translate/translations.db/`
-///
-/// Note: sled creates a directory at this path, not a single file.
-fn default_cache_path() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("zhtw-anchor-translate")
-        .join("translations.db")
-}
-
-/// Cache configuration (mirrors cjk-token-reducer CacheConfig).
-pub struct CacheConfig {
-    /// TTL for cache entries.
-    pub ttl: Duration,
-    /// Maximum cache size in bytes before eviction kicks in.
-    pub max_size_bytes: u64,
-}
-
-impl Default for CacheConfig {
-    fn default() -> Self {
-        Self {
-            ttl: Duration::from_secs(30 * 86400), // 30 days
-            max_size_bytes: 10 * 1024 * 1024,     // 10 MB
-        }
-    }
-}
-
-/// Session-level hit/miss counters (atomic, thread-safe).
-static CACHE_HITS: AtomicU64 = AtomicU64::new(0);
-static CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
-static INSERT_COUNT: AtomicU64 = AtomicU64::new(0);
-
-/// Check interval for cache size enforcement (every N inserts).
-const SIZE_CHECK_INTERVAL: u64 = 50;
-/// Entries larger than this trigger an immediate size check.
-const LARGE_ENTRY_THRESHOLD: usize = 4096;
-/// Maximum eviction rounds to prevent infinite loops.
-const MAX_EVICTION_ROUNDS: usize = 10;
-
-/// Cache entry stored in sled, serialized via postcard.
-#[derive(serde::Serialize, serde::Deserialize)]
-struct CacheEntry {
-    translated: String,
-    timestamp: i64, // Unix seconds
-    source_lang: String,
-    target_lang: String,
-}
-
-/// sled-backed translation cache with SHA-256 keys, TTL, and size limits.
-pub struct TranslationCache {
-    db: sled::Db,
-    config: CacheConfig,
-}
-
-impl TranslationCache {
-    /// Open or create the cache at the default location.
-    pub fn open() -> anyhow::Result<Self> {
-        Self::open_at(default_cache_path(), CacheConfig::default())
-    }
-
-    /// Open or create the cache at a specific path.
-    pub fn open_at(path: PathBuf, config: CacheConfig) -> anyhow::Result<Self> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        let db = match sled::open(&path) {
-            Ok(db) => db,
-            Err(e) => {
-                let msg = e.to_string();
-                // Detect lock errors (concurrent access).
-                // POSIX: lock, EWOULDBLOCK, EBUSY, EPERM
-                // Windows (fs2): "Access is denied", "sharing violation"
-                if msg.contains("lock")
-                    || msg.contains("EWOULDBLOCK")
-                    || msg.contains("EBUSY")
-                    || msg.contains("EPERM")
-                    || msg.contains("Access is denied")
-                    || msg.contains("sharing violation")
-                {
-                    anyhow::bail!(
-                        "Cache locked by another process at {}. Use --no-cache to bypass.",
-                        path.display()
-                    );
-                }
-                return Err(e.into());
-            }
-        };
-
-        Ok(Self { db, config })
-    }
-
-    /// SHA-256 hash key: "{src}:{tgt}:{text}" → 32-byte digest.
-    fn make_key(src: &str, tgt: &str, text: &str) -> Vec<u8> {
-        let mut h = Sha256::new();
-        h.update(format!("{src}:{tgt}:{text}").as_bytes());
-        h.finalize().to_vec()
-    }
-
-    fn now_secs() -> i64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64
-    }
-
-    /// Look up a cached translation. Returns None on miss or expiry.
-    pub fn get(&self, src: &str, tgt: &str, text: &str) -> Option<String> {
-        let key = Self::make_key(src, tgt, text);
-        let raw = match self.db.get(&key) {
-            Ok(Some(v)) => v,
-            _ => {
-                CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
-                return None;
-            }
-        };
-
-        let entry: CacheEntry = match postcard::from_bytes(&raw) {
-            Ok(e) => e,
-            Err(_) => {
-                // Corrupted entry — remove silently.
-                let _ = self.db.remove(&key);
-                CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
-                return None;
-            }
-        };
-
-        // TTL check.
-        let age = Self::now_secs().saturating_sub(entry.timestamp);
-        if age as u64 > self.config.ttl.as_secs() {
-            let _ = self.db.remove(&key);
-            CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
-            return None;
-        }
-
-        CACHE_HITS.fetch_add(1, Ordering::Relaxed);
-        Some(entry.translated)
-    }
-
-    /// Store a translation in the cache.
-    pub fn put(&self, src: &str, tgt: &str, text: &str, value: &str) {
-        let key = Self::make_key(src, tgt, text);
-        let entry = CacheEntry {
-            translated: value.to_string(),
-            timestamp: Self::now_secs(),
-            source_lang: src.to_string(),
-            target_lang: tgt.to_string(),
-        };
-
-        let encoded = match postcard::to_allocvec(&entry) {
-            Ok(v) => v,
-            Err(e) => {
-                log::warn!("cache encode error: {e}");
-                return;
-            }
-        };
-
-        let is_large = encoded.len() > LARGE_ENTRY_THRESHOLD;
-        let _ = self.db.insert(&key, encoded);
-
-        let count = INSERT_COUNT.fetch_add(1, Ordering::Relaxed);
-        if is_large || count.is_multiple_of(SIZE_CHECK_INTERVAL) {
-            self.enforce_size_limit();
-        }
-    }
-
-    /// Evict entries if cache exceeds max size (random eviction, ~25% per round).
-    fn enforce_size_limit(&self) {
-        let disk_size = self.db.size_on_disk().unwrap_or(0);
-        if disk_size <= self.config.max_size_bytes {
-            return;
-        }
-
-        for _ in 0..MAX_EVICTION_ROUNDS {
-            let len = self.db.len();
-            if len == 0 {
-                break;
-            }
-            let to_remove = (len / 4).max(1);
-            let mut removed = 0;
-            for item in self.db.iter() {
-                if removed >= to_remove {
-                    break;
-                }
-                if let Ok((key, _)) = item {
-                    let _ = self.db.remove(key);
-                    removed += 1;
-                }
-            }
-
-            let _ = self.db.flush();
-            if self.db.size_on_disk().unwrap_or(0) <= self.config.max_size_bytes {
-                break;
-            }
-        }
-    }
-
-    /// Cache statistics for reporting.
-    pub fn stats(&self) -> CacheStats {
-        CacheStats {
-            entries: self.db.len(),
-            disk_bytes: self.db.size_on_disk().unwrap_or(0),
-            hits: CACHE_HITS.load(Ordering::Relaxed) as usize,
-            misses: CACHE_MISSES.load(Ordering::Relaxed) as usize,
-        }
-    }
-
-    /// Clear all cache entries.
-    pub fn clear(&self) {
-        self.db.clear().ok();
-        let _ = self.db.flush();
-    }
-
-    /// Flush pending writes to disk.
-    pub fn flush(&self) {
-        let _ = self.db.flush();
-    }
-}
-
-pub struct CacheStats {
-    pub entries: usize,
-    pub disk_bytes: u64,
-    pub hits: usize,
-    pub misses: usize,
-}
-
-impl CacheStats {
-    pub fn hit_rate(&self) -> f64 {
-        let total = self.hits + self.misses;
-        if total == 0 {
-            0.0
-        } else {
-            self.hits as f64 / total as f64 * 100.0
-        }
-    }
-}
-
-// Google Translate API (free gtx endpoint)
-
 const GOOGLE_TRANSLATE_URL: &str = "https://translate.googleapis.com/translate_a/single";
 const USER_AGENT: &str = "Mozilla/5.0 (compatible; zhtw-anchor/2.0)";
 
-/// Translate text using the free Google Translate API.
+/// Maximum payload bytes sent to Google Translate in a single request.
+/// The free endpoint rejects overly long URLs; keep well under the ~8KB
+/// practical limit for GET query strings.
+const MAX_PAYLOAD_BYTES: usize = 4096;
+
+/// English stopwords to exclude from anchor matching.  These are so common
+/// in any translation that matching on them provides zero signal.
+const STOPWORDS: &[&str] = &[
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being", "have", "has", "had",
+    "do", "does", "did", "will", "would", "shall", "should", "may", "might", "must", "can",
+    "could", "of", "in", "to", "for", "with", "on", "at", "from", "by", "as", "into", "through",
+    "during", "before", "after", "above", "below", "between", "under", "again", "further", "then",
+    "once", "here", "there", "when", "where", "why", "how", "all", "each", "every", "both", "few",
+    "more", "most", "other", "some", "such", "no", "nor", "not", "only", "own", "same", "so",
+    "than", "too", "very", "just", "about", "also", "and", "but", "or", "if", "while", "that",
+    "this", "these", "those", "it", "its", "he", "she", "they", "them", "we", "you", "i", "me",
+    "my", "your", "his", "her", "our", "their", "what", "which", "who", "whom", "s", "t", "don",
+    "doesn", "didn", "won", "wouldn", "shouldn", "couldn",
+];
+
+/// Tokenize English text into lowercase words, splitting on whitespace and
+/// punctuation (preserving hyphens and apostrophes within words).  Hyphenated
+/// and possessive tokens also emit their sub-parts.
+pub(crate) fn tokenize_words(text: &str) -> Vec<String> {
+    let mut tokens: Vec<String> = Vec::new();
+    for chunk in text.split(|c: char| {
+        c.is_ascii_whitespace() || (c.is_ascii_punctuation() && c != '-' && c != '\'')
+    }) {
+        if chunk.is_empty() {
+            continue;
+        }
+        tokens.push(chunk.to_string());
+        // Emit sub-parts for hyphenated or possessive tokens.
+        if chunk.contains('-') || chunk.contains('\'') {
+            for sub in chunk.split(['-', '\'']) {
+                if !sub.is_empty() && sub != chunk {
+                    tokens.push(sub.to_string());
+                }
+            }
+        }
+    }
+    tokens
+}
+
+/// Call Google Translate free endpoint (client=gtx).
 ///
-/// Returns the translated text, or a 'TranslateError' on failure.
-fn google_translate_raw(text: &str, src: &str, tgt: &str) -> Result<String, TranslateError> {
+/// Returns `TranslateError::Parse` if the response is valid JSON but contains
+/// no translated text fragments (endpoint shape change).
+pub(crate) fn google_translate_raw(
+    text: &str,
+    src: &str,
+    tgt: &str,
+) -> Result<String, TranslateError> {
     let url = format!(
         "{GOOGLE_TRANSLATE_URL}?client=gtx&sl={src}&tl={tgt}&dt=t&q={}",
         urlencoding::encode(text)
@@ -362,377 +132,342 @@ fn google_translate_raw(text: &str, src: &str, tgt: &str) -> Result<String, Tran
         }
     }
 
+    // #4: Detect endpoint shape change — valid JSON but no translated fragments.
+    if result.is_empty() {
+        return Err(TranslateError::Parse(
+            "response JSON had no translated text fragments".into(),
+        ));
+    }
+
     Ok(result)
 }
 
-// Context extraction
+/// Result of a calibration run.
+#[derive(Debug, Clone)]
+pub struct CalibrateResult {
+    /// Whether the API call succeeded.
+    pub api_ok: bool,
+    /// The full translated text (empty if API failed).
+    pub translated: String,
+    /// Number of tokens in the translation.
+    pub token_count: usize,
+    /// Issues where anchor was found in translation.
+    pub matched: usize,
+    /// Issues where anchor was NOT found in translation.
+    pub unmatched: usize,
+    /// Issues with no `english` field (left as None).
+    pub no_english: usize,
+}
 
-/// Extract sentence-ish context around a byte offset for translation.
-///
-/// Scans backwards and forwards for CJK sentence-ending punctuation
-/// (。！？ or newline), falling back to a fixed window.
-fn extract_context(text: &str, offset: usize, length: usize, window: usize) -> &str {
-    let len = text.len();
+/// Sentinel prefix for segment delimiters in the translation payload.
+/// Chosen to be unlikely to appear in Chinese text and stable through
+/// translation (numbers are preserved verbatim by Google Translate).
+const SENTINEL_PREFIX: &str = "###SEG";
 
-    // Find start: clamp to char boundary, then scan backwards for sentence end.
-    let raw_start = text.floor_char_boundary(offset.saturating_sub(window));
-    let mut start = raw_start;
-    let prefix = &text[raw_start..offset.min(len)];
-    for (i, ch) in prefix.char_indices().rev() {
-        if matches!(ch, '。' | '！' | '？' | '\n') {
-            start = raw_start + i + ch.len_utf8();
+/// Extract ±sentence context around an issue offset, bounded by CJK sentence
+/// punctuation (。！？) or paragraph breaks (\n), up to ~40 characters in
+/// each direction.
+fn extract_issue_context(text: &str, offset: usize) -> &str {
+    let offset = offset.min(text.len());
+    let offset = text.floor_char_boundary(offset);
+
+    fn is_sentence_boundary(c: char) -> bool {
+        matches!(c, '\n' | '\r' | '。' | '！' | '？' | '；')
+    }
+
+    // Scan backward by characters.
+    let mut start = offset;
+    let mut chars_back = 0;
+    for (idx, c) in text[..offset].char_indices().rev() {
+        if is_sentence_boundary(c) {
+            start = idx + c.len_utf8();
+            break;
+        }
+        start = idx;
+        chars_back += 1;
+        if chars_back >= 40 {
             break;
         }
     }
 
-    // Find end: clamp to char boundary, then scan forwards for sentence end.
-    let match_end = (offset + length).min(len);
-    let raw_end = text.floor_char_boundary((match_end + window).min(len));
-    let mut end = raw_end;
-    let suffix = &text[match_end..raw_end];
-    for (i, ch) in suffix.char_indices() {
-        if matches!(ch, '。' | '！' | '？' | '\n') {
-            end = match_end + i + ch.len_utf8();
+    // Scan forward by characters.
+    let mut end = offset;
+    let mut chars_fwd = 0;
+    for (idx, c) in text[offset..].char_indices() {
+        if is_sentence_boundary(c) {
+            end = offset + idx;
+            break;
+        }
+        end = offset + idx + c.len_utf8();
+        chars_fwd += 1;
+        if chars_fwd >= 40 {
             break;
         }
     }
 
-    text[start..end].trim()
+    &text[start..end]
 }
 
-// Anchor confirmation: the core algorithm
-
-/// Configuration for anchor-confirmation.
-pub struct ConfirmConfig {
-    /// Delay between API calls to avoid rate limiting.
-    pub request_delay: Duration,
-    /// If true, downgrade unconfirmed issues to Info instead of removing them.
-    pub downgrade_unconfirmed: bool,
-    /// Maximum number of Google Translate API calls per confirm pass.
-    /// After hitting this cap, remaining terms get Unknown outcome (fail-open).
-    /// Bounds worst-case latency to max_api_calls * (~300ms HTTP + request_delay).
-    pub max_api_calls: usize,
+/// Filter anchor words to content words only (remove stopwords and
+/// single-character tokens that are likely noise).
+fn content_anchor_words(english: &str) -> Vec<String> {
+    let stopset: HashSet<&str> = STOPWORDS.iter().copied().collect();
+    english
+        .split('/')
+        .flat_map(|v| tokenize_words(v.trim()))
+        .map(|t| t.to_lowercase())
+        .filter(|w| w.len() > 1 && !stopset.contains(w.as_str()))
+        .collect()
 }
 
-impl Default for ConfirmConfig {
-    fn default() -> Self {
-        Self {
-            request_delay: Duration::from_millis(200),
-            downgrade_unconfirmed: true,
-            max_api_calls: 10,
-        }
-    }
-}
-
-/// Result of the confirmation pass.
-pub struct ConfirmResult {
-    /// Number of issues confirmed by English anchor match.
-    pub confirmed: usize,
-    /// Number of issues rejected (translation succeeded, anchor absent).
-    pub unconfirmed: usize,
-    /// Number of issues where translation failed (fail-open, severity preserved).
-    pub unknown: usize,
-    /// Number of API calls made.
-    pub api_calls: usize,
-    /// Number of cache hits.
-    pub cache_hits: usize,
-    /// True when the transport itself failed (sampling timeout/error), distinct
-    /// from individual terms being Unknown. Callers can use this to decide
-    /// whether to fall back to an alternative confirmation path.
-    pub transport_failed: bool,
-}
-
-/// Determine the outcome for a single term given its english anchor and
-/// the translation result.
-fn check_anchor(
-    english: &str,
-    translate_result: &Result<String, TranslateError>,
-) -> TranslateOutcome {
-    match translate_result {
-        Err(e) => {
-            log::debug!("translation failed, keeping severity (fail-open): {e}");
-            TranslateOutcome::Unknown
-        }
-        Ok(translated) if translated.is_empty() => {
-            // Empty response from API — treat as unknown, not rejected.
-            log::debug!("empty translation response, keeping severity (fail-open)");
-            TranslateOutcome::Unknown
-        }
-        Ok(translated) => {
-            let translated_lower = translated.to_lowercase();
-            let found = english
-                .split('/')
-                .map(|v| v.trim().to_lowercase())
-                .filter(|v| v.len() >= 3)
-                .any(|v| translated_lower.contains(&v));
-            if found {
-                TranslateOutcome::Confirmed
-            } else {
-                TranslateOutcome::Rejected
-            }
-        }
-    }
-}
-
-/// Apply a single outcome: tally counters and optionally downgrade severity.
-fn apply_outcome(
-    outcome: &TranslateOutcome,
-    issue: &mut Issue,
-    confirmed: &mut usize,
-    unconfirmed: &mut usize,
-    unknown_count: &mut usize,
-    downgrade: bool,
-) {
-    match outcome {
-        TranslateOutcome::Confirmed => *confirmed += 1,
-        TranslateOutcome::Rejected => {
-            *unconfirmed += 1;
-            if downgrade {
-                issue.severity = Severity::Info;
-            }
-        }
-        TranslateOutcome::Unknown => *unknown_count += 1,
-    }
-}
-
-/// Run anchor-confirmation on a list of issues.
+/// Calibrate issues by translating their context sentences and checking for
+/// English anchor matches.
 ///
-/// For each issue that has an 'english' field, translates the surrounding
-/// context from zh-TW to English and checks if the translation contains
-/// the expected English term.
+/// - `Some(true)`: anchor present in non-empty translation segment.
+/// - `Some(false)`: anchor absent in non-empty translation segment.
+/// - `None`: calibration not attempted (no `english` field, API failure,
+///   empty input, empty translation, no content words in anchor).
 ///
-/// Tri-state outcomes:
-/// - Confirmed — anchor found in translation; keep severity.
-/// - Rejected — translation succeeded, anchor absent; downgrade to Info.
-/// - Unknown — translation failed (network/rate-limit/parse); keep severity (fail-open).
-///
-/// Issues without an 'english' field are left unchanged.
-pub fn confirm_issues(
-    issues: &mut [Issue],
-    text: &str,
-    config: &ConfirmConfig,
-    cache: Option<&TranslationCache>,
-) -> ConfirmResult {
-    // Reset session counters.
-    CACHE_HITS.store(0, Ordering::Relaxed);
-    CACHE_MISSES.store(0, Ordering::Relaxed);
-    INSERT_COUNT.store(0, Ordering::Relaxed);
+/// Pure annotation. No severity mutation. Fail-open on API failure.
+pub fn calibrate_issues(text: &str, issues: &mut [Issue]) -> CalibrateResult {
+    let mut result = CalibrateResult {
+        api_ok: false,
+        translated: String::new(),
+        token_count: 0,
+        matched: 0,
+        unmatched: 0,
+        no_english: 0,
+    };
 
-    let mut confirmed = 0usize;
-    let mut unconfirmed = 0usize;
-    let mut unknown_count = 0usize;
-    let mut api_calls = 0usize;
-
-    // Dedup key is (found, english) — same surface form in different semantic
-    // contexts (different english anchors) must be translated separately.
-    let mut term_results: HashMap<(String, String), TranslateOutcome> = HashMap::new();
-
-    for issue in issues.iter_mut() {
-        let english = match &issue.english {
-            Some(e) if !e.trim().is_empty() => e.trim().to_string(),
-            _ => continue, // no english anchor — leave unchanged
-        };
-
-        let dedup_key = (issue.found.clone(), english.clone());
-
-        // Check if we already translated this (term, english) pair.
-        if let Some(outcome) = term_results.get(&dedup_key) {
-            apply_outcome(
-                outcome,
-                issue,
-                &mut confirmed,
-                &mut unconfirmed,
-                &mut unknown_count,
-                config.downgrade_unconfirmed,
-            );
-            continue;
-        }
-
-        // Extract context around the issue.
-        let context = extract_context(text, issue.offset, issue.length, 80);
-        if context.is_empty() {
-            term_results.insert(dedup_key, TranslateOutcome::Unknown);
-            unknown_count += 1;
-            continue;
-        }
-
-        // Check cache first — cache hits work regardless of API cap.
-        if let Some(c) = cache {
-            if let Some(cached) = c.get("zh-TW", "en", context) {
-                let outcome = check_anchor(&english, &Ok(cached));
-                apply_outcome(
-                    &outcome,
-                    issue,
-                    &mut confirmed,
-                    &mut unconfirmed,
-                    &mut unknown_count,
-                    config.downgrade_unconfirmed,
-                );
-                term_results.insert(dedup_key, outcome);
-                continue;
-            }
-        }
-
-        // Cache miss — check API cap before making a network call.
-        if api_calls >= config.max_api_calls {
-            term_results.insert(dedup_key, TranslateOutcome::Unknown);
-            unknown_count += 1;
-            continue;
-        }
-
-        // Network call.
-        let translate_result = google_translate_raw(context, "zh-TW", "en");
-        api_calls += 1;
-
-        // Cache successful results.
-        if let (Ok(ref translated), Some(c)) = (&translate_result, cache) {
-            if !translated.is_empty() {
-                c.put("zh-TW", "en", context, translated);
-            }
-        }
-
-        // Rate-limit between network requests.
-        if !config.request_delay.is_zero() {
-            std::thread::sleep(config.request_delay);
-        }
-
-        let outcome = check_anchor(&english, &translate_result);
-        apply_outcome(
-            &outcome,
-            issue,
-            &mut confirmed,
-            &mut unconfirmed,
-            &mut unknown_count,
-            config.downgrade_unconfirmed,
-        );
-        term_results.insert(dedup_key, outcome);
+    // Short-circuit: nothing to calibrate.
+    if text.trim().is_empty() || issues.is_empty() {
+        result.no_english = issues.len();
+        return result;
     }
 
-    let cache_hits = cache.map_or(0, |c| c.stats().hits);
-
-    // Flush cache to disk.
-    if let Some(c) = cache {
-        c.flush();
-    }
-
-    ConfirmResult {
-        confirmed,
-        unconfirmed,
-        unknown: unknown_count,
-        api_calls,
-        cache_hits,
-        transport_failed: false,
-    }
-}
-
-/// Run anchor-confirmation using a sampling bridge.
-///
-/// Collects all terms with english anchors, sends them to the LLM in a single
-/// bulk request, and applies the boolean results. Falls back gracefully: if the
-/// bridge returns None (timeout, error, budget), all terms get `Unknown` outcome.
-///
-/// Uses a separate budget from disambiguation sampling (budget=1 for the single
-/// bulk call), so it does not consume the disambiguation budget.
-pub(crate) fn confirm_issues_with_sampling(
-    issues: &mut [Issue],
-    text: &str,
-    bridge: &mut crate::mcp::sampling::SamplingBridge<'_>,
-    config: &ConfirmConfig,
-) -> ConfirmResult {
-    use crate::mcp::sampling::BulkConfirmTerm;
-
-    let mut confirmed = 0usize;
-    let mut unconfirmed = 0usize;
-    let mut unknown_count = 0usize;
-
-    // Collect unique (found, english) terms with their contexts.
-    let mut seen: HashMap<(String, String), usize> = HashMap::new();
-    let mut terms: Vec<BulkConfirmTerm> = Vec::new();
+    // Collect unique context sentences for issues that have english fields.
+    // Map each issue index to its context segment index.
+    // #6: Use HashMap<String, usize> instead of HashSet + position() scan.
+    let mut segments: Vec<String> = Vec::new();
+    let mut segment_map: HashMap<String, usize> = HashMap::new();
+    let mut issue_to_segment: Vec<Option<usize>> = Vec::with_capacity(issues.len());
 
     for issue in issues.iter() {
-        let english = match &issue.english {
-            Some(e) if !e.trim().is_empty() => e.trim().to_string(),
-            _ => continue,
+        if issue.english.is_none() {
+            issue_to_segment.push(None);
+            result.no_english += 1;
+            continue;
+        }
+
+        let ctx = extract_issue_context(text, issue.offset).to_string();
+        if ctx.trim().is_empty() {
+            issue_to_segment.push(None);
+            result.no_english += 1;
+            continue;
+        }
+
+        let seg_idx = *segment_map.entry(ctx.clone()).or_insert_with(|| {
+            let idx = segments.len();
+            segments.push(ctx);
+            idx
+        });
+        issue_to_segment.push(Some(seg_idx));
+    }
+
+    if segments.is_empty() {
+        return result;
+    }
+
+    // #5: Cap payload size.  If the joined payload exceeds MAX_PAYLOAD_BYTES,
+    // truncate to the segments that fit.  Issues referencing truncated segments
+    // will get anchor_match = None (fail-open).
+    // Also cap individual segments: a single oversized context must not blow
+    // past the URL limit and disable calibration for the entire batch.
+    let max_segment_bytes = MAX_PAYLOAD_BYTES / 2; // no single segment > half budget
+    let max_segments = {
+        let mut total = 0usize;
+        let mut count = 0usize;
+        for seg in &segments {
+            // Account for sentinel + newline overhead per segment.
+            let overhead = SENTINEL_PREFIX.len() + 6 + 1; // "###SEGnn\n"
+            let seg_cost = seg.len().min(max_segment_bytes) + overhead;
+            if total + seg_cost > MAX_PAYLOAD_BYTES && count > 0 {
+                break;
+            }
+            total += seg_cost;
+            count += 1;
+        }
+        count
+    };
+
+    // #2: Use sentinel markers instead of bare \n for segment delimiting.
+    // Format: "###SEG0\n<segment0>\n###SEG1\n<segment1>\n..."
+    // After translation, find markers to recover per-segment text.
+    // Note: if user text literally contains "###SEG\d+", sentinel parsing could
+    // be corrupted.  Acceptable risk — this pattern is vanishingly rare in zh-TW.
+    let mut payload = String::new();
+    let mut truncated_segments: HashSet<usize> = HashSet::new();
+    for (i, seg) in segments.iter().enumerate() {
+        if i >= max_segments {
+            break;
+        }
+        if !payload.is_empty() {
+            payload.push('\n');
+        }
+        // Truncate oversized segments at a char boundary to stay within budget.
+        // Truncated segments get anchor_match = None (the anchor word might have
+        // been beyond the truncation point — evaluating would create false negatives).
+        let truncated = if seg.len() > max_segment_bytes {
+            truncated_segments.insert(i);
+            &seg[..seg.floor_char_boundary(max_segment_bytes)]
+        } else {
+            seg.as_str()
         };
-        let key = (issue.found.clone(), english.clone());
-        if let std::collections::hash_map::Entry::Vacant(e) = seen.entry(key) {
-            let context = extract_context(text, issue.offset, issue.length, 80);
-            e.insert(terms.len());
-            terms.push(BulkConfirmTerm {
-                found: issue.found.clone(),
-                english,
-                context: context.to_string(),
-            });
+        payload.push_str(&format!("{SENTINEL_PREFIX}{i}\n{truncated}"));
+    }
+
+    // Translate.
+    let translation = match google_translate_raw(&payload, "zh", "en") {
+        Ok(t) => t,
+        Err(_) => {
+            // Fail-open: all anchor_match = None.
+            return result;
+        }
+    };
+
+    result.api_ok = true;
+    result.translated = translation.clone();
+
+    // #2: Parse sentinel-delimited translation back into per-segment results.
+    // Look for "###SEGn" markers (case-insensitive, Google may capitalize).
+    let translated_segments = parse_sentinel_segments(&translation, segments.len());
+
+    // Tokenize each segment.
+    let segment_tokens: Vec<HashSet<String>> = translated_segments
+        .iter()
+        .map(|seg| {
+            tokenize_words(seg)
+                .into_iter()
+                .map(|t| t.to_lowercase())
+                .collect()
+        })
+        .collect();
+
+    result.token_count = segment_tokens.iter().map(|s| s.len()).sum();
+
+    // Check each issue against its corresponding segment.
+    for (i, issue) in issues.iter_mut().enumerate() {
+        let seg_idx = match issue_to_segment.get(i).copied().flatten() {
+            Some(idx) => idx,
+            None => continue, // no english field → anchor_match stays None
+        };
+
+        // Segment was dropped (payload cap) or individually truncated → no signal.
+        // Truncated segments might have lost the anchor word beyond the cut point.
+        if seg_idx >= max_segments || truncated_segments.contains(&seg_idx) {
+            continue;
+        }
+
+        let english = match &issue.english {
+            Some(e) => e.clone(),
+            None => continue,
+        };
+
+        // Get the token set for this segment.
+        let tokens = match segment_tokens.get(seg_idx) {
+            Some(t) if !t.is_empty() => t,
+            _ => continue, // empty/missing → no signal
+        };
+
+        // #1: Filter to content words only (no stopwords, no single chars).
+        let anchors = content_anchor_words(&english);
+        if anchors.is_empty() {
+            // All anchor words were stopwords → no signal, not a false negative.
+            continue;
+        }
+
+        let found = anchors.iter().any(|w| tokens.contains(w));
+
+        issue.anchor_match = Some(found);
+        if found {
+            result.matched += 1;
+        } else {
+            result.unmatched += 1;
         }
     }
 
-    if terms.is_empty() {
-        return ConfirmResult {
-            confirmed: 0,
-            unconfirmed: 0,
-            unknown: 0,
-            api_calls: 0,
-            cache_hits: 0,
-            transport_failed: false,
-        };
+    result
+}
+
+/// Parse sentinel-delimited translation output.
+///
+/// Looks for `###SEGn` markers (case-insensitive) and extracts the text
+/// between consecutive markers.  Returns a Vec indexed by segment number;
+/// missing segments get empty strings.
+fn parse_sentinel_segments(translation: &str, expected_count: usize) -> Vec<String> {
+    let lower = translation.to_lowercase();
+    let sentinel_lower = SENTINEL_PREFIX.to_lowercase();
+
+    // Find all marker positions: (byte_offset, segment_number).
+    let mut markers: Vec<(usize, usize)> = Vec::new();
+    let mut search_from = 0;
+    while let Some(pos) = lower[search_from..].find(&sentinel_lower) {
+        let abs_pos = search_from + pos;
+        let after_prefix = abs_pos + sentinel_lower.len();
+        // Parse the segment number immediately after the prefix.
+        let num_str: String = lower[after_prefix..]
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
+        if let Ok(n) = num_str.parse::<usize>() {
+            let content_start = after_prefix + num_str.len();
+            // Skip optional newline after marker.
+            let content_start = if translation.as_bytes().get(content_start) == Some(&b'\n') {
+                content_start + 1
+            } else {
+                content_start
+            };
+            markers.push((content_start, n));
+        }
+        search_from = abs_pos + sentinel_lower.len();
     }
 
-    // Single bulk LLM call.
-    let bulk_result = bridge.sample_bulk_confirm(&terms);
-    let bulk_succeeded = bulk_result.is_some();
+    let mut result = vec![String::new(); expected_count];
 
-    // Build outcome map from index-keyed LLM response.
-    let mut term_outcomes: HashMap<(String, String), TranslateOutcome> = HashMap::new();
-    match bulk_result {
-        Some(map) => {
-            for (idx, term) in terms.iter().enumerate() {
-                let outcome = match map.get(&idx) {
-                    Some(true) => TranslateOutcome::Confirmed,
-                    Some(false) => TranslateOutcome::Rejected,
-                    None => TranslateOutcome::Unknown,
-                };
-                term_outcomes.insert((term.found.clone(), term.english.clone()), outcome);
+    if markers.is_empty() {
+        // No markers found — Google may have stripped them.  Fall back to
+        // newline splitting for backward compat (best-effort).
+        for (i, line) in translation.split('\n').enumerate() {
+            if i < expected_count {
+                result[i] = line.trim().to_string();
             }
         }
-        None => {
-            // LLM unavailable — all terms are Unknown (fail-open).
-            for term in &terms {
-                term_outcomes.insert(
-                    (term.found.clone(), term.english.clone()),
-                    TranslateOutcome::Unknown,
-                );
-            }
+        return result;
+    }
+
+    // For each marker, extract text from content_start to the byte position
+    // where the next marker begins (searching for the sentinel prefix in the
+    // original case-insensitive text).
+    for (idx, &(start, seg_num)) in markers.iter().enumerate() {
+        if seg_num >= expected_count {
+            continue;
         }
-    }
-
-    // Apply outcomes to issues.
-    for issue in issues.iter_mut() {
-        let english = match &issue.english {
-            Some(e) if !e.trim().is_empty() => e.trim().to_string(),
-            _ => continue,
+        let end = if idx + 1 < markers.len() {
+            // Find where the next sentinel prefix starts in the original text.
+            // markers[idx+1].0 is the content start (after "###SEGn\n"), so we
+            // need to back up to find the "###SEG" prefix itself.
+            let next_content = markers[idx + 1].0;
+            // Search backwards from next_content for the sentinel prefix.
+            lower[..next_content]
+                .rfind(&sentinel_lower)
+                .unwrap_or(next_content)
+        } else {
+            translation.len()
         };
-        let key = (issue.found.clone(), english);
-        let outcome = term_outcomes
-            .get(&key)
-            .unwrap_or(&TranslateOutcome::Unknown);
-        apply_outcome(
-            outcome,
-            issue,
-            &mut confirmed,
-            &mut unconfirmed,
-            &mut unknown_count,
-            config.downgrade_unconfirmed,
-        );
+        result[seg_num] = translation[start..end].trim().to_string();
     }
 
-    ConfirmResult {
-        confirmed,
-        unconfirmed,
-        unknown: unknown_count,
-        api_calls: if bulk_succeeded { 1 } else { 0 },
-        cache_hits: 0,
-        transport_failed: !bulk_succeeded,
-    }
+    result
 }
 
 #[cfg(test)]
@@ -740,301 +475,189 @@ mod tests {
     use super::*;
 
     #[test]
-    fn extract_context_sentence_boundaries() {
-        let text = "前面的句子。這是包含目標詞的句子。後面的句子。";
-        let target = "目標詞";
-        let pos = text.find(target).unwrap();
-        let ctx = extract_context(text, pos, target.len(), 80);
-        assert!(ctx.contains(target));
-        assert!(!ctx.contains("前面的句子"));
-        assert!(!ctx.contains("後面的句子"));
+    fn tokenize_words_basic() {
+        let tokens = tokenize_words("Hello, world! This is a test.");
+        assert!(tokens.contains(&"Hello".to_string()));
+        assert!(tokens.contains(&"world".to_string()));
+        assert!(tokens.contains(&"test".to_string()));
     }
 
     #[test]
-    fn extract_context_fallback_window() {
-        let text = "abcdef目標ghijkl";
-        let target = "目標";
-        let pos = text.find(target).unwrap();
-        let ctx = extract_context(text, pos, target.len(), 4);
-        assert!(ctx.contains(target));
+    fn tokenize_words_hyphenated() {
+        let tokens = tokenize_words("multi-threaded server-side");
+        assert!(tokens.contains(&"multi-threaded".to_string()));
+        assert!(tokens.contains(&"multi".to_string()));
+        assert!(tokens.contains(&"threaded".to_string()));
     }
 
     #[test]
-    fn cache_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.db");
-        let cache = TranslationCache::open_at(path, CacheConfig::default()).unwrap();
-
-        // Miss.
-        assert!(cache.get("zh-TW", "en", "hello").is_none());
-
-        // Put + hit.
-        cache.put("zh-TW", "en", "hello", "world");
-        let val = cache.get("zh-TW", "en", "hello");
-        assert_eq!(val.as_deref(), Some("world"));
+    fn tokenize_words_possessive() {
+        let tokens = tokenize_words("it's don't");
+        assert!(tokens.contains(&"it's".to_string()));
+        assert!(tokens.contains(&"it".to_string()));
+        assert!(tokens.contains(&"s".to_string()));
     }
 
+    // #3: Context extraction now counts chars, not bytes, and respects CJK punctuation.
     #[test]
-    fn cache_ttl_expiry() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.db");
-        let config = CacheConfig {
-            ttl: Duration::from_secs(0), // instant expiry
-            max_size_bytes: 10 * 1024 * 1024,
-        };
-        let cache = TranslationCache::open_at(path, config).unwrap();
-
-        cache.put("zh-TW", "en", "hello", "world");
-        // With 0-second TTL, wait for the timestamp to roll over to the next second.
-        std::thread::sleep(Duration::from_secs(1));
-        assert!(cache.get("zh-TW", "en", "hello").is_none());
-    }
-
-    #[test]
-    fn cache_clear() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.db");
-        let cache = TranslationCache::open_at(path, CacheConfig::default()).unwrap();
-
-        cache.put("zh-TW", "en", "hello", "world");
-        assert!(cache.get("zh-TW", "en", "hello").is_some());
-
-        cache.clear();
-        assert_eq!(cache.stats().entries, 0);
-    }
-
-    #[test]
-    fn cache_key_deterministic() {
-        let k1 = TranslationCache::make_key("zh-TW", "en", "hello");
-        let k2 = TranslationCache::make_key("zh-TW", "en", "hello");
-        assert_eq!(k1, k2);
-        assert_eq!(k1.len(), 32); // SHA-256 = 32 bytes
-    }
-
-    #[test]
-    fn cache_key_differs_for_different_text() {
-        let k1 = TranslationCache::make_key("zh-TW", "en", "hello");
-        let k2 = TranslationCache::make_key("zh-TW", "en", "world");
-        assert_ne!(k1, k2);
-    }
-
-    #[test]
-    fn confirm_issues_skips_without_english() {
-        let mut issues = vec![{
-            let mut i = Issue::new(
-                0,
-                6,
-                "測試",
-                vec!["test".into()],
-                crate::rules::ruleset::IssueType::CrossStrait,
-                Severity::Warning,
-            );
-            i.line = 1;
-            i.col = 1;
-            i
-        }];
-
-        let config = ConfirmConfig {
-            request_delay: Duration::ZERO,
-            downgrade_unconfirmed: true,
-            max_api_calls: 10,
-        };
-        let result = confirm_issues(&mut issues, "測試文字", &config, None);
-
-        // No english field → skipped entirely, severity unchanged.
-        assert_eq!(result.confirmed, 0);
-        assert_eq!(result.unconfirmed, 0);
-        assert_eq!(issues[0].severity, Severity::Warning);
-    }
-
-    // check_anchor unit tests
-
-    #[test]
-    fn check_anchor_confirmed_when_english_present() {
-        let result = Ok("This is about rendering in computer graphics".to_string());
-        assert_eq!(
-            check_anchor("rendering", &result),
-            TranslateOutcome::Confirmed
+    fn extract_context_respects_cjk_sentence_punctuation() {
+        let text = "第一句話。這個軟件很好用。第三句話在這裡。";
+        // Offset points into the second sentence (after 。).
+        let second_sentence_offset = "第一句話。".len();
+        let ctx = extract_issue_context(text, second_sentence_offset);
+        // Should NOT include the first sentence (bounded by 。).
+        assert!(!ctx.contains("第一句話"), "context leaked past 。: {ctx}");
+        assert!(
+            ctx.contains("軟件"),
+            "context should contain the issue: {ctx}"
         );
     }
 
     #[test]
-    fn check_anchor_confirmed_slash_variants() {
-        // english field with slash-separated variants
-        let result = Ok("The simulation results are accurate".to_string());
-        assert_eq!(
-            check_anchor("simulation/emulation", &result),
-            TranslateOutcome::Confirmed
+    fn extract_context_counts_chars_not_bytes() {
+        // 50 CJK characters = 150 bytes.  With ±40 char window, context
+        // should be bounded around ~40 chars each direction, not 40 bytes.
+        let text: String = (0..50).map(|_| '測').collect();
+        let ctx = extract_issue_context(&text, text.len() / 2);
+        let char_count = ctx.chars().count();
+        // Should be ~80 chars (40 back + 40 forward), not ~26 (80 bytes / 3).
+        assert!(
+            char_count >= 50,
+            "context too short: {char_count} chars (byte-counting bug?)"
         );
     }
 
     #[test]
-    fn check_anchor_rejected_when_anchor_absent() {
-        let result = Ok("This is about painting techniques in art".to_string());
-        assert_eq!(
-            check_anchor("rendering", &result),
-            TranslateOutcome::Rejected
+    fn extract_context_at_start() {
+        let text = "軟件品質很好。";
+        let ctx = extract_issue_context(text, 0);
+        assert!(!ctx.is_empty());
+    }
+
+    #[test]
+    fn extract_context_at_end() {
+        let text = "測試文字";
+        let ctx = extract_issue_context(text, text.len());
+        assert!(!ctx.is_empty());
+    }
+
+    // #1: Stopword filtering prevents false matches on common words.
+    #[test]
+    fn content_anchor_words_filters_stopwords() {
+        let words = content_anchor_words("if and only if");
+        // "if", "and" are stopwords; "only" is also a stopword.
+        assert!(
+            words.is_empty(),
+            "all stopwords should be filtered: {words:?}"
         );
     }
 
     #[test]
-    fn check_anchor_unknown_on_io_error() {
-        let result = Err(TranslateError::Io("connection refused".into()));
-        assert_eq!(
-            check_anchor("rendering", &result),
-            TranslateOutcome::Unknown
+    fn content_anchor_words_keeps_content() {
+        let words = content_anchor_words("memory (RAM)");
+        assert!(words.contains(&"memory".to_string()));
+        assert!(words.contains(&"ram".to_string()));
+        assert!(!words.contains(&"a".to_string())); // single char filtered
+    }
+
+    #[test]
+    fn content_anchor_words_multivariant() {
+        let words = content_anchor_words("simulation/emulation");
+        assert!(words.contains(&"simulation".to_string()));
+        assert!(words.contains(&"emulation".to_string()));
+    }
+
+    // #2: Sentinel segment parsing.
+    #[test]
+    fn parse_sentinel_segments_basic() {
+        let translation = "###SEG0\nThis is memory.\n###SEG1\nA friend afar.";
+        let segs = parse_sentinel_segments(translation, 2);
+        assert_eq!(segs.len(), 2);
+        assert!(
+            segs[0].contains("memory"),
+            "seg0 should contain 'memory': {:?}",
+            segs[0]
+        );
+        assert!(
+            segs[1].contains("friend"),
+            "seg1 should contain 'friend': {:?}",
+            segs[1]
         );
     }
 
     #[test]
-    fn check_anchor_unknown_on_rate_limit() {
-        let result = Err(TranslateError::RateLimit(429));
-        assert_eq!(
-            check_anchor("rendering", &result),
-            TranslateOutcome::Unknown
+    fn parse_sentinel_segments_case_insensitive() {
+        // Google Translate may capitalize the sentinel.
+        let translation = "###Seg0\nTranslated text here.";
+        let segs = parse_sentinel_segments(translation, 1);
+        assert!(
+            !segs[0].is_empty(),
+            "should handle case-insensitive markers"
         );
     }
 
     #[test]
-    fn check_anchor_unknown_on_parse_error() {
-        let result = Err(TranslateError::Parse("invalid json".into()));
-        assert_eq!(check_anchor("anything", &result), TranslateOutcome::Unknown);
+    fn parse_sentinel_segments_missing_markers() {
+        // If Google strips all markers, fall back to newline splitting.
+        let translation = "Line one translation.\nLine two translation.";
+        let segs = parse_sentinel_segments(translation, 2);
+        assert_eq!(segs.len(), 2);
+        assert!(!segs[0].is_empty());
+        assert!(!segs[1].is_empty());
     }
 
     #[test]
-    fn check_anchor_unknown_on_empty_translation() {
-        // Empty string from API = unknown, NOT rejected.
-        let result = Ok(String::new());
-        assert_eq!(
-            check_anchor("rendering", &result),
-            TranslateOutcome::Unknown
-        );
+    fn calibrate_empty_text() {
+        let mut issues = vec![];
+        let r = calibrate_issues("", &mut issues);
+        assert!(!r.api_ok);
+        assert_eq!(r.matched, 0);
     }
 
     #[test]
-    fn check_anchor_case_insensitive() {
-        let result = Ok("The RENDERING pipeline is complex".to_string());
-        assert_eq!(
-            check_anchor("rendering", &result),
-            TranslateOutcome::Confirmed
-        );
+    fn calibrate_empty_issues() {
+        let mut issues = vec![];
+        let r = calibrate_issues("Some text here", &mut issues);
+        assert!(!r.api_ok);
+        assert_eq!(r.matched, 0);
     }
 
     #[test]
-    fn check_anchor_skips_short_variants() {
-        // Variants < 3 chars are skipped to avoid false matches.
-        let result = Ok("This is an example".to_string());
-        assert_eq!(
-            check_anchor("an/example", &result),
-            TranslateOutcome::Confirmed
-        );
-        // "an" is 2 chars → skipped, but "example" matches.
-        let result2 = Ok("An unrelated text".to_string());
-        assert_eq!(check_anchor("an", &result2), TranslateOutcome::Rejected);
+    fn calibrate_no_english_field() {
+        let mut issues = vec![Issue::new(
+            0,
+            6,
+            "軟件",
+            vec!["軟體".to_string()],
+            crate::rules::ruleset::IssueType::CrossStrait,
+            crate::rules::ruleset::Severity::Warning,
+        )];
+        // english is None by default
+        assert!(issues[0].english.is_none());
+        let r = calibrate_issues("這個軟件很好", &mut issues);
+        assert_eq!(r.no_english, 1);
+        assert!(issues[0].anchor_match.is_none());
     }
 
-    // Windows lock detection
-
+    // #1: Anchor with only stopwords should produce None, not false positive.
     #[test]
-    fn open_at_windows_lock_error_message() {
-        // Simulate a Windows-style lock error via a path that triggers sled to fail.
-        // We can't easily force sled to produce Windows errors on non-Windows,
-        // so test the string matching logic directly.
-        let windows_errors = [
-            "Access is denied",
-            "sharing violation",
-            "lock",
-            "EWOULDBLOCK",
-            "EBUSY",
-            "EPERM",
-        ];
-        for err_msg in &windows_errors {
-            assert!(
-                err_msg.contains("lock")
-                    || err_msg.contains("EWOULDBLOCK")
-                    || err_msg.contains("EBUSY")
-                    || err_msg.contains("EPERM")
-                    || err_msg.contains("Access is denied")
-                    || err_msg.contains("sharing violation"),
-                "Lock detection should match: {err_msg}"
-            );
-        }
-    }
-
-    // dedup key includes english
-
-    #[test]
-    fn check_anchor_same_term_different_english() {
-        // Same surface form but different english anchors should produce
-        // different outcomes — tests that dedup key must be (found, english).
-        let painting_result = Ok("This painting uses rendering technique".to_string());
-        let gpu_result = Ok("This is about GPU optimization".to_string());
-
-        // "渲染" with english "rendering" in painting context → confirmed
-        assert_eq!(
-            check_anchor("rendering", &painting_result),
-            TranslateOutcome::Confirmed
-        );
-        // "渲染" with english "rendering" in GPU context → rejected
-        assert_eq!(
-            check_anchor("rendering", &gpu_result),
-            TranslateOutcome::Rejected
-        );
-    }
-
-    // API call cap
-
-    #[test]
-    fn confirm_issues_respects_api_cap() {
-        // With max_api_calls=1 and no cache, only the first term gets a
-        // network call; subsequent terms get Unknown (fail-open).
-        let mut issues = vec![
-            {
-                let mut i = Issue::new(
-                    0,
-                    6,
-                    "渲染",
-                    vec!["算繪".into()],
-                    crate::rules::ruleset::IssueType::CrossStrait,
-                    Severity::Warning,
-                )
-                .with_english("rendering");
-                i.line = 1;
-                i.col = 1;
-                i
-            },
-            {
-                let mut i = Issue::new(
-                    6,
-                    6,
-                    "實例",
-                    vec!["實體".into()],
-                    crate::rules::ruleset::IssueType::CrossStrait,
-                    Severity::Warning,
-                )
-                .with_english("instance");
-                i.line = 1;
-                i.col = 3;
-                i
-            },
-        ];
-
-        let config = ConfirmConfig {
-            request_delay: Duration::ZERO,
-            downgrade_unconfirmed: true,
-            max_api_calls: 1, // allow 1 API call, cap the rest
-        };
-        let result = confirm_issues(&mut issues, "渲染實例的測試文字", &config, None);
-
-        // First term: 1 API call (network error in test env → Unknown).
-        // Second term: API-capped → Unknown without network call.
-        // Both severities preserved (fail-open).
-        assert_eq!(result.api_calls, 1);
-        assert!(result.unknown >= 1, "capped term should be Unknown");
-        assert_eq!(
-            issues[1].severity,
-            Severity::Warning,
-            "capped term severity preserved"
+    fn calibrate_stopword_only_anchor_yields_none() {
+        // "if and only if" — all stopwords.  Should not produce a false match.
+        let _issues = vec![Issue::new(
+            0,
+            6,
+            "當且僅當",
+            vec!["若且唯若".to_string()],
+            crate::rules::ruleset::IssueType::CrossStrait,
+            crate::rules::ruleset::Severity::Warning,
+        )
+        .with_english("if and only if")];
+        // We can't call the real API in unit tests, but we can verify the
+        // content_anchor_words logic that gates the match.
+        let anchors = content_anchor_words("if and only if");
+        assert!(
+            anchors.is_empty(),
+            "stopword-only anchor should produce no content words"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
     let mut update_baseline = false;
     let mut diff_from: Option<String> = None;
     #[cfg(feature = "translate")]
-    let mut confirm = false;
+    let mut verify = false;
     let mut setup_host: Option<String> = None;
     let mut pack_cmd: Option<String> = None;
     let mut pack_arg: Option<String> = None;
@@ -193,12 +193,12 @@ fn main() -> Result<()> {
                             );
                         }
                         #[cfg(feature = "translate")]
-                        "--confirm" => {
-                            confirm = true;
+                        "--verify" => {
+                            verify = true;
                         }
                         #[cfg(not(feature = "translate"))]
-                        "--confirm" => {
-                            anyhow::bail!("--confirm requires the 'translate' feature (rebuild without --no-default-features)");
+                        "--verify" => {
+                            anyhow::bail!("--verify requires the 'translate' feature (rebuild without --no-default-features)");
                         }
                         _ => {
                             lint_files.push(args[i].clone());
@@ -366,7 +366,7 @@ fn main() -> Result<()> {
             update_baseline,
             diff_from: diff_from.as_deref(),
             #[cfg(feature = "translate")]
-            confirm,
+            verify,
         });
     }
 
@@ -434,7 +434,7 @@ struct LintBatchParams<'a> {
     update_baseline: bool,
     diff_from: Option<&'a str>,
     #[cfg(feature = "translate")]
-    confirm: bool,
+    verify: bool,
 }
 
 fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
@@ -615,10 +615,10 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
             issues
         };
 
-        // --confirm: anchor-confirm issues via Google Translate.
+        // --verify: calibrate issues via Google Translate.
         #[cfg(feature = "translate")]
-        let report_issues = if params.confirm {
-            let confirm_text = if has_text_changes && !params.dry_run {
+        let report_issues = if params.verify {
+            let calibrate_text = if has_text_changes && !params.dry_run {
                 fix_result
                     .as_ref()
                     .map_or(text.as_str(), |f| f.text.as_str())
@@ -626,23 +626,11 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
                 &text
             };
             let mut issues_mut = report_issues;
-            let config = zhtw_mcp::engine::translate::ConfirmConfig::default();
-            let cache = zhtw_mcp::engine::translate::TranslationCache::open().ok();
-            let result = zhtw_mcp::engine::translate::confirm_issues(
-                &mut issues_mut,
-                confirm_text,
-                &config,
-                cache.as_ref(),
-            );
+            let result =
+                zhtw_mcp::engine::translate::calibrate_issues(calibrate_text, &mut issues_mut);
             eprintln!(
-                "{}  confirm: {} confirmed, {} unconfirmed, {} unknown, {} API calls, {} cache hits{}",
-                c.dim,
-                result.confirmed,
-                result.unconfirmed,
-                result.unknown,
-                result.api_calls,
-                result.cache_hits,
-                c.reset,
+                "{}  verify: {} matched, {} unmatched, {} no_english, api_ok={}{}",
+                c.dim, result.matched, result.unmatched, result.no_english, result.api_ok, c.reset,
             );
             issues_mut
         } else {
@@ -727,8 +715,13 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
                         let rule_str = serde_json::to_string(&issue.rule_type).unwrap_or_default();
                         let rule_name = rule_str.trim_matches('"');
                         let suggestions = issue.suggestions.join(", ");
+                        let verify_tag = match issue.anchor_match {
+                            Some(true) => " [verified]",
+                            Some(false) => " [unverified]",
+                            None => "",
+                        };
                         eprintln!(
-                            "{prefix}{}:{}: {}{}{} {}[{}]{} '{}{}{}' -> {}",
+                            "{prefix}{}:{}: {}{}{} {}[{}]{} '{}{}{}' -> {}{}",
                             issue.line,
                             issue.col,
                             sev_color,
@@ -741,6 +734,7 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
                             issue.found,
                             c.reset,
                             suggestions,
+                            verify_tag,
                         );
                         if params.explain {
                             if let Some(ctx) = &issue.context {
@@ -1064,7 +1058,7 @@ fn run_convert(
         text = fix_result.text;
     }
 
-    // Step 4: Final confirmation via Google Translate (if feature enabled).
+    // Step 4: Final verification via Google Translate (if feature enabled).
     #[cfg(feature = "translate")]
     {
         let excluded =
@@ -1077,26 +1071,25 @@ fn run_convert(
         );
         let mut remaining = scan_out.issues;
         if !remaining.is_empty() {
-            let config = zhtw_mcp::engine::translate::ConfirmConfig::default();
-            let cache = zhtw_mcp::engine::translate::TranslationCache::open().ok();
-            let cr = zhtw_mcp::engine::translate::confirm_issues(
-                &mut remaining,
-                &text,
-                &config,
-                cache.as_ref(),
-            );
-            let unconfirmed_count = remaining
-                .iter()
-                .filter(|i| i.severity != zhtw_mcp::rules::ruleset::Severity::Info)
-                .count();
+            let cr = zhtw_mcp::engine::translate::calibrate_issues(&text, &mut remaining);
             eprintln!(
-                "convert: confirm — {} confirmed, {} unconfirmed, {} unknown, {} API calls, {} cache hits",
-                cr.confirmed, cr.unconfirmed, cr.unknown, cr.api_calls, cr.cache_hits,
+                "convert: verify — {} matched, {} unmatched, {} no_english, api_ok={}",
+                cr.matched, cr.unmatched, cr.no_english, cr.api_ok,
             );
-            if unconfirmed_count > 0 {
+            let rejected_count = remaining
+                .iter()
+                .filter(|i| i.anchor_match == Some(false))
+                .count();
+            let no_signal_count = remaining
+                .iter()
+                .filter(|i| i.anchor_match.is_none() && i.english.is_some())
+                .count();
+            if rejected_count + no_signal_count > 0 {
                 eprintln!(
-                    "convert: {} residual issues (unconfirmed by Google Translate)",
-                    unconfirmed_count,
+                    "convert: {} residual issues ({} unconfirmed, {} no signal)",
+                    rejected_count + no_signal_count,
+                    rejected_count,
+                    no_signal_count,
                 );
             }
         }

--- a/src/mcp/sampling.rs
+++ b/src/mcp/sampling.rs
@@ -34,8 +34,9 @@ pub(crate) const DEFAULT_SAMPLING_TIMEOUT: Duration = Duration::from_secs(5);
 /// Default per-invocation budget for sampling calls.
 pub(crate) const DEFAULT_SAMPLING_BUDGET: usize = 5;
 
-/// Term descriptor for bulk anchor-confirmation (32.6).
+/// Term descriptor for bulk anchor-confirmation via sampling.
 #[derive(Debug, Clone)]
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) struct BulkConfirmTerm {
     /// The cross-strait term found in the text (e.g. "渲染").
     pub found: String,
@@ -178,6 +179,7 @@ impl<'a> SamplingBridge<'a> {
     ///
     /// Returns `None` on timeout, error, budget exhaustion, or parse failure.
     /// Consumes 1 budget unit regardless of term count.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn sample_bulk_confirm(
         &mut self,
         terms: &[BulkConfirmTerm],
@@ -363,9 +365,37 @@ fn find_matching_suggestion(text: &str, suggestions: &[String]) -> Option<String
 
 /// Whether an issue is eligible for sampling disambiguation.
 ///
-/// Eligible if the issue has an english field AND either multiple suggestions
-/// or context_clues (indicating ambiguity that an LLM could help resolve).
-pub(crate) fn is_sampling_eligible(issue: &Issue) -> bool {
+/// When anchor_match is set by calibration:
+/// - `Some(true)` with single suggestion = calibration confirmed the match AND
+///   the replacement is unambiguous → skip sampling.
+/// - `Some(true)` with multiple suggestions = calibration confirms the issue
+///   exists but the LLM still needs to pick the right suggestion → eligible.
+/// - `Some(false)` = calibration found no anchor → KEEP eligible for sampling
+///   so the LLM can provide a second opinion on the potential false positive.
+/// - `None` = no calibration signal, fall back to heuristic.
+///
+/// Without calibration, eligible if english + (multi-suggestion or context_clues).
+pub(crate) fn is_sampling_eligible(
+    issue: &Issue,
+    _ambiguous_threshold: f32,
+    _decided_threshold: f32,
+) -> bool {
+    if issue.anchor_match == Some(true) && issue.suggestions.len() <= 1 {
+        // Calibration confirmed the match and there's only one suggestion —
+        // no ambiguity for the LLM to resolve.
+        return false;
+    }
+    if issue.anchor_match == Some(false) {
+        // Calibration found no anchor — potential false positive.  The LLM
+        // should get a second opinion regardless of suggestion count.
+        // For single-suggestion issues, the LLM can still downgrade severity
+        // to Info (rejecting the match), which is a meaningful outcome.
+        // This does spend from the sampling budget — acceptable tradeoff
+        // since unconfirmed issues are the highest-value disambiguation targets.
+        return issue.english.is_some();
+    }
+    // anchor_match == None or Some(true) with multiple suggestions:
+    // eligible if english + (multi-suggestion or context_clues).
     issue.english.is_some() && (issue.suggestions.len() > 1 || issue.context_clues.is_some())
 }
 
@@ -377,12 +407,14 @@ pub(crate) fn refine_issues_with_sampling(
     issues: &mut [Issue],
     bridge: &mut SamplingBridge<'_>,
     text: &str,
+    ambiguous_threshold: f32,
+    decided_threshold: f32,
 ) {
     for issue in issues.iter_mut() {
         if !bridge.has_budget() {
             break;
         }
-        if !is_sampling_eligible(issue) {
+        if !is_sampling_eligible(issue, ambiguous_threshold, decided_threshold) {
             continue;
         }
 
@@ -465,21 +497,21 @@ mod tests {
     #[test]
     fn eligible_confusable_with_english_multiple_suggestions() {
         let issue = make_confusable_issue("並行", vec!["平行", "並行"], "parallelism");
-        assert!(is_sampling_eligible(&issue));
+        assert!(is_sampling_eligible(&issue, 0.3, 0.8));
     }
 
     #[test]
     fn eligible_with_context_clues() {
         let mut issue = make_confusable_issue("程序", vec!["程式"], "program");
         issue.context_clues = Some(vec!["編寫".into(), "執行".into()]);
-        assert!(is_sampling_eligible(&issue));
+        assert!(is_sampling_eligible(&issue, 0.3, 0.8));
     }
 
     #[test]
     fn not_eligible_without_english() {
         let mut issue = make_confusable_issue("軟件", vec!["軟體"], "software");
         issue.english = None;
-        assert!(!is_sampling_eligible(&issue));
+        assert!(!is_sampling_eligible(&issue, 0.3, 0.8));
     }
 
     #[test]
@@ -498,7 +530,52 @@ mod tests {
             i.col = 1;
             i
         };
-        assert!(!is_sampling_eligible(&issue));
+        assert!(!is_sampling_eligible(&issue, 0.3, 0.8));
+    }
+
+    #[test]
+    fn not_eligible_when_calibrated_true() {
+        // anchor_match = Some(true) → calibration confirmed → skip sampling.
+        let mut issue = make_confusable_issue("渲染", vec!["算繪"], "rendering");
+        issue.anchor_match = Some(true);
+        assert!(!is_sampling_eligible(&issue, 0.3, 0.8));
+    }
+
+    #[test]
+    fn eligible_when_calibrated_true_multi_suggestion() {
+        // anchor_match = Some(true) but multiple suggestions → LLM still
+        // needs to pick which suggestion is correct.
+        let mut issue = make_confusable_issue("並行", vec!["平行", "並行"], "parallelism");
+        issue.anchor_match = Some(true);
+        assert!(is_sampling_eligible(&issue, 0.3, 0.8));
+    }
+
+    #[test]
+    fn eligible_when_calibrated_false() {
+        // anchor_match = Some(false) → calibration found no anchor → LLM should
+        // get a second opinion, so sampling remains eligible.
+        let mut issue = make_confusable_issue("渲染", vec!["算繪", "彩現"], "rendering");
+        issue.anchor_match = Some(false);
+        assert!(is_sampling_eligible(&issue, 0.3, 0.8));
+    }
+
+    #[test]
+    fn eligible_when_calibrated_false_single_suggestion() {
+        // anchor_match = Some(false) with single suggestion → still eligible.
+        // The LLM should weigh in on potential false positives regardless of
+        // suggestion count.
+        let mut issue = make_confusable_issue("渲染", vec!["算繪"], "rendering");
+        issue.anchor_match = Some(false);
+        assert!(is_sampling_eligible(&issue, 0.3, 0.8));
+    }
+
+    #[test]
+    fn eligible_when_no_calibration() {
+        // When anchor_match is None, fall back to heuristic:
+        // eligible if english + (multi-suggestion or context_clues).
+        let issue = make_confusable_issue("渲染", vec!["算繪", "彩現"], "rendering");
+        assert!(issue.anchor_match.is_none());
+        assert!(is_sampling_eligible(&issue, 0.3, 0.8));
     }
 
     #[test]
@@ -759,7 +836,7 @@ mod tests {
         let mut writer = Cursor::new(Vec::new());
         let mut bridge = SamplingBridge::new(&mut writer, &rx, Duration::from_secs(5), 5);
 
-        refine_issues_with_sampling(&mut issues, &mut bridge, "這個算法支持並行計算");
+        refine_issues_with_sampling(&mut issues, &mut bridge, "這個算法支持並行計算", 0.3, 0.8);
 
         assert_eq!(issues[0].suggestions[0], "平行"); // promoted to front
         assert!(issues[0]
@@ -920,122 +997,8 @@ mod tests {
         assert_eq!(bridge.used(), 0);
     }
 
-    #[test]
-    fn confirm_with_sampling_applies_bulk_results() {
-        use crate::engine::translate::{confirm_issues_with_sampling, ConfirmConfig};
-
-        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
-        let mut issues = vec![
-            {
-                let mut i = Issue::new(
-                    0,
-                    6,
-                    "渲染",
-                    vec!["算繪".into()],
-                    IssueType::CrossStrait,
-                    Severity::Warning,
-                )
-                .with_english("rendering");
-                i.line = 1;
-                i.col = 1;
-                i
-            },
-            {
-                let mut i = Issue::new(
-                    12,
-                    6,
-                    "實例",
-                    vec!["實體".into()],
-                    IssueType::CrossStrait,
-                    Severity::Warning,
-                )
-                .with_english("instance");
-                i.line = 1;
-                i.col = 5;
-                i
-            },
-        ];
-
-        let expected_id = next_expected_id();
-        let response = serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": expected_id,
-            "result": {
-                "role": "assistant",
-                "content": {
-                    "type": "text",
-                    "text": "{\"0\": true, \"1\": false}"
-                }
-            }
-        });
-
-        let (tx, rx) = mpsc::channel();
-        tx.send(StdinMsg::Line(response.to_string())).unwrap();
-
-        let mut writer = Cursor::new(Vec::new());
-        let mut bridge = SamplingBridge::new(&mut writer, &rx, Duration::from_secs(5), 1);
-
-        let config = ConfirmConfig {
-            request_delay: Duration::ZERO,
-            downgrade_unconfirmed: true,
-            max_api_calls: 10,
-        };
-        let text = "GPU渲染管線需要建立一個實例才能運作";
-        let result = confirm_issues_with_sampling(&mut issues, text, &mut bridge, &config);
-
-        assert_eq!(result.confirmed, 1);
-        assert_eq!(result.unconfirmed, 1);
-        assert_eq!(result.api_calls, 1);
-        assert!(
-            !result.transport_failed,
-            "successful sampling should not signal transport failure"
-        );
-        assert_eq!(issues[0].severity, Severity::Warning); // confirmed → keep
-        assert_eq!(issues[1].severity, Severity::Info); // rejected → downgrade
-    }
-
-    #[test]
-    fn confirm_with_sampling_fails_open_on_timeout() {
-        use crate::engine::translate::{confirm_issues_with_sampling, ConfirmConfig};
-
-        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
-        let mut issues = vec![{
-            let mut i = Issue::new(
-                0,
-                6,
-                "渲染",
-                vec!["算繪".into()],
-                IssueType::CrossStrait,
-                Severity::Warning,
-            )
-            .with_english("rendering");
-            i.line = 1;
-            i.col = 1;
-            i
-        }];
-
-        let (_tx, rx) = mpsc::channel::<StdinMsg>();
-        let mut writer = Cursor::new(Vec::new());
-        let mut bridge = SamplingBridge::new(&mut writer, &rx, Duration::from_millis(50), 1);
-
-        let config = ConfirmConfig {
-            request_delay: Duration::ZERO,
-            downgrade_unconfirmed: true,
-            max_api_calls: 10,
-        };
-        let result = confirm_issues_with_sampling(&mut issues, "GPU渲染管線", &mut bridge, &config);
-
-        assert_eq!(result.unknown, 1);
-        assert_eq!(result.confirmed, 0);
-        assert_eq!(result.unconfirmed, 0);
-        assert!(
-            result.transport_failed,
-            "timeout should signal transport failure"
-        );
-        assert_eq!(issues[0].severity, Severity::Warning); // fail-open
-    }
+    // Tests for confirm_issues_with_sampling removed — old anchor confirmation
+    // system replaced by calibrate_issues() in translate.rs.
 
     #[test]
     fn refine_issues_preserves_severity_on_timeout() {
@@ -1053,7 +1016,7 @@ mod tests {
         let mut writer = Cursor::new(Vec::new());
         let mut bridge = SamplingBridge::new(&mut writer, &rx, Duration::from_millis(10), 5);
 
-        refine_issues_with_sampling(&mut issues, &mut bridge, "context");
+        refine_issues_with_sampling(&mut issues, &mut bridge, "context", 0.3, 0.8);
 
         // Severity must be unchanged; only the context annotation is added.
         assert_eq!(issues[0].severity, original_severity);

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -20,9 +20,7 @@ use crate::engine::excluded::ByteRange;
 use crate::engine::s2t::S2TConverter;
 use crate::engine::scan::{build_exclusions_for_content_type, ContentType, Scanner};
 #[cfg(feature = "translate")]
-use crate::engine::translate::{
-    confirm_issues, confirm_issues_with_sampling, ConfirmConfig, ConfirmResult, TranslationCache,
-};
+use crate::engine::translate::calibrate_issues;
 use crate::engine::zhtype::{detect_chinese_type, ChineseType};
 use crate::fixer::{
     apply_fixes_with_context, remap_to_post_fix, suppress_convergent_issues, FixMode,
@@ -46,9 +44,6 @@ pub struct Server {
     initialized: bool,
     /// Client name from initialize handshake, used for auto-compact detection.
     client_name: Option<String>,
-    /// Singleton translation cache, opened once at server start (32.3).
-    #[cfg(feature = "translate")]
-    translation_cache: Option<TranslationCache>,
 }
 
 impl Server {
@@ -64,15 +59,6 @@ impl Server {
         let (scanner, ruleset_hash) =
             Self::build_scanner(&base_ruleset, &store, &pack_store, &active_packs)?;
 
-        #[cfg(feature = "translate")]
-        let translation_cache = match TranslationCache::open() {
-            Ok(c) => Some(c),
-            Err(e) => {
-                log::warn!("translation cache open failed, proceeding without: {e}");
-                None
-            }
-        };
-
         Ok(Self {
             scanner,
             s2t: S2TConverter::new(),
@@ -81,8 +67,6 @@ impl Server {
             client_capabilities: ClientCapabilities::default(),
             initialized: false,
             client_name: None,
-            #[cfg(feature = "translate")]
-            translation_cache,
         })
     }
 
@@ -313,7 +297,7 @@ impl Server {
                 Err(r) => return r,
             };
         #[cfg(feature = "translate")]
-        let confirm = parse_confirm(args);
+        let verify = parse_verify(args);
 
         let stance_name = stance.unwrap_or(PoliticalStance::RocCentric).name();
 
@@ -332,20 +316,19 @@ impl Server {
                 if let Some(st) = stance {
                     filter_by_stance(&mut issues, st);
                 }
+                // Calibrate issues via Google Translate anchor matching.
+                #[cfg(feature = "translate")]
+                let calibrate_result = if verify {
+                    Some(calibrate_issues(text, &mut issues))
+                } else {
+                    None
+                };
+
                 if let Some(b) = bridge.as_mut() {
-                    refine_issues_with_sampling(&mut issues, b, text);
+                    refine_issues_with_sampling(&mut issues, b, text, 0.3, 0.8);
                 }
                 self.apply_suppressions(&mut issues);
                 apply_ignore_terms(&mut issues, &ignore_terms);
-
-                #[cfg(feature = "translate")]
-                let confirm_result = run_anchor_confirm(
-                    &mut issues,
-                    text,
-                    bridge,
-                    self.translation_cache.as_ref(),
-                    confirm,
-                );
 
                 let trace =
                     Trace::new("zhtw", &self.ruleset_hash, text).with_issue_count(issues.len());
@@ -365,7 +348,7 @@ impl Server {
                     output_mode,
                     has_fixes: s2t_converted.is_some(),
                     #[cfg(feature = "translate")]
-                    confirm_result,
+                    calibrate_result,
                 })
             }
 
@@ -388,30 +371,46 @@ impl Server {
                     filter_by_stance(&mut issues, st);
                 }
 
-                // Snapshot severities before sampling to detect downgrades.
-                let pre_severities: Vec<Severity> = if bridge.is_some() {
-                    issues.iter().map(|i| i.severity).collect()
+                // Calibrate issues via Google Translate anchor matching.
+                #[cfg(feature = "translate")]
+                let calibrate_result = if verify {
+                    Some(calibrate_issues(text, &mut issues))
                 } else {
-                    Vec::new()
+                    None
                 };
 
                 if let Some(b) = bridge.as_mut() {
-                    refine_issues_with_sampling(&mut issues, b, text);
+                    refine_issues_with_sampling(&mut issues, b, text, 0.3, 0.8);
                 }
-
-                // Track terms downgraded to Info by sampling, keyed by (text, offset)
-                // so re-scan can match by position, not just term text.
-                let sampling_downgraded: Vec<(String, usize)> = issues
-                    .iter()
-                    .zip(pre_severities.iter())
-                    .filter(|(issue, &orig)| {
-                        orig != Severity::Info && issue.severity == Severity::Info
-                    })
-                    .map(|(issue, _)| (issue.found.clone(), issue.offset))
-                    .collect();
 
                 self.apply_suppressions(&mut issues);
                 apply_ignore_terms(&mut issues, &ignore_terms);
+
+                // Snapshot AFTER suppressions so restored severity reflects final state.
+                struct PreservedState {
+                    term: String,
+                    orig_offset: usize,
+                    length: usize,
+                    english: Option<String>,
+                    severity: Severity,
+                    anchor_match: Option<bool>,
+                    context: Option<String>,
+                    suggestions: Vec<String>,
+                }
+
+                let preserved_states: Vec<PreservedState> = issues
+                    .iter()
+                    .map(|i| PreservedState {
+                        term: i.found.clone(),
+                        orig_offset: i.offset,
+                        length: i.length,
+                        english: i.english.clone(),
+                        severity: i.severity,
+                        anchor_match: i.anchor_match,
+                        context: i.context.clone(),
+                        suggestions: i.suggestions.clone(),
+                    })
+                    .collect();
 
                 let excluded_pairs = to_offset_pairs(&excluded);
                 let fix_result = apply_fixes_with_context(
@@ -433,29 +432,26 @@ impl Server {
                 self.apply_suppressions(&mut remaining_issues);
                 apply_ignore_terms(&mut remaining_issues, &ignore_terms);
 
-                // Re-apply sampling downgrades using exact offset remapping.
+                // Re-apply preserved states using identity-safe matching:
+                // term + remapped offset + length + english must all match.
                 for issue in &mut remaining_issues {
-                    let matched = sampling_downgraded.iter().any(|(term, orig_offset)| {
-                        let expected = remap_to_post_fix(*orig_offset, &fix_result.applied_fixes);
-                        term == &issue.found && issue.offset == expected
-                    });
-                    if matched {
-                        issue.severity = Severity::Info;
+                    if let Some(state) = preserved_states.iter().find(|s| {
+                        let expected = remap_to_post_fix(s.orig_offset, &fix_result.applied_fixes);
+                        s.term == issue.found
+                            && issue.offset == expected
+                            && s.length == issue.length
+                            && s.english == issue.english
+                    }) {
+                        issue.severity = state.severity;
+                        issue.anchor_match = state.anchor_match;
+                        issue.context = state.context.clone();
+                        issue.suggestions = state.suggestions.clone();
                     }
                 }
 
                 // Suppress convergent-chain noise: remove re-scan issues
                 // whose offset falls within a byte range written by the fixer.
                 suppress_convergent_issues(&mut remaining_issues, &fix_result.applied_fixes);
-
-                #[cfg(feature = "translate")]
-                let confirm_result = run_anchor_confirm(
-                    &mut remaining_issues,
-                    &fix_result.text,
-                    bridge,
-                    self.translation_cache.as_ref(),
-                    confirm,
-                );
 
                 let trace = Trace::new("zhtw", &self.ruleset_hash, text)
                     .with_issue_count(remaining_issues.len())
@@ -476,7 +472,7 @@ impl Server {
                     output_mode,
                     has_fixes: fix_result.applied > 0 || s2t_converted.is_some(),
                     #[cfg(feature = "translate")]
-                    confirm_result,
+                    calibrate_result,
                 })
             }
         }
@@ -543,32 +539,6 @@ impl Server {
             ),
         }
     }
-}
-
-/// Run anchor-confirmation on issues, preferring sampling bridge over Google
-/// Translate cache. Returns None if confirm is disabled.
-#[cfg(feature = "translate")]
-fn run_anchor_confirm(
-    issues: &mut [Issue],
-    text: &str,
-    mut bridge: Option<&mut SamplingBridge<'_>>,
-    cache: Option<&TranslationCache>,
-    confirm: bool,
-) -> Option<ConfirmResult> {
-    if !confirm {
-        return None;
-    }
-    let config = ConfirmConfig::default();
-    if let Some(b) = bridge.as_mut() {
-        if b.has_budget() {
-            let r = confirm_issues_with_sampling(issues, text, b, &config);
-            if r.transport_failed {
-                return Some(confirm_issues(issues, text, &config, cache));
-            }
-            return Some(r);
-        }
-    }
-    Some(confirm_issues(issues, text, &config, cache))
 }
 
 /// Serialize result to JSON and wrap in a success response, or return an
@@ -741,10 +711,10 @@ fn default_output_mode(client_name: Option<&str>) -> OutputMode {
     }
 }
 
-/// Parse the optional "confirm" flag from tool arguments.
+/// Parse the optional "verify" flag from tool arguments.
 #[cfg(feature = "translate")]
-fn parse_confirm(args: &Value) -> bool {
-    args.get("confirm")
+fn parse_verify(args: &Value) -> bool {
+    args.get("verify")
         .and_then(|v| v.as_bool())
         .unwrap_or(false)
 }
@@ -904,7 +874,7 @@ struct CheckOutputParams<'a> {
     output_mode: OutputMode,
     has_fixes: bool,
     #[cfg(feature = "translate")]
-    confirm_result: Option<ConfirmResult>,
+    calibrate_result: Option<crate::engine::translate::CalibrateResult>,
 }
 
 /// Build the unified zhtw JSON response and wrap it in a CallToolResult.
@@ -983,17 +953,16 @@ fn build_check_output(params: &CheckOutputParams<'_>) -> CallToolResult {
         }
     };
 
-    // Append confirm stats when anchor-confirmation was used.
+    // Append calibration stats when anchor-verification was used.
     #[cfg(feature = "translate")]
     let output = {
         let mut out = output;
-        if let Some(ref cr) = params.confirm_result {
-            out["confirm"] = json!({
-                "confirmed": cr.confirmed,
-                "unconfirmed": cr.unconfirmed,
-                "unknown": cr.unknown,
-                "api_calls": cr.api_calls,
-                "cache_hits": cr.cache_hits,
+        if let Some(ref cr) = params.calibrate_result {
+            out["verify"] = json!({
+                "api_ok": cr.api_ok,
+                "matched": cr.matched,
+                "unmatched": cr.unmatched,
+                "no_english": cr.no_english,
             });
         }
         out
@@ -1023,6 +992,15 @@ fn build_issues_full(issues: &[Issue], explain: bool) -> Value {
                 Ok(mut obj) => {
                     if let Some(explanation) = build_explanation(issue) {
                         obj["explanation"] = Value::String(explanation);
+                    }
+                    // Anchor provenance: structured object for LLM reasoning chains.
+                    if issue.anchor_match.is_some() {
+                        let mut prov = serde_json::Map::new();
+                        if let Some(eng) = &issue.english {
+                            prov.insert("anchor_en".into(), json!(eng));
+                        }
+                        prov.insert("anchor_match".into(), json!(issue.anchor_match));
+                        obj["anchor_provenance"] = Value::Object(prov);
                     }
                     Some(obj)
                 }
@@ -1074,6 +1052,16 @@ fn build_issues_compact(issues: &[Issue], explain: bool) -> Value {
             } else {
                 None
             },
+            anchor_provenance: if explain && issue.anchor_match.is_some() {
+                let mut prov = serde_json::Map::new();
+                if let Some(eng) = &issue.english {
+                    prov.insert("anchor_en".into(), json!(eng));
+                }
+                prov.insert("anchor_match".into(), json!(issue.anchor_match));
+                Some(Value::Object(prov))
+            } else {
+                None
+            },
             count: 0,
             locations: Vec::new(),
         });
@@ -1103,6 +1091,9 @@ fn build_issues_compact(issues: &[Issue], explain: bool) -> Value {
             if let Some(expl) = &g.explanation {
                 obj["explanation"] = Value::String(expl.clone());
             }
+            if let Some(prov) = &g.anchor_provenance {
+                obj["anchor_provenance"] = prov.clone();
+            }
             obj
         })
         .collect();
@@ -1119,6 +1110,7 @@ struct CompactGroup {
     context: Option<String>,
     english: Option<String>,
     explanation: Option<String>,
+    anchor_provenance: Option<Value>,
     count: usize,
     locations: Vec<(usize, usize)>,
 }
@@ -1128,7 +1120,7 @@ struct CompactGroup {
 fn tool_definitions() -> Vec<ToolDef> {
     vec![ToolDef {
         name: "zhtw".into(),
-        description: "Lint/fix/gate zh-TW text. Auto-converts Simplified Chinese to Traditional before applying rules.".into(),
+        description: "Lint/fix/gate zh-TW text. Auto-converts Simplified Chinese to Traditional before applying rules. Use verify=true to calibrate issues via Google Translate anchor matching.".into(),
         input_schema: {
             let mut props = serde_json::Map::new();
             props.insert("text".into(), json!({ "type": "string" }));
@@ -1156,9 +1148,9 @@ fn tool_definitions() -> Vec<ToolDef> {
             }));
             props.insert("explain".into(), json!({ "type": "boolean" }));
             #[cfg(feature = "translate")]
-            props.insert("confirm".into(), json!({
+            props.insert("verify".into(), json!({
                 "type": "boolean",
-                "description": "Anchor-confirm issues via Google Translate"
+                "description": "Anchor-verify issues via Google Translate"
             }));
             props.insert("output".into(), json!({
                 "type": "string",

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -386,6 +386,12 @@ pub struct Issue {
     /// segmenter to decide whether an ambiguous term should be corrected.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_clues: Option<Vec<String>>,
+    /// Calibration result from translation verification.
+    /// `Some(true)`: anchor found in translation (confirmed).
+    /// `Some(false)`: anchor absent in translation (unconfirmed).
+    /// `None`: calibration not attempted or API failure (no signal).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anchor_match: Option<bool>,
 }
 
 impl Issue {
@@ -411,6 +417,7 @@ impl Issue {
             context: None,
             english: None,
             context_clues: None,
+            anchor_match: None,
         }
     }
 

--- a/tests/anchor_benchmark.rs
+++ b/tests/anchor_benchmark.rs
@@ -1,0 +1,365 @@
+// Benchmark for calibration-based anchor verification (35.6).
+//
+// Measures: anchor coverage, match/unmatch rate, latency overhead,
+// and multi-run convergence.
+//
+// Requires network access (Google Translate API) so marked #[ignore] by default.
+// Run explicitly:
+//   cargo test --test anchor_benchmark -- --ignored --nocapture
+//
+// Set CORPUS_DIR=path/to/dir to lint real-world .md/.txt files instead of
+// the built-in synthetic corpus.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+fn binary_path() -> std::path::PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push("zhtw-mcp");
+    path
+}
+
+fn run_lint_json(input: &str, extra_args: &[&str]) -> (String, std::time::Duration) {
+    let bin = binary_path();
+    let start = Instant::now();
+    let output = Command::new(&bin)
+        .args(["lint", "--"])
+        .args(["--format", "json"])
+        .args(extra_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(input.as_bytes())
+                .unwrap();
+            child.wait_with_output()
+        })
+        .unwrap();
+    let elapsed = start.elapsed();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    (stdout, elapsed)
+}
+
+/// Synthetic corpus: cross-strait terms in realistic sentence contexts.
+fn synthetic_corpus() -> &'static str {
+    concat!(
+        // IT terms
+        "這個軟件的質量很好，內存佔用也很低。\n",
+        "我們正在優化視頻播放器的渲染引擎。\n",
+        "請檢查服務器的網絡帶寬是否足夠。\n",
+        "程序員在調試這段代碼的時候發現了問題。\n",
+        "硬盤空間不足，需要清理緩存文件。\n",
+        "該操作系統的內核支持多線程並發處理。\n",
+        "移動端應用需要適配不同的分辨率。\n",
+        "在雲計算平台上部署容器化的微服務架構。\n",
+        // General terms
+        "他的表達方式非常簡練。\n",
+        "這個方案的信息量很大。\n",
+        // Mixed: some terms should fire, some should not
+        "使用正確的軟體開發方法論。\n", // 軟體 is zh-TW, should NOT fire
+        "正確的繁體中文排版很重要。\n", // clean text
+    )
+}
+
+#[derive(Debug, Default)]
+struct BenchmarkMetrics {
+    total_issues: usize,
+    issues_with_anchor: usize,
+    matched: usize,
+    unmatched: usize,
+    no_signal: usize,
+    baseline_duration: std::time::Duration,
+    verify_duration_1: std::time::Duration,
+    verify_duration_2: std::time::Duration,
+    convergence_identical: bool,
+}
+
+fn parse_issues(json_str: &str) -> serde_json::Value {
+    serde_json::from_str(json_str).unwrap_or_else(|e| {
+        panic!("Failed to parse JSON output: {e}\nRaw output:\n{json_str}");
+    })
+}
+
+fn count_anchor_stats(issues: &[serde_json::Value]) -> (usize, usize, usize, usize) {
+    let mut with_anchor = 0usize;
+    let mut matched = 0usize;
+    let mut unmatched = 0usize;
+    let mut no_signal = 0usize;
+
+    for issue in issues {
+        match issue.get("anchor_match") {
+            Some(serde_json::Value::Bool(true)) => {
+                with_anchor += 1;
+                matched += 1;
+            }
+            Some(serde_json::Value::Bool(false)) => {
+                with_anchor += 1;
+                unmatched += 1;
+            }
+            _ => {
+                no_signal += 1;
+            }
+        }
+    }
+    (with_anchor, matched, unmatched, no_signal)
+}
+
+fn collect_metrics(corpus: &str) -> BenchmarkMetrics {
+    let mut m = BenchmarkMetrics::default();
+
+    // Run 1: baseline without --verify
+    let (baseline_json, baseline_dur) = run_lint_json(corpus, &[]);
+    m.baseline_duration = baseline_dur;
+    let baseline = parse_issues(&baseline_json);
+    m.total_issues = baseline["total"].as_u64().unwrap_or(0) as usize;
+
+    // Run 2: first --verify (single API call, no cache)
+    let (verify1_json, verify1_dur) = run_lint_json(corpus, &["--verify"]);
+    m.verify_duration_1 = verify1_dur;
+
+    // Run 3: second --verify (for convergence check)
+    let (verify2_json, verify2_dur) = run_lint_json(corpus, &["--verify"]);
+    m.verify_duration_2 = verify2_dur;
+
+    let v1 = parse_issues(&verify1_json);
+    if let Some(issues) = v1["issues"].as_array() {
+        let (with_anchor, matched, unmatched, no_signal) = count_anchor_stats(issues);
+        m.issues_with_anchor = with_anchor;
+        m.matched = matched;
+        m.unmatched = unmatched;
+        m.no_signal = no_signal;
+    }
+
+    // Convergence: both verify runs should produce identical anchor_match values
+    let v2 = parse_issues(&verify2_json);
+    m.convergence_identical = v1["issues"] == v2["issues"];
+
+    m
+}
+
+fn pct(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        numerator as f64 / denominator as f64 * 100.0
+    }
+}
+
+fn print_report(m: &BenchmarkMetrics) {
+    println!("\n========================================");
+    println!("  Calibration Benchmark Report (35.6)");
+    println!("========================================\n");
+
+    println!("1. Issue Summary");
+    println!("   Total issues detected:       {}", m.total_issues);
+    println!("   Issues with anchor signal:   {}", m.issues_with_anchor);
+    println!("   No signal (no english/API):  {}", m.no_signal);
+    println!(
+        "   Anchor coverage:             {:.1}%",
+        pct(m.issues_with_anchor, m.total_issues)
+    );
+    println!();
+
+    println!("2. Anchor Match Results");
+    println!(
+        "   Matched (true):              {} ({:.1}%)",
+        m.matched,
+        pct(m.matched, m.issues_with_anchor)
+    );
+    println!(
+        "   Unmatched (false):           {} ({:.1}%)",
+        m.unmatched,
+        pct(m.unmatched, m.issues_with_anchor)
+    );
+    println!();
+
+    println!("3. Latency Analysis");
+    println!(
+        "   Baseline (no verify):        {:>8.1}ms",
+        m.baseline_duration.as_secs_f64() * 1000.0
+    );
+    println!(
+        "   Verify run 1:                {:>8.1}ms",
+        m.verify_duration_1.as_secs_f64() * 1000.0
+    );
+    println!(
+        "   Verify run 2:                {:>8.1}ms",
+        m.verify_duration_2.as_secs_f64() * 1000.0
+    );
+    if m.baseline_duration.as_nanos() > 0 {
+        let overhead =
+            (m.verify_duration_1.as_secs_f64() / m.baseline_duration.as_secs_f64() - 1.0) * 100.0;
+        println!("   Overhead vs baseline:        {:>8.1}%", overhead);
+    }
+    println!();
+
+    println!("4. Convergence (Multi-Run Stability)");
+    println!(
+        "   Run 1 vs run 2 identical:    {}",
+        if m.convergence_identical {
+            "YES (stable)"
+        } else {
+            "NO (non-deterministic)"
+        }
+    );
+    println!();
+
+    println!("========================================\n");
+}
+
+#[test]
+#[ignore]
+fn anchor_benchmark_synthetic() {
+    let corpus = synthetic_corpus();
+    let m = collect_metrics(corpus);
+    print_report(&m);
+
+    assert!(
+        m.total_issues >= 5,
+        "synthetic corpus should produce at least 5 issues, got {}",
+        m.total_issues
+    );
+}
+
+#[test]
+#[ignore]
+fn anchor_benchmark_corpus_dir() {
+    let corpus_dir = match std::env::var("CORPUS_DIR") {
+        Ok(d) => d,
+        Err(_) => {
+            eprintln!("CORPUS_DIR not set, skipping corpus_dir benchmark");
+            return;
+        }
+    };
+
+    let bin = binary_path();
+
+    // Run 1: baseline
+    let start = Instant::now();
+    let baseline_output = Command::new(&bin)
+        .args(["lint", &corpus_dir, "--format", "json"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+    let baseline_dur = start.elapsed();
+
+    // Run 2: verify
+    let start = Instant::now();
+    let verify_output = Command::new(&bin)
+        .args(["lint", &corpus_dir, "--format", "json", "--verify"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+    let verify_dur = start.elapsed();
+
+    let baseline_json = String::from_utf8_lossy(&baseline_output.stdout);
+    let verify_json = String::from_utf8_lossy(&verify_output.stdout);
+
+    // zhtw lint exits 0 (clean) or 1 (issues found).  Both are expected for
+    // benchmark corpora.  Any other exit code indicates a crash or usage error.
+    let baseline_code = baseline_output.status.code().unwrap_or(-1);
+    assert!(
+        baseline_code == 0 || baseline_code == 1,
+        "baseline CLI unexpected exit code {baseline_code}: {}",
+        String::from_utf8_lossy(&baseline_output.stderr)
+    );
+    let verify_code = verify_output.status.code().unwrap_or(-1);
+    assert!(
+        verify_code == 0 || verify_code == 1,
+        "verify CLI unexpected exit code {verify_code}: {}",
+        String::from_utf8_lossy(&verify_output.stderr)
+    );
+
+    let baseline: serde_json::Value = serde_json::from_str(&baseline_json)
+        .unwrap_or_else(|e| panic!("Failed to parse baseline JSON: {e}\nRaw: {baseline_json}"));
+    let verified: serde_json::Value = serde_json::from_str(&verify_json)
+        .unwrap_or_else(|e| panic!("Failed to parse verify JSON: {e}\nRaw: {verify_json}"));
+
+    // Aggregate across files
+    let mut total_issues = 0usize;
+    let mut issues_with_anchor = 0usize;
+    let mut matched = 0usize;
+    let mut unmatched = 0usize;
+    let mut no_signal = 0usize;
+
+    let files = if verified.is_array() {
+        verified.as_array().unwrap().clone()
+    } else {
+        vec![verified.clone()]
+    };
+
+    for file_result in &files {
+        if let Some(issues) = file_result["issues"].as_array() {
+            total_issues += issues.len();
+            let (wa, ma, um, ns) = count_anchor_stats(issues);
+            issues_with_anchor += wa;
+            matched += ma;
+            unmatched += um;
+            no_signal += ns;
+        }
+    }
+
+    let baseline_files = if baseline.is_array() {
+        baseline.as_array().unwrap().clone()
+    } else {
+        vec![baseline.clone()]
+    };
+    let baseline_total: usize = baseline_files
+        .iter()
+        .filter_map(|f| f["total"].as_u64())
+        .sum::<u64>() as usize;
+
+    println!("\n========================================");
+    println!("  Calibration Benchmark: Corpus Directory");
+    println!("  {}", corpus_dir);
+    println!("========================================\n");
+
+    println!("Files scanned:              {}", files.len());
+    println!("Baseline total issues:      {}", baseline_total);
+    println!("Verified total issues:      {}", total_issues);
+    println!("Issues with anchor signal:  {}", issues_with_anchor);
+    println!(
+        "Anchor coverage:            {:.1}%",
+        pct(issues_with_anchor, total_issues)
+    );
+    println!();
+    println!(
+        "Matched (true):             {} ({:.1}%)",
+        matched,
+        pct(matched, issues_with_anchor)
+    );
+    println!(
+        "Unmatched (false):          {} ({:.1}%)",
+        unmatched,
+        pct(unmatched, issues_with_anchor)
+    );
+    println!("No signal:                  {}", no_signal);
+    println!();
+
+    println!(
+        "Baseline latency:           {:>8.1}ms",
+        baseline_dur.as_secs_f64() * 1000.0
+    );
+    println!(
+        "Verify latency:             {:>8.1}ms",
+        verify_dur.as_secs_f64() * 1000.0
+    );
+    if baseline_dur.as_nanos() > 0 {
+        let overhead = (verify_dur.as_secs_f64() / baseline_dur.as_secs_f64() - 1.0) * 100.0;
+        println!("Overhead vs baseline:       {:>8.1}%", overhead);
+    }
+
+    println!("\n========================================\n");
+}

--- a/tests/e2e_mcp.rs
+++ b/tests/e2e_mcp.rs
@@ -815,3 +815,119 @@ fn e2e_auto_compact_for_ai_clients() {
     let status = child.wait().unwrap();
     assert!(status.success());
 }
+
+/// Verify explain mode includes explanation annotations and deterministic results.
+#[test]
+fn e2e_explain_mode_and_determinism() {
+    let bin = binary_path();
+    if !bin.exists() {
+        panic!("binary not found at {:?}; run `cargo build` first", bin);
+    }
+
+    let tmp_dir = tempfile::tempdir().expect("create temp dir");
+    let overrides_path = tmp_dir.path().join("overrides.json");
+    let suppressions_path = tmp_dir.path().join("suppressions.json");
+
+    let mut child = Command::new(&bin)
+        .args([
+            "--overrides",
+            overrides_path.to_str().unwrap(),
+            "--suppressions",
+            suppressions_path.to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn zhtw-mcp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    // Initialize
+    let resp = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test-explain", "version": "0.1" }
+            }
+        }),
+    );
+    assert_eq!(resp["id"], 1);
+
+    send_notification(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }),
+    );
+
+    // Lint with explain mode.
+    let resp = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 2,
+            "params": {
+                "name": "zhtw",
+                "arguments": {
+                    "text": "這個軟件很好用",
+                    "explain": true,
+                    "output": "full"
+                }
+            }
+        }),
+    );
+    assert_eq!(resp["id"], 2);
+    let content_text = resp["result"]["content"][0]["text"].as_str().unwrap();
+    let output: Value = serde_json::from_str(content_text).unwrap();
+
+    // Issues should be present with explain-specific annotations.
+    let issues = output["issues"].as_array().unwrap();
+    assert!(!issues.is_empty());
+    // Verify explain mode actually produces the explanation annotation
+    // (distinct from the `context` field which exists regardless of explain mode).
+    let has_explanation = issues.iter().any(|i| i.get("explanation").is_some());
+    assert!(
+        has_explanation,
+        "explain mode should produce 'explanation' field on at least one issue"
+    );
+
+    // Lint same text twice — results should be identical (deterministic).
+    let resp2 = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 3,
+            "params": {
+                "name": "zhtw",
+                "arguments": {
+                    "text": "這個軟件很好用",
+                    "explain": true,
+                    "output": "full"
+                }
+            }
+        }),
+    );
+    assert_eq!(resp2["id"], 3);
+    let content_text2 = resp2["result"]["content"][0]["text"].as_str().unwrap();
+    let output2: Value = serde_json::from_str(content_text2).unwrap();
+
+    let issues2 = output2["issues"].as_array().unwrap();
+    assert_eq!(issues, issues2, "same text should produce identical issues");
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success());
+}


### PR DESCRIPTION
This strips the over-engineered anchor system (AnchorOutcome, ResolutionMethod, ConfirmConfig, TranslationCache, sled cache, synonym tables, LCP stem matching) and replace with a stateless calibration API that makes one Google Translate call per lint invocation.

Calibration flow: extract ±sentence context per issue, deduplicate, translate via sentinel-delimited payload (###SEG0/###SEG1), tokenize each segment, check if any content-word anchor appears. Result is a tri-state annotation (Some(true)/Some(false)/None) with no severity mutation and fail-open on API failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the anchor-confirmation system with a stateless calibration step that verifies anchors via a single Google Translate call per lint run. Results are stored as tri-state `anchor_match` on each issue, with fail-open behavior and no severity changes; CLI now surfaces [verified]/[unverified] tags and residual stats, and MCP exposes a `verify` parameter.

- **Refactors**
  - Removed the legacy anchor stack (outcomes, caches, synonyms, LCP matching).
  - Implemented calibration: deduplicate sentence contexts, send sentinel-delimited segments, stopword-filter, tokenize, and check content-word anchors.
  - Simplified `translate` feature to `ureq` + `urlencoding`; removed `sled` and `postcard`.
  - Sampling interaction: skip when confirmed and unambiguous; allow second opinion for ambiguous or unconfirmed.
  - Added calibration benchmark and E2E determinism tests.
  - Ruleset tweak: added exception for “海內存知己” under “memory (RAM)”.

- **Migration**
  - Use `--verify` instead of `--confirm`; MCP `verify` parameter supported.
  - Read `anchor_match` on `Issue`; severity unchanged; CLI shows [verified]/[unverified] and splits unconfirmed vs no-signal counts.
  - No persistent cache; expect one Google Translate call per lint invocation.

<sup>Written for commit d3bf7962d543242b08f93e41f6c537f66657ca6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

