### PR TITLE
Harden transport layer

### DIFF
--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -15,7 +15,7 @@
 
 use std::collections::VecDeque;
 use std::io::{self, BufRead, Read, Write};
-use std::string::FromUtf8Error;
+use std::str;
 use std::sync::mpsc;
 use std::thread;
 
@@ -23,9 +23,7 @@ use anyhow::Result;
 
 use super::sampling::{SamplingBridge, DEFAULT_SAMPLING_BUDGET, DEFAULT_SAMPLING_TIMEOUT};
 use super::tools::Server;
-use super::types::{
-    JsonRpcRequest, JsonRpcResponse, INVALID_REQUEST, JSONRPC_VERSION, PARSE_ERROR,
-};
+use super::types::{JsonRpcRequest, JsonRpcResponse, TransportError, INVALID_REQUEST, PARSE_ERROR};
 
 /// Maximum line length we'll accept from stdin (4 MiB payload).
 /// Prevents memory exhaustion from malformed input.
@@ -39,7 +37,7 @@ pub(crate) enum StdinMsg {
     /// A line that exceeded the maximum allowed size.
     TooLong,
     /// A line that contains malformed UTF-8 text
-    MalformedUtf8(FromUtf8Error),
+    MalformedUtf8(str::Utf8Error),
 }
 
 /// Result of a bounded line read (internal to the reader thread).
@@ -47,30 +45,31 @@ enum ReadLine {
     Line,
     Eof,
     TooLong,
-    MalformedUtf8(FromUtf8Error),
+    MalformedUtf8(str::Utf8Error),
 }
 
 /// Serialize a response as JSON and write it to stdout, followed by a newline.
+/// Writes directly to the buffered writer without an intermediate String.
 fn send(out: &mut impl Write, resp: &JsonRpcResponse) -> Result<()> {
-    let json = serde_json::to_string(resp)?;
-    writeln!(out, "{json}")?;
+    serde_json::to_writer(&mut *out, resp)?;
+    out.write_all(b"\n")?;
     out.flush()?;
     Ok(())
 }
 
 /// Read a single line from reader, bounded to MAX_LINE_BYTES.
 ///
