### PR TITLE
Reduce post-processing hot-path complexity

### DIFF
--- a/benches/scanner.rs
+++ b/benches/scanner.rs
@@ -290,6 +290,103 @@ fn bench_segmenter(c: &mut Criterion) {
     });
 }
 
+// 7. Post-scan transforms: ignore_terms downgrade + preserved-state remap
+
+fn bench_post_scan_transforms(c: &mut Criterion) {
+    use rustc_hash::FxHashMap;
+    use std::collections::HashSet;
+    use zhtw_mcp::fixer::remap_to_post_fix;
+    use zhtw_mcp::fixer::AppliedFix;
+    use zhtw_mcp::rules::ruleset::{Issue, IssueType, Severity};
+
+    // Simulate post-scan transform workload at three issue counts.
+    let issue_counts: &[(usize, &str)] = &[(100, "100"), (500, "500"), (1000, "1000")];
+    let ignore_terms: HashSet<&str> = ["軟件", "信息", "數據"].iter().copied().collect();
+
+    let mut group = c.benchmark_group("post_scan_transforms");
+    for &(count, label) in issue_counts {
+        // Build synthetic issues at evenly spaced offsets.
+        let terms = ["軟件", "信息", "數據", "應用程序", "網絡"];
+        let issues: Vec<Issue> = (0..count)
+            .map(|i| {
+                let term = terms[i % terms.len()];
+                Issue {
+                    offset: i * 100,
+                    length: term.len(),
+                    line: i + 1,
+                    col: 1,
+                    found: term.to_string(),
+                    suggestions: vec!["替代".to_string()],
+                    rule_type: IssueType::CrossStrait,
+                    severity: Severity::Warning,
+                    context: Some("test context".to_string()),
+                    english: Some("term".to_string()),
+                    context_clues: None,
+                    anchor_match: None,
+                }
+            })
+            .collect();
+
+        // Simulate applied fixes (every 5th issue gets a fix with +3 byte delta).
+        let applied_fixes: Vec<AppliedFix> = (0..count)
+            .step_by(5)
+            .map(|i| AppliedFix {
+                offset: i * 100,
+                old_len: terms[i % terms.len()].len(),
+                replacement: "替代用語".to_string(),
+            })
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("ignore_downgrade", label),
+            &issues,
+            |b, issues| {
+                b.iter(|| {
+                    let mut cloned = issues.clone();
+                    let set = black_box(&ignore_terms);
+                    for issue in &mut cloned {
+                        if set.contains(issue.found.as_str()) {
+                            issue.severity = Severity::Info;
+                        }
+                    }
+                    black_box(&cloned);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("remap_hashmap_lookup", label),
+            &issues,
+            |b, issues| {
+                b.iter(|| {
+                    // Precompute remapped offsets and build index.
+                    let mut state_by_offset: FxHashMap<usize, Vec<usize>> =
+                        FxHashMap::with_capacity_and_hasher(issues.len(), Default::default());
+                    for (idx, issue) in issues.iter().enumerate() {
+                        let remapped = remap_to_post_fix(issue.offset, black_box(&applied_fixes));
+                        state_by_offset.entry(remapped).or_default().push(idx);
+                    }
+                    // Simulate lookup for each remaining issue using post-fix offsets.
+                    let mut match_count = 0usize;
+                    for issue in issues {
+                        let remapped = remap_to_post_fix(issue.offset, black_box(&applied_fixes));
+                        if let Some(candidates) = state_by_offset.get(&remapped) {
+                            if candidates.iter().any(|&idx| {
+                                let s = &issues[idx];
+                                s.found == issue.found && s.length == issue.length
+                            }) {
+                                match_count += 1;
+                            }
+                        }
+                    }
+                    black_box(match_count);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 // Criterion harness
 
 criterion_group!(
@@ -302,5 +399,6 @@ criterion_group!(
     bench_scan_context_clues,
     bench_markdown_exclusion,
     bench_segmenter,
+    bench_post_scan_transforms,
 );
 criterion_main!(benches);

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -290,6 +290,8 @@ impl Server {
         let max_errors = args.get("max_errors").and_then(|v| v.as_u64());
         let max_warnings = args.get("max_warnings").and_then(|v| v.as_u64());
         let ignore_terms = parse_ignore_terms(args);
+        let ignore_set: std::collections::HashSet<&str> =
+            ignore_terms.iter().map(String::as_str).collect();
         let explain = parse_explain(args);
         let output_mode =
             match parse_output_mode(args, default_output_mode(self.client_name.as_deref())) {
@@ -328,7 +330,7 @@ impl Server {
                     refine_issues_with_sampling(&mut issues, b, text, 0.3, 0.8);
                 }
                 self.apply_suppressions(&mut issues);
-                apply_ignore_terms(&mut issues, &ignore_terms);
+                apply_ignore_set(&mut issues, &ignore_set);
 
                 let trace =
                     Trace::new("zhtw", &self.ruleset_hash, text).with_issue_count(issues.len());
@@ -384,7 +386,7 @@ impl Server {
                 }
 
                 self.apply_suppressions(&mut issues);
-                apply_ignore_terms(&mut issues, &ignore_terms);
+                apply_ignore_set(&mut issues, &ignore_set);
 
                 // Snapshot AFTER suppressions so restored severity reflects final state.
                 struct PreservedState {
@@ -430,22 +432,34 @@ impl Server {
                     filter_by_stance(&mut remaining_issues, st);
                 }
                 self.apply_suppressions(&mut remaining_issues);
-                apply_ignore_terms(&mut remaining_issues, &ignore_terms);
+                apply_ignore_set(&mut remaining_issues, &ignore_set);
+
+                // Precompute remapped offsets once (O(M*F)) and index by
+                // post-fix offset for O(1) lookup per remaining issue.
+                use rustc_hash::FxHashMap;
+                let mut state_by_offset: FxHashMap<usize, Vec<usize>> =
+                    FxHashMap::with_capacity_and_hasher(preserved_states.len(), Default::default());
+                for (idx, state) in preserved_states.iter().enumerate() {
+                    let remapped = remap_to_post_fix(state.orig_offset, &fix_result.applied_fixes);
+                    state_by_offset.entry(remapped).or_default().push(idx);
+                }
 
                 // Re-apply preserved states using identity-safe matching:
                 // term + remapped offset + length + english must all match.
                 for issue in &mut remaining_issues {
-                    if let Some(state) = preserved_states.iter().find(|s| {
-                        let expected = remap_to_post_fix(s.orig_offset, &fix_result.applied_fixes);
-                        s.term == issue.found
-                            && issue.offset == expected
-                            && s.length == issue.length
-                            && s.english == issue.english
-                    }) {
-                        issue.severity = state.severity;
-                        issue.anchor_match = state.anchor_match;
-                        issue.context = state.context.clone();
-                        issue.suggestions = state.suggestions.clone();
+                    if let Some(candidates) = state_by_offset.get(&issue.offset) {
+                        if let Some(&idx) = candidates.iter().find(|&&idx| {
+                            let s = &preserved_states[idx];
+                            s.term == issue.found
+                                && s.length == issue.length
+                                && s.english == issue.english
+                        }) {
+                            let state = &preserved_states[idx];
+                            issue.severity = state.severity;
+                            issue.anchor_match = state.anchor_match;
+                            issue.context = state.context.clone();
+                            issue.suggestions = state.suggestions.clone();
+                        }
                     }
                 }
 
@@ -840,14 +854,13 @@ fn filter_by_stance(issues: &mut Vec<Issue>, stance: PoliticalStance) {
     });
 }
 
-/// Downgrade issues whose found term matches an ignore_terms entry to Info.
-fn apply_ignore_terms(issues: &mut [Issue], ignore_terms: &[String]) {
-    if ignore_terms.is_empty() {
+/// Downgrade issues whose found term matches a pre-built ignore set to Info.
+fn apply_ignore_set(issues: &mut [Issue], ignore_set: &std::collections::HashSet<&str>) {
+    if ignore_set.is_empty() {
         return;
     }
-    let set: std::collections::HashSet<&str> = ignore_terms.iter().map(String::as_str).collect();
     for issue in issues {
-        if set.contains(issue.found.as_str()) {
+        if ignore_set.contains(issue.found.as_str()) {
             issue.severity = Severity::Info;
         }
     }


### PR DESCRIPTION
This builds ignore_terms HashSet once per request instead of rebuilding on each of 3 call sites. It replaces O(N*M*F) preserved-state remap loop with FxHashMap precomputed index for O(M*F+N) lookup and adds criterion microbench for post-scan transforms at 100/500/1000 issue counts.

Close #1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up post-scan processing by reusing a pre-built ignore-term set and indexing preserved state by post-fix offset using `rustc_hash` for faster remap matching. Adds `criterion` microbenchmarks and fixes the remap lookup to use post-fix offsets in the benchmark.

- **Refactors**
  - Build the ignore-term `HashSet<&str>` once per request and reuse via `apply_ignore_set` across three call sites.
  - Precompute remapped offsets and index preserved state by post-fix offset using `FxHashMap`, reducing matching from O(N*M*F) to O(M*F + N).

- **Bug Fixes**
  - Correct `remap_hashmap_lookup` in benchmarks to use post-fix offsets during lookup, measuring the intended preserved-state path.

<sup>Written for commit 6dbe0d6fd4eb9a55f62626010a1fb0ab9c456a1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