-/// Uses read_until on raw bytes so that a multi-byte UTF-8 sequence
-/// straddling the MAX_LINE_BYTES boundary does not cause an InvalidData
-/// error (which would kill the reader thread). If the completed line
-/// contains invalid UTF-8, returns `ReadLine::MalformedUtf8` so the
-/// caller can emit a proper error response.
-fn read_bounded_line(reader: &mut impl BufRead, buf: &mut String) -> io::Result<ReadLine> {
-    let mut raw: Vec<u8> = Vec::new();
+/// Reads into `raw` (cleared first) so the caller can reuse the allocation
+/// across calls.  UTF-8 is validated via `str::from_utf8` (borrow) instead
+/// of `String::from_utf8` (move), keeping ownership of the buffer with the
+/// caller.  On `ReadLine::Line`, `raw` contains valid UTF-8 bytes that the
+/// caller can convert to `&str` without re-validation.
+fn read_bounded_line(reader: &mut impl BufRead, raw: &mut Vec<u8>) -> io::Result<ReadLine> {
+    raw.clear();
     let n = reader
         .by_ref()
         .take(MAX_LINE_BYTES + 1)
-        .read_until(b'\n', &mut raw)?;
+        .read_until(b'\n', raw)?;
 
     if n == 0 {
         return Ok(ReadLine::Eof);
@@ -81,11 +80,8 @@ fn read_bounded_line(reader: &mut impl BufRead, buf: &mut String) -> io::Result<
         return Ok(ReadLine::TooLong);
     }
 
-    match String::from_utf8(raw) {
-        Ok(text) => {
-            *buf = text;
-            Ok(ReadLine::Line)
-        }
+    match str::from_utf8(raw) {
+        Ok(_) => Ok(ReadLine::Line),
         Err(e) => Ok(ReadLine::MalformedUtf8(e)),
     }
 }
@@ -119,16 +115,21 @@ pub fn run_stdio(server: &mut Server) -> Result<()> {
     let (line_tx, line_rx) = mpsc::channel::<StdinMsg>();
 
     // Background stdin reader: reads bounded lines and sends them to the channel.
+    // The raw buffer is allocated once and reused across reads.
     thread::spawn(move || {
         let stdin = io::stdin();
         let mut reader = stdin.lock();
-        let mut buf = String::new();
+        let mut raw: Vec<u8> = Vec::new();
         loop {
-            match read_bounded_line(&mut reader, &mut buf) {
+            match read_bounded_line(&mut reader, &mut raw) {
                 Ok(ReadLine::Eof) => break,
                 Ok(ReadLine::Line) => {
-                    let trimmed = buf.trim().to_string();
-                    if !trimmed.is_empty() && line_tx.send(StdinMsg::Line(trimmed)).is_err() {
+                    // raw is validated UTF-8 by read_bounded_line
+                    let text = str::from_utf8(&raw).expect("ReadLine::Line implies valid UTF-8");
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty()
+                        && line_tx.send(StdinMsg::Line(trimmed.to_owned())).is_err()
+                    {
                         break; // receiver dropped
                     }
                 }
@@ -181,48 +182,23 @@ pub fn run_stdio(server: &mut Server) -> Result<()> {
             }
         };
 
-        // Parse once as a generic Value; reuse the result for both the
-        // response-shape check and the typed JsonRpcRequest conversion.
-        let obj: serde_json::Value = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(e) => {
-                log::warn!("invalid JSON-RPC: {e}");
-                let resp =
-                    JsonRpcResponse::error(None, PARSE_ERROR, "invalid JSON-RPC request".into());
-                send(&mut writer, &resp)?;
-                continue;
-            }
-        };
-
-        // Silently discard response-shaped messages (no method field).
-        // These can arrive when a stale sampling response from a previous
-        // bridge lifetime reaches the channel after the bridge was dropped.
-        if obj.is_object() && obj.get("method").is_none() {
-            log::debug!("discarding response-shaped message");
-            continue;
-        }
-
-        let mut req: JsonRpcRequest = match serde_json::from_value(obj) {
+        // Parse and validate the JSON-RPC request via shared parser.
+        // Distinguishes malformed JSON (-32700) from invalid request (-32600)
+        // and silently discards stale sampling responses (no id, no method).
+        let mut req: JsonRpcRequest = match super::types::parse_jsonrpc_line(&line) {
             Ok(r) => r,
+            Err(TransportError::StaleResponse) => {
+                log::debug!("discarding stale response-shaped message (no id)");
+                continue;
+            }
             Err(e) => {
-                log::warn!("invalid JSON-RPC request: {e}");
-                let resp =
-                    JsonRpcResponse::error(None, INVALID_REQUEST, format!("invalid request: {e}"));
-                send(&mut writer, &resp)?;
+                log::warn!("{e}");
+                if let Some(resp) = e.into_response(None) {
+                    send(&mut writer, &resp)?;
+                }
                 continue;
             }
         };
-
-        if req.jsonrpc != JSONRPC_VERSION {
-            log::warn!("invalid jsonrpc version: {}", req.jsonrpc);
-            let resp = JsonRpcResponse::error(
-                req.id.clone(),
-                INVALID_REQUEST,
-                "unsupported JSON-RPC version".into(),
-            );
-            send(&mut writer, &resp)?;
-            continue;
-        }
 
         // Notifications (no id) get no response per JSON-RPC spec.
         let (resp, spillover) = dispatch(server, &mut req, &line_rx, &mut writer);
@@ -265,5 +241,246 @@ fn dispatch(
         (Some(resp), spillover)
     } else {
         (server.dispatch_method(req), Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    // -- read_bounded_line tests --
+
+    #[test]
+    fn rbl_eof_returns_eof() {
+        let mut reader = Cursor::new(b"" as &[u8]);
+        let mut raw = Vec::new();
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Eof
+        ));
+    }
+
+    #[test]
+    fn rbl_simple_line_with_newline() {
+        let mut reader = Cursor::new(b"hello\n" as &[u8]);
+        let mut raw = Vec::new();
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Line
+        ));
+        let text = str::from_utf8(&raw).unwrap();
+        assert_eq!(text.trim(), "hello");
+    }
+
+    #[test]
+    fn rbl_line_without_trailing_newline() {
+        // Last line in stream with no newline — still valid
+        let mut reader = Cursor::new(b"hello" as &[u8]);
+        let mut raw = Vec::new();
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Line
+        ));
+        assert_eq!(str::from_utf8(&raw).unwrap(), "hello");
+    }
+
+    #[test]
+    fn rbl_empty_line() {
+        let mut reader = Cursor::new(b"\n" as &[u8]);
+        let mut raw = Vec::new();
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Line
+        ));
+        assert_eq!(raw, b"\n");
+        assert!(str::from_utf8(&raw).unwrap().trim().is_empty());
+    }
+
+    #[test]
+    fn rbl_utf8_boundary_at_max() {
+        // CJK char '中' (3 bytes E4 B8 AD) at the boundary
+        let padding_len = (MAX_LINE_BYTES as usize) - 4; // 3-byte char + newline
+        let mut data = vec![b'a'; padding_len];
+        data.extend_from_slice("中".as_bytes());
+        data.push(b'\n');
+        assert_eq!(data.len(), MAX_LINE_BYTES as usize);
+
+        let mut reader = Cursor::new(data);
+        let mut raw = Vec::new();
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Line
+        ));
+        let text = str::from_utf8(&raw).unwrap();
+        assert!(text.trim().ends_with('中'));
+    }
+
+    #[test]
+    fn rbl_utf8_multibyte_straddling_limit() {
+        // 4-byte emoji that would straddle MAX_LINE_BYTES if we used
+        // BufRead::read_line instead of raw bytes.  read_until on raw
+        // bytes reads the full sequence without InvalidData.
+        let padding_len = (MAX_LINE_BYTES as usize) - 2; // emoji is 4 bytes, total > limit
+        let mut data = vec![b'a'; padding_len];
+        data.extend_from_slice("🦀".as_bytes()); // 4 bytes
+        data.push(b'\n');
+        // total = padding_len + 4 + 1 = MAX_LINE_BYTES + 3, exceeds limit
+        // but since it has a newline, read_until stops at it.
+        // However, the take() limit is MAX_LINE_BYTES + 1, so only
+        // MAX_LINE_BYTES + 1 bytes are read — the emoji is split.
+        // Since there's no newline within the first MAX_LINE_BYTES+1 bytes,
+        // and n > MAX_LINE_BYTES, this is TooLong.
+
+        let mut reader = Cursor::new(data);
+        let mut raw = Vec::new();
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::TooLong
+        ));
+    }
+
+    #[test]
+    fn rbl_too_long_no_newline() {
+        let data = vec![b'x'; (MAX_LINE_BYTES as usize) + 100];
+        let mut reader = Cursor::new(data);
+        let mut raw = Vec::new();
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::TooLong
+        ));
+    }
+
+    #[test]
+    fn rbl_too_long_drain_to_next_newline() {
+        // Oversized line followed by a valid line. After TooLong + drain,
+        // the next read should get the second line.
+        let mut data = vec![b'x'; (MAX_LINE_BYTES as usize) + 100];
+        data.push(b'\n');
+        data.extend_from_slice(b"valid\n");
+
+        let mut reader = Cursor::new(data);
+        let mut raw = Vec::new();
+
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::TooLong
+        ));
+        // Next read should yield the valid line
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Line
+        ));
+        assert_eq!(str::from_utf8(&raw).unwrap().trim(), "valid");
+    }
+
+    #[test]
+    fn rbl_malformed_utf8() {
+        let data = vec![0xFF, 0xFE, b'\n'];
+        let mut reader = Cursor::new(data);
+        let mut raw = Vec::new();
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::MalformedUtf8(_)
+        ));
+    }
+
+    #[test]
+    fn rbl_buffer_reused_across_calls() {
+        let data = b"line1\nline2\n";
+        let mut reader = Cursor::new(&data[..]);
+        let mut raw = Vec::new();
+
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Line
+        ));
+        assert_eq!(str::from_utf8(&raw).unwrap().trim(), "line1");
+
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Line
+        ));
+        assert_eq!(str::from_utf8(&raw).unwrap().trim(), "line2");
+
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Eof
+        ));
+    }
+
+    #[test]
+    fn rbl_mixed_valid_and_empty_lines() {
+        let data = b"first\n\nsecond\n";
+        let mut reader = Cursor::new(&data[..]);
+        let mut raw = Vec::new();
+
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Line
+        ));
+        assert_eq!(str::from_utf8(&raw).unwrap().trim(), "first");
+
+        // Empty line
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Line
+        ));
+        assert!(str::from_utf8(&raw).unwrap().trim().is_empty());
+
+        assert!(matches!(
+            read_bounded_line(&mut reader, &mut raw).unwrap(),
+            ReadLine::Line
+        ));
+        assert_eq!(str::from_utf8(&raw).unwrap().trim(), "second");
+    }
+
+    // -- send() tests --
+
+    #[test]
+    fn send_writes_json_newline() {
+        let resp = JsonRpcResponse::success(
+            Some(super::super::types::RequestId::Int(1)),
+            serde_json::json!({"ok": true}),
+        );
+        let mut buf: Vec<u8> = Vec::new();
+        send(&mut buf, &resp).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.ends_with('\n'));
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(parsed["id"], 1);
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert_eq!(parsed["result"]["ok"], true);
+    }
+
+    #[test]
+    fn send_error_response_format() {
+        let resp = JsonRpcResponse::error(
+            Some(super::super::types::RequestId::Str("abc".into())),
+            PARSE_ERROR,
+            "bad json".into(),
+        );
+        let mut buf: Vec<u8> = Vec::new();
+        send(&mut buf, &resp).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(parsed["id"], "abc");
+        assert_eq!(parsed["error"]["code"], PARSE_ERROR);
+        assert!(parsed.get("result").is_none());
+    }
+
+    #[test]
+    fn send_propagates_writer_failure() {
+        struct FailWriter;
+        impl Write for FailWriter {
+            fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "broken"))
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "broken"))
+            }
+        }
+        let resp = JsonRpcResponse::success(None, serde_json::json!(null));
+        assert!(send(&mut FailWriter, &resp).is_err());
     }
 }

--- a/src/mcp/transport_async.rs
+++ b/src/mcp/transport_async.rs
@@ -10,9 +10,7 @@ use anyhow::Result;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 
 use super::tools::Server;
-use super::types::{
-    JsonRpcRequest, JsonRpcResponse, INVALID_REQUEST, JSONRPC_VERSION, PARSE_ERROR,
-};
+use super::types::{JsonRpcRequest, JsonRpcResponse, TransportError, INVALID_REQUEST, PARSE_ERROR};
 
 /// Maximum line length (4 MiB), matching the sync transport.
 const MAX_LINE_BYTES: usize = 4 * 1024 * 1024;
@@ -35,6 +33,7 @@ async fn async_stdio_loop(server: &mut Server) -> Result<()> {
     let mut reader = BufReader::new(stdin);
     let mut stdout = tokio::io::stdout();
     let mut raw_buf: Vec<u8> = Vec::new();
+    let mut write_buf: Vec<u8> = Vec::new();
 
     loop {
         raw_buf.clear();
@@ -50,12 +49,25 @@ async fn async_stdio_loop(server: &mut Server) -> Result<()> {
         }
         if raw_buf.len() > MAX_LINE_BYTES {
             // Drain the remainder of the oversized line so the next
-            // iteration starts at a fresh line boundary.
+            // iteration starts at a fresh line boundary.  Use a small
+            // scratch buffer instead of appending to raw_buf (which
+            // would allow unbounded memory growth).
             if raw_buf.last() != Some(&b'\n') {
-                let _ = reader.read_until(b'\n', &mut raw_buf).await;
+                loop {
+                    let buf = reader.fill_buf().await?;
+                    if buf.is_empty() {
+                        break;
+                    }
+                    if let Some(pos) = buf.iter().position(|&b| b == b'\n') {
+                        reader.consume(pos + 1);
+                        break;
+                    }
+                    let len = buf.len();
+                    reader.consume(len);
+                }
             }
             let resp = JsonRpcResponse::error(None, INVALID_REQUEST, "request too large".into());
-            send_async(&mut stdout, &resp).await?;
+            send_async(&mut stdout, &resp, &mut write_buf).await?;
             continue;
         }
         let Ok(line) = str::from_utf8(&raw_buf).map(str::trim) else {
@@ -64,7 +76,7 @@ async fn async_stdio_loop(server: &mut Server) -> Result<()> {
                 PARSE_ERROR,
                 "request contains malformed UTF-8 character(s)".into(),
             );
-            send_async(&mut stdout, &resp).await?;
+            send_async(&mut stdout, &resp, &mut write_buf).await?;
             continue;
         };
 
@@ -72,46 +84,21 @@ async fn async_stdio_loop(server: &mut Server) -> Result<()> {
             continue;
         }
 
-        // Parse once; reuse for response-shape check and typed conversion.
-        let obj: serde_json::Value = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(e) => {
-                log::warn!("invalid JSON-RPC: {e}");
-                let resp = JsonRpcResponse::error(None, PARSE_ERROR, format!("parse error: {e}"));
-                send_async(&mut stdout, &resp).await?;
-                continue;
-            }
-        };
-
-        // Discard response-shaped messages (stale sampling responses).
-        if obj.is_object() && obj.get("method").is_none() {
-            log::debug!("discarding response-shaped message");
-            continue;
-        }
-
-        let mut req: JsonRpcRequest = match serde_json::from_value(obj) {
+        // Parse and validate the JSON-RPC request via shared parser.
+        let mut req = match super::types::parse_jsonrpc_line(line) {
             Ok(r) => r,
+            Err(TransportError::StaleResponse) => {
+                log::debug!("discarding stale response-shaped message (no id)");
+                continue;
+            }
             Err(e) => {
-                log::warn!("invalid JSON-RPC request: {e}");
-                let resp =
-                    JsonRpcResponse::error(None, INVALID_REQUEST, format!("invalid request: {e}"));
-                send_async(&mut stdout, &resp).await?;
+                log::warn!("{e}");
+                if let Some(resp) = e.into_response(None) {
+                    send_async(&mut stdout, &resp, &mut write_buf).await?;
+                }
                 continue;
             }
         };
-
-        if req.jsonrpc != JSONRPC_VERSION {
-            let resp = JsonRpcResponse::error(
-                req.id.clone(),
-                INVALID_REQUEST,
-                format!(
-                    "expected jsonrpc \"{JSONRPC_VERSION}\", got \"{}\"",
-                    req.jsonrpc
-                ),
-            );
-            send_async(&mut stdout, &resp).await?;
-            continue;
-        }
 
         // Dispatch synchronously. For tools/call with sampling, we fall back
         // to the synchronous SamplingBridge since the Server is not async.
@@ -119,7 +106,7 @@ async fn async_stdio_loop(server: &mut Server) -> Result<()> {
         // simple non-sampling dispatch for the async path.
         let resp = dispatch_async(server, &mut req);
         if let Some(resp) = resp {
-            send_async(&mut stdout, &resp).await?;
+            send_async(&mut stdout, &resp, &mut write_buf).await?;
         }
     }
 
@@ -143,10 +130,15 @@ fn dispatch_async(server: &mut Server, req: &mut JsonRpcRequest) -> Option<JsonR
     }
 }
 
-async fn send_async(writer: &mut tokio::io::Stdout, resp: &JsonRpcResponse) -> Result<()> {
-    let mut buf = serde_json::to_string(resp)?;
-    buf.push('\n');
-    writer.write_all(buf.as_bytes()).await?;
+async fn send_async(
+    writer: &mut tokio::io::Stdout,
+    resp: &JsonRpcResponse,
+    buf: &mut Vec<u8>,
+) -> Result<()> {
+    buf.clear();
+    serde_json::to_writer(&mut *buf, resp)?;
+    buf.push(b'\n');
+    writer.write_all(buf).await?;
     writer.flush().await?;
     Ok(())
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -11,30 +11,87 @@ use serde_json::Value;
 
 // JSON-RPC base types
 
-/// A JSON-RPC 2.0 request ID (integer or string).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
+/// A JSON-RPC 2.0 request ID (integer, string, or null).
+///
+/// JSON-RPC 2.0 allows `"id": null` in requests. A request with an explicit
+/// null id is NOT a notification (notifications omit the id field entirely).
+/// Error responses for requests with null id must include `"id": null`.
+#[derive(Debug, Clone)]
 pub enum RequestId {
     Int(i64),
     Str(String),
+    /// Explicit `"id": null` in the request. Distinct from absent id
+    /// (which indicates a notification).
+    Null,
+}
+
+impl Serialize for RequestId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            RequestId::Int(i) => serializer.serialize_i64(*i),
+            RequestId::Str(s) => serializer.serialize_str(s),
+            RequestId::Null => serializer.serialize_unit(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RequestId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let v = Value::deserialize(deserializer)?;
+        match &v {
+            Value::Null => Ok(RequestId::Null),
+            Value::Number(n) => n
+                .as_i64()
+                .map(RequestId::Int)
+                .ok_or_else(|| serde::de::Error::custom("id number must be an integer")),
+            Value::String(s) => Ok(RequestId::Str(s.clone())),
+            _ => Err(serde::de::Error::custom(
+                "id must be a string, integer, or null",
+            )),
+        }
+    }
 }
 
 /// Incoming JSON-RPC request (method call or notification).
+///
+/// When `id` is `None`, this is a notification (no response expected).
+/// When `id` is `Some(RequestId::Null)`, the client sent `"id": null`
+/// and still expects a response.
 #[derive(Debug, Deserialize)]
 pub struct JsonRpcRequest {
     pub jsonrpc: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_request_id")]
     pub id: Option<RequestId>,
     pub method: String,
     #[serde(default)]
     pub params: Value,
 }
 
+/// Deserialize the `id` field so that `"id": null` becomes
+/// `Some(RequestId::Null)` rather than `None` (which serde's default
+/// `Option<T>` handling would produce).  An absent field still yields
+/// `None` via `#[serde(default)]`.
+fn deserialize_request_id<'de, D>(deserializer: D) -> Result<Option<RequestId>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    RequestId::deserialize(deserializer).map(Some)
+}
+
 /// Outgoing JSON-RPC response.
+///
+/// The `id` field is always serialized per JSON-RPC 2.0: `None` produces
+/// `"id": null` (required for error responses when the request id is
+/// unknown).
 #[derive(Debug, Serialize)]
 pub struct JsonRpcResponse {
     pub jsonrpc: &'static str,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<RequestId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<Value>,
@@ -348,8 +405,14 @@ pub enum TransportError {
     /// Input contains invalid UTF-8 sequences.
     InvalidUtf8(FromUtf8Error),
     /// Valid JSON but not a valid JSON-RPC request (missing method, wrong
-    /// version, response-shaped message, etc.).
-    InvalidRequest(String),
+    /// version, response-shaped message with id, etc.).  Carries the
+    /// extracted request id (if any) for error response correlation.
+    InvalidRequest(Option<RequestId>, String),
+    /// Response-shaped message (has result/error, no method).
+    /// Silently discarded per JSON-RPC 2.0: "The Server MUST NOT reply
+    /// to a Response."  Covers both late sampling responses and orphaned
+    /// messages, regardless of whether they carry an id.
+    StaleResponse,
 }
 
 impl TransportError {
@@ -359,14 +422,14 @@ impl TransportError {
     }
 
     /// JSON-RPC error code for this transport error, if applicable.
-    /// Returns None for Closed (no error response should be sent).
+    /// Returns None for Closed and StaleResponse (no error response sent).
     pub fn error_code(&self) -> Option<i64> {
         match self {
             TransportError::Io(_) => Some(-32000),
-            TransportError::Closed => None,
+            TransportError::Closed | TransportError::StaleResponse => None,
             TransportError::Parse(_) => Some(PARSE_ERROR),
             TransportError::InvalidUtf8(_) => Some(PARSE_ERROR),
-            TransportError::InvalidRequest(_) => Some(INVALID_REQUEST),
+            TransportError::InvalidRequest(..) => Some(INVALID_REQUEST),
         }
     }
 
@@ -375,11 +438,12 @@ impl TransportError {
         match self {
             TransportError::Io(e) => format!("transport I/O error: {e}"),
             TransportError::Closed => "transport closed".into(),
+            TransportError::StaleResponse => "stale response (discarded)".into(),
             TransportError::Parse(e) => format!("parse error: {e}"),
             TransportError::InvalidUtf8(_) => {
                 "request contains malformed UTF-8 character(s)".into()
             }
-            TransportError::InvalidRequest(msg) => format!("invalid request: {msg}"),
+            TransportError::InvalidRequest(_, msg) => format!("invalid request: {msg}"),
         }
     }
 }
@@ -391,7 +455,8 @@ impl std::fmt::Display for TransportError {
             TransportError::Closed => write!(f, "transport closed"),
             TransportError::Parse(e) => write!(f, "JSON parse: {e}"),
             TransportError::InvalidUtf8(e) => write!(f, "invalid UTF-8: {e}"),
-            TransportError::InvalidRequest(msg) => write!(f, "invalid request: {msg}"),
+            TransportError::InvalidRequest(_, msg) => write!(f, "invalid request: {msg}"),
+            TransportError::StaleResponse => write!(f, "stale response (discarded)"),
         }
     }
 }
@@ -427,13 +492,18 @@ impl From<FromUtf8Error> for TransportError {
 
 impl TransportError {
     /// Build a JSON-RPC error response for this transport error, if one
-    /// should be sent. Returns None for Closed (no response).
+    /// should be sent.  Returns None for Closed and StaleResponse.
     ///
-    /// Accepts an optional request id so that InvalidRequest errors (where
-    /// the JSON was valid enough to extract an id) can be correlated by
-    /// the client.
-    pub fn into_response(self, id: Option<RequestId>) -> Option<JsonRpcResponse> {
+    /// For InvalidRequest, the carried id (extracted during parsing) is
+    /// used so the client can correlate the error with its original request.
+    /// The `fallback_id` is used for other error variants (Parse, Io, etc.)
+    /// where no id could be extracted.
+    pub fn into_response(self, fallback_id: Option<RequestId>) -> Option<JsonRpcResponse> {
         let code = self.error_code()?;
+        let id = match &self {
+            TransportError::InvalidRequest(carried_id, _) => carried_id.clone(),
+            _ => fallback_id,
+        };
         let message = self.error_message();
         Some(JsonRpcResponse::error(id, code, message))
     }
@@ -448,23 +518,52 @@ pub fn parse_jsonrpc_line(line: &str) -> Result<JsonRpcRequest, TransportError> 
     // Step 1: parse as generic JSON.
     let obj: serde_json::Value = serde_json::from_str(line).map_err(TransportError::Parse)?;
 
-    // Step 2: discard response-shaped messages (has result/error, no method).
+    // Step 2: extract id once for error correlation across all branches.
+    // id_present is true when the JSON has an "id" key (even if null or
+    // an unparseable type like boolean/array).  raw_id is the parsed id
+    // when it's a valid string, integer, or null.
+    let id_value = obj.get("id");
+    let raw_id: Option<RequestId> = id_value.and_then(|v| serde_json::from_value(v.clone()).ok());
+    let id_present = id_value.is_some();
+
+    // Step 3: handle messages without a method field.
     if obj.is_object() && obj.get("method").is_none() {
+        let is_response = obj.get("result").is_some() || obj.get("error").is_some();
+        if is_response {
+            // Response-shaped (has result/error, no method): silently discard.
+            // JSON-RPC 2.0: "The Server MUST NOT reply to a Response."
+            // Covers late sampling responses (with id) and orphaned responses
+            // (without id).
+            return Err(TransportError::StaleResponse);
+        }
+        if id_present {
+            // Has id, no method, not response-shaped — genuinely invalid.
+            return Err(TransportError::InvalidRequest(
+                raw_id,
+                "message has id but no method".into(),
+            ));
+        }
+        // No id, no method, no result/error — genuinely invalid request
+        // (e.g. `{}` or `{"foo":"bar"}`).
         return Err(TransportError::InvalidRequest(
-            "response-shaped message (no method field)".into(),
+            None,
+            "object has no method, result, or error field".into(),
         ));
     }
 
-    // Step 3: convert to typed request.
-    let req: JsonRpcRequest =
-        serde_json::from_value(obj).map_err(|e| TransportError::InvalidRequest(e.to_string()))?;
+    // Step 4: convert to typed request.
+    let req: JsonRpcRequest = serde_json::from_value(obj)
+        .map_err(|e| TransportError::InvalidRequest(raw_id.clone(), e.to_string()))?;
 
-    // Step 4: validate JSON-RPC version.
+    // Step 5: validate JSON-RPC version.
     if req.jsonrpc != JSONRPC_VERSION {
-        return Err(TransportError::InvalidRequest(format!(
-            "expected jsonrpc \"{JSONRPC_VERSION}\", got \"{}\"",
-            req.jsonrpc
-        )));
+        return Err(TransportError::InvalidRequest(
+            raw_id,
+            format!(
+                "expected jsonrpc \"{JSONRPC_VERSION}\", got \"{}\"",
+                req.jsonrpc
+            ),
+        ));
     }
 
     Ok(req)
@@ -482,3 +581,283 @@ pub const METHOD_NOT_FOUND: i64 = -32601;
 pub const INVALID_PARAMS: i64 = -32602;
 pub const INTERNAL_ERROR: i64 = -32603;
 pub const SERVER_NOT_INITIALIZED: i64 = -32002;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // -- RequestId serde round-trips --
+
+    #[test]
+    fn request_id_int_roundtrip() {
+        let id = RequestId::Int(42);
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "42");
+        let parsed: RequestId = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, RequestId::Int(42)));
+    }
+
+    #[test]
+    fn request_id_string_roundtrip() {
+        let id = RequestId::Str("req-abc".into());
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "\"req-abc\"");
+        let parsed: RequestId = serde_json::from_str(&json).unwrap();
+        match parsed {
+            RequestId::Str(s) => assert_eq!(s, "req-abc"),
+            _ => panic!("expected string id"),
+        }
+    }
+
+    #[test]
+    fn request_id_negative_int() {
+        let id = RequestId::Int(-1);
+        let json = serde_json::to_string(&id).unwrap();
+        let parsed: RequestId = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, RequestId::Int(-1)));
+    }
+
+    #[test]
+    fn request_id_null_roundtrip() {
+        let id = RequestId::Null;
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "null");
+        let parsed: RequestId = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, RequestId::Null));
+    }
+
+    #[test]
+    fn request_id_boolean_rejected() {
+        let result = serde_json::from_str::<RequestId>("true");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn request_id_array_rejected() {
+        let result = serde_json::from_str::<RequestId>("[1,2]");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn request_null_id_is_not_notification() {
+        // "id": null is a request, not a notification.
+        let line = r#"{"jsonrpc":"2.0","method":"ping","id":null}"#;
+        let req = parse_jsonrpc_line(line).unwrap();
+        assert!(req.id.is_some(), "null id must be Some(RequestId::Null)");
+        assert!(matches!(req.id, Some(RequestId::Null)));
+    }
+
+    #[test]
+    fn request_absent_id_is_notification() {
+        let line = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+        let req = parse_jsonrpc_line(line).unwrap();
+        assert!(req.id.is_none(), "absent id must be None (notification)");
+    }
+
+    // -- JsonRpcError serde --
+
+    #[test]
+    fn jsonrpc_error_with_data_roundtrip() {
+        let err = JsonRpcError {
+            code: INVALID_REQUEST,
+            message: "bad request".into(),
+            data: Some(json!({"field": "profile", "accepted": ["default"]})),
+        };
+        let json = serde_json::to_string(&err).unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["code"], INVALID_REQUEST);
+        assert_eq!(parsed["message"], "bad request");
+        assert_eq!(parsed["data"]["field"], "profile");
+    }
+
+    #[test]
+    fn jsonrpc_error_without_data_omits_field() {
+        let err = JsonRpcError {
+            code: PARSE_ERROR,
+            message: "parse error".into(),
+            data: None,
+        };
+        let json = serde_json::to_string(&err).unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["code"], PARSE_ERROR);
+        assert!(parsed.get("data").is_none());
+    }
+
+    // -- ClientCapabilities serde --
+
+    #[test]
+    fn client_capabilities_empty_object() {
+        let raw: ClientCapabilitiesRaw = serde_json::from_str("{}").unwrap();
+        let caps = ClientCapabilities::from(&raw);
+        assert!(!caps.sampling);
+        assert!(!caps.roots);
+    }
+
+    #[test]
+    fn client_capabilities_with_sampling_only() {
+        let raw: ClientCapabilitiesRaw = serde_json::from_str(r#"{"sampling": {}}"#).unwrap();
+        let caps = ClientCapabilities::from(&raw);
+        assert!(caps.sampling);
+        assert!(!caps.roots);
+    }
+
+    #[test]
+    fn client_capabilities_with_extra_fields_ignored() {
+        let raw: ClientCapabilitiesRaw = serde_json::from_str(
+            r#"{"sampling": {}, "roots": {"listChanged": true}, "experimental": 42}"#,
+        )
+        .unwrap();
+        let caps = ClientCapabilities::from(&raw);
+        assert!(caps.sampling);
+        assert!(caps.roots);
+    }
+
+    #[test]
+    fn client_capabilities_null_sampling_is_none() {
+        // JSON null for sampling should be treated as absent
+        let raw: ClientCapabilitiesRaw = serde_json::from_str(r#"{"sampling": null}"#).unwrap();
+        let caps = ClientCapabilities::from(&raw);
+        assert!(!caps.sampling);
+    }
+
+    // -- JsonRpcResponse serde --
+
+    #[test]
+    fn response_success_omits_error() {
+        let resp = JsonRpcResponse::success(Some(RequestId::Int(1)), json!("ok"));
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["result"], "ok");
+        assert!(parsed.get("error").is_none());
+    }
+
+    #[test]
+    fn response_error_omits_result() {
+        let resp = JsonRpcResponse::error(Some(RequestId::Int(1)), -32600, "bad".into());
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.get("result").is_none());
+        assert_eq!(parsed["error"]["code"], -32600);
+    }
+
+    #[test]
+    fn response_unknown_id_serializes_as_null() {
+        // JSON-RPC 2.0: error responses with unknown id must include "id": null
+        let resp = JsonRpcResponse::error(None, PARSE_ERROR, "err".into());
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.get("id").is_some(), "id field must be present");
+        assert!(parsed["id"].is_null(), "unknown id must serialize as null");
+    }
+
+    // -- parse_jsonrpc_line --
+
+    #[test]
+    fn parse_valid_request() {
+        let line = r#"{"jsonrpc":"2.0","method":"tools/list","id":1,"params":{}}"#;
+        let req = parse_jsonrpc_line(line).unwrap();
+        assert_eq!(req.method, "tools/list");
+        assert!(matches!(req.id, Some(RequestId::Int(1))));
+    }
+
+    #[test]
+    fn parse_malformed_json_returns_parse_error() {
+        let line = "not json at all";
+        let err = parse_jsonrpc_line(line).unwrap_err();
+        assert!(matches!(err, TransportError::Parse(_)));
+        assert_eq!(err.error_code(), Some(PARSE_ERROR));
+    }
+
+    #[test]
+    fn parse_response_shaped_with_id_returns_stale() {
+        // JSON-RPC 2.0: "The Server MUST NOT reply to a Response."
+        // Response-shaped messages (has result/error, no method) are silently
+        // discarded regardless of whether they carry an id.
+        let line = r#"{"jsonrpc":"2.0","id":1,"result":"ok"}"#;
+        let err = parse_jsonrpc_line(line).unwrap_err();
+        assert!(matches!(err, TransportError::StaleResponse));
+        assert_eq!(err.error_code(), None);
+        assert!(err.into_response(None).is_none());
+    }
+
+    #[test]
+    fn parse_response_shaped_without_id_returns_stale() {
+        let line = r#"{"jsonrpc":"2.0","result":"stale"}"#;
+        let err = parse_jsonrpc_line(line).unwrap_err();
+        assert!(matches!(err, TransportError::StaleResponse));
+        assert_eq!(err.error_code(), None);
+        assert!(err.into_response(None).is_none());
+    }
+
+    #[test]
+    fn parse_wrong_jsonrpc_version() {
+        let line = r#"{"jsonrpc":"1.0","method":"test","id":1}"#;
+        let err = parse_jsonrpc_line(line).unwrap_err();
+        assert!(matches!(err, TransportError::InvalidRequest(..)));
+    }
+
+    #[test]
+    fn parse_notification_no_id() {
+        let line = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+        let req = parse_jsonrpc_line(line).unwrap();
+        assert!(req.id.is_none());
+        assert_eq!(req.method, "notifications/initialized");
+    }
+
+    #[test]
+    fn parse_empty_object_returns_invalid_request() {
+        let line = r#"{}"#;
+        let err = parse_jsonrpc_line(line).unwrap_err();
+        assert!(matches!(err, TransportError::InvalidRequest(..)));
+        assert_eq!(err.error_code(), Some(INVALID_REQUEST));
+    }
+
+    #[test]
+    fn parse_arbitrary_object_without_method_returns_invalid_request() {
+        let line = r#"{"foo":"bar","baz":42}"#;
+        let err = parse_jsonrpc_line(line).unwrap_err();
+        assert!(matches!(err, TransportError::InvalidRequest(..)));
+    }
+
+    #[test]
+    fn parse_invalid_request_carries_id() {
+        // A message with id but no method and not response-shaped should
+        // produce an error response that echoes the id back to the client.
+        let line = r#"{"id":99,"jsonrpc":"2.0"}"#;
+        let err = parse_jsonrpc_line(line).unwrap_err();
+        assert!(matches!(err, TransportError::InvalidRequest(..)));
+        let resp = err.into_response(None).expect("should produce response");
+        match &resp.id {
+            Some(RequestId::Int(99)) => {}
+            other => panic!("expected id=99, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_wrong_version_carries_id() {
+        let line = r#"{"jsonrpc":"1.0","method":"test","id":7}"#;
+        let err = parse_jsonrpc_line(line).unwrap_err();
+        let resp = err.into_response(None).expect("should produce response");
+        match &resp.id {
+            Some(RequestId::Int(7)) => {}
+            other => panic!("expected id=7, got {other:?}"),
+        }
+    }
+
+    // -- TransportError --
+
+    #[test]
+    fn transport_error_closed_has_no_code() {
+        let err = TransportError::Closed;
+        assert!(err.is_closed());
+        assert_eq!(err.error_code(), None);
+        assert!(err.into_response(None).is_none());
+    }
+
+    #[test]
+    fn transport_error_io_has_server_code() {
+        let err = TransportError::Io(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe"));
+        assert_eq!(err.error_code(), Some(-32000));
+    }
+}

--- a/tests/e2e_mcp.rs
+++ b/tests/e2e_mcp.rs
@@ -688,6 +688,309 @@ fn e2e_initialize_and_tools_list() {
     // tmp_dir auto-cleaned on drop
 }
 
+/// Spawn an initialized MCP child for malformed protocol tests.
+fn spawn_initialized_child() -> (
+    impl Write,
+    impl BufRead,
+    std::process::Child,
+    tempfile::TempDir,
+) {
+    let bin = binary_path();
+    let tmp_dir = tempfile::tempdir().expect("create temp dir");
+    let overrides_path = tmp_dir.path().join("overrides.json");
+    let suppressions_path = tmp_dir.path().join("suppressions.json");
+
+    let mut child = Command::new(&bin)
+        .args([
+            "--overrides",
+            overrides_path.to_str().unwrap(),
+            "--suppressions",
+            suppressions_path.to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn zhtw-mcp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    let _resp = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "malformed-test", "version": "0.1" }
+            }
+        }),
+    );
+    send_notification(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }),
+    );
+
+    (stdin, stdout, child, tmp_dir)
+}
+
+// -- 25.8 Malformed protocol E2E tests --
+
+#[test]
+fn e2e_missing_jsonrpc_field() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    let resp = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "method": "tools/list",
+            "id": 100
+        }),
+    );
+    assert!(
+        resp["error"].is_object(),
+        "missing jsonrpc should return error: {resp}"
+    );
+    let code = resp["error"]["code"].as_i64().unwrap();
+    assert!(
+        code == -32600,
+        "expected INVALID_REQUEST (-32600), got {code}"
+    );
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
+#[test]
+fn e2e_wrong_jsonrpc_version() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    let resp = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "1.0",
+            "method": "tools/list",
+            "id": 101
+        }),
+    );
+    assert!(resp["error"].is_object());
+    assert_eq!(
+        resp["error"]["code"].as_i64().unwrap(),
+        -32600,
+        "wrong version should be INVALID_REQUEST"
+    );
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
+#[test]
+fn e2e_id_as_array_rejected() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    let raw = r#"{"jsonrpc":"2.0","method":"tools/list","id":[1,2],"params":{}}"#;
+    writeln!(stdin, "{raw}").unwrap();
+    stdin.flush().unwrap();
+
+    let mut line = String::new();
+    stdout.read_line(&mut line).unwrap();
+    let resp: Value = serde_json::from_str(line.trim()).unwrap();
+    assert!(
+        resp["error"].is_object(),
+        "array id should be rejected: {resp}"
+    );
+    assert_eq!(resp["error"]["code"].as_i64().unwrap(), -32600);
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
+#[test]
+fn e2e_id_as_object_rejected() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    let raw = r#"{"jsonrpc":"2.0","method":"tools/list","id":{"a":1},"params":{}}"#;
+    writeln!(stdin, "{raw}").unwrap();
+    stdin.flush().unwrap();
+
+    let mut line = String::new();
+    stdout.read_line(&mut line).unwrap();
+    let resp: Value = serde_json::from_str(line.trim()).unwrap();
+    assert!(resp["error"].is_object(), "object id should be rejected");
+    assert_eq!(resp["error"]["code"].as_i64().unwrap(), -32600);
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
+#[test]
+fn e2e_params_as_array_handled() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    let raw = r#"{"jsonrpc":"2.0","method":"tools/list","id":102,"params":[1,2,3]}"#;
+    writeln!(stdin, "{raw}").unwrap();
+    stdin.flush().unwrap();
+
+    let mut line = String::new();
+    stdout.read_line(&mut line).unwrap();
+    let resp: Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(resp["id"], 102);
+    assert!(
+        resp.get("result").is_some() || resp.get("error").is_some(),
+        "server should handle array params without crashing"
+    );
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
+#[test]
+fn e2e_empty_method_returns_not_found() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    let resp = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "",
+            "id": 103
+        }),
+    );
+    assert!(resp["error"].is_object(), "empty method should error");
+    assert_eq!(
+        resp["error"]["code"].as_i64().unwrap(),
+        -32601,
+        "empty method should be METHOD_NOT_FOUND"
+    );
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
+#[test]
+fn e2e_method_trailing_whitespace() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    let resp = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "tools/list ",
+            "id": 104,
+            "params": {}
+        }),
+    );
+    assert!(
+        resp["error"].is_object(),
+        "trailing whitespace method should error"
+    );
+    assert_eq!(
+        resp["error"]["code"].as_i64().unwrap(),
+        -32601,
+        "mangled method should be METHOD_NOT_FOUND"
+    );
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
+#[test]
+fn e2e_not_json_returns_parse_error() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    writeln!(stdin, "this is not json at all").unwrap();
+    stdin.flush().unwrap();
+
+    let mut line = String::new();
+    stdout.read_line(&mut line).unwrap();
+    let resp: Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(
+        resp["error"]["code"].as_i64().unwrap(),
+        -32700,
+        "non-JSON should return PARSE_ERROR"
+    );
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
+#[test]
+fn e2e_response_shaped_with_id_discarded() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    // Response-shaped message WITH id: silently discarded per JSON-RPC 2.0
+    // ("The Server MUST NOT reply to a Response").
+    let response_msg = r#"{"jsonrpc":"2.0","id":999,"result":"stale"}"#;
+    writeln!(stdin, "{response_msg}").unwrap();
+    stdin.flush().unwrap();
+
+    // No error response expected — verify the server is still alive by
+    // sending a real request and getting a valid response.
+    let resp = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "id": 105,
+            "params": {}
+        }),
+    );
+    assert_eq!(resp["id"], 105);
+    assert!(resp["result"].is_object(), "server should still be alive");
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
+#[test]
+fn e2e_response_shaped_without_id_discarded() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    // Response-shaped message WITHOUT id: silently discarded (stale sampling).
+    let response_msg = r#"{"jsonrpc":"2.0","result":"stale"}"#;
+    writeln!(stdin, "{response_msg}").unwrap();
+    stdin.flush().unwrap();
+
+    // No response for the stale message. Send a real request to verify alive.
+    let resp = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "id": 106,
+            "params": {}
+        }),
+    );
+    assert_eq!(resp["id"], 106);
+    assert!(resp["result"].is_object(), "server should still be alive");
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
 /// AI agent clients (e.g. claude-code) should auto-default to compact output
 /// without explicitly passing `"output": "compact"`.
 #[test]


### PR DESCRIPTION
Transport error handling:
- Add TransportError enum (Io, Closed, Parse, InvalidUtf8, InvalidRequest, StaleResponse) with JSON-RPC error code mapping and id correlation.
- InvalidRequest carries Option<RequestId> so error responses echo the client's request id. into_response() prefers carried id over fallback.
- StaleResponse silently discards all response-shaped messages (has result/error, no method) per JSON-RPC 2.0 spec: "The Server MUST NOT reply to a Response."

JSON-RPC 2.0 id:null compliance:
- Add RequestId::Null variant with custom Serialize/Deserialize to distinguish "id": null (request needing response) from absent id (notification). Custom deserialize_request_id bypasses serde's Option<T> null handling.
- Remove skip_serializing_if on JsonRpcResponse.id so error responses with unknown id emit "id": null per spec.

Shared parser and transport cleanup:
- Extract parse_jsonrpc_line() in types.rs: two-pass Value->typed struct with id extraction before validation for error-path correlation.
- Both sync and async transports use shared parser + TransportError.
- Sync transport: buffer reuse (str::from_utf8 borrow), serde_json::to_writer.
- Async transport: fill_buf/consume drain (fixes data loss from read()), write buffer reuse via serde_json::to_writer.

Close #3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the MCP transport with a shared JSON‑RPC parser, structured errors, strict `id:null` handling, and silent discard of stale response‑shaped messages. Improves reliability on oversized lines and reduces allocations by reusing buffers.

- **New Features**
  - Added `TransportError` with JSON‑RPC code mapping; `InvalidRequest` carries `Option<RequestId>` for id correlation; `StaleResponse` discards response‑shaped messages (with or without id) without replying.
  - Implemented `RequestId::Null` and always serialize response `id` (unknown ids emit `"id": null`); introduced `parse_jsonrpc_line()` to separate parse vs invalid errors and prefer the carried id.

- **Bug Fixes**
  - Async stdin drain now uses `fill_buf/consume` for oversized lines; sync/async transports reuse read/write buffers and use `serde_json::to_writer`, cutting copies and UTF‑8 revalidation.

<sup>Written for commit 27f0762352a09597a01ace79563e4c5d274cb068. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

