### PR TITLE
Add incremental scan cache for CLI lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,10 +60,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
 
 [[package]]
 name = "block-buffer"
@@ -143,6 +178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +234,31 @@ dependencies = [
  "cast",
  "itertools",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -545,6 +611,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_users"
@@ -1222,6 +1308,8 @@ version = "0.1.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "bincode",
+ "blake3",
  "criterion",
  "daachorse",
  "dirs",
@@ -1229,6 +1317,7 @@ dependencies = [
  "fs2",
  "log",
  "pulldown-cmark",
+ "rayon",
  "regex",
  "rustc-hash",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ aho-corasick = "1"
 daachorse = "1"
 regex = "1"
 sha2 = "0.10"
+blake3 = "1"
+bincode = "1"
+rayon = "1"
 anyhow = "1"
 unicode-normalization = "0.1"
 pulldown-cmark = { version = "0.12", default-features = false }
@@ -35,7 +38,7 @@ toml = "0.8"
 tokio = { version = "1", features = ["rt", "io-util", "time", "sync", "macros", "io-std"], optional = true }
 ureq = { version = "3", optional = true }
 urlencoding = { version = "2", optional = true }
-rustc-hash = "2.1.1"
+rustc-hash = "2"
 fs2 = "0.4"
 
 [dev-dependencies]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,468 @@
+// Incremental scan cache for CLI lint.
+//
+// Two-tier lookup to avoid reading files on cache hit:
+//   1. Fast path: stat(file) -> check (path, mtime, size, params) -> return
+//      cached ScanOutput without reading the file.
+//   2. Slow path (mtime miss): read file, blake3 hash, full cache key check.
+//
+// TTL-based expiry (default 24h) and MAX_ENTRIES cap prevent unbounded
+// growth.  Atomic writes via tempfile+rename with flock serialization.
+//
+// MCP path does NOT use this cache (stateless by design).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+
+use crate::engine::scan::ScanOutput;
+
+/// Default TTL in seconds (24 hours).
+const DEFAULT_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// Maximum number of cached entries.  Prevents unbounded growth when
+/// scanning large monorepos.  Oldest entries evicted first on overflow.
+const MAX_ENTRIES: usize = 2000;
+
+/// BLAKE3 hash of `data`, returned as a 64-char lowercase hex string.
+/// ~3-4x faster than SHA-256 thanks to SIMD acceleration.  Non-cryptographic
+/// use (local cache keys) makes this a safe choice.
+fn blake3_hex(data: &[u8]) -> String {
+    blake3::hash(data).to_hex().to_string()
+}
+
+/// Filesystem metadata used for the fast-path cache check.
+/// Avoids reading the file and computing a content hash when mtime+size match.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FileMeta {
+    mtime_secs: u64,
+    size: u64,
+}
+
+/// Scan parameters that affect output (excluding file content).
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScanParams {
+    pub ruleset_hash: String,
+    pub profile: String,
+    pub content_type: String,
+    // Currently always "None" because caching is disabled when fix_mode
+    // is active.  Kept for forward-compatibility.
+    pub fix_mode: String,
+}
+
+/// A single cached entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheEntry {
+    file_path: String,
+    content_hash: String,
+    file_meta: FileMeta,
+    params: ScanParams,
+    output: ScanOutput,
+    input_was_sc: bool,
+    timestamp_secs: u64,
+}
+
+/// Persistent scan cache backed by a bincode file.
+#[derive(Debug)]
+pub struct ScanCache {
+    path: PathBuf,
+    entries: HashMap<String, CacheEntry>,
+    ttl_secs: u64,
+    dirty: bool,
+}
+
+/// Cached scan result including script classification.
+pub struct CacheHit {
+    pub output: ScanOutput,
+    pub input_was_sc: bool,
+}
+
+/// Result of a cache lookup.
+pub enum CacheResult {
+    /// Fast-path hit: mtime+size match, no file read needed.
+    Hit(CacheHit),
+    /// mtime changed or no entry: caller must read file and call `check_content`.
+    Miss,
+}
+
+impl CacheResult {
+    /// Extract the cached hit, or None on miss.
+    pub fn into_hit(self) -> Option<CacheHit> {
+        match self {
+            CacheResult::Hit(h) => Some(h),
+            CacheResult::Miss => None,
+        }
+    }
+}
+
+impl ScanCache {
+    /// Open (or create) the scan cache at the default location.
+    pub fn open_default() -> Self {
+        Self::open(default_cache_path())
+    }
+
+    /// Open (or create) the scan cache at a specific path.
+    pub fn open(path: PathBuf) -> Self {
+        let entries = load_entries(&path, DEFAULT_TTL_SECS);
+        ScanCache {
+            path,
+            entries,
+            ttl_secs: DEFAULT_TTL_SECS,
+            dirty: false,
+        }
+    }
+
+    /// Fast-path lookup using filesystem metadata (mtime + size).
+    /// Avoids reading the file when metadata matches.
+    pub fn check_fast(
+        &self,
+        file_path: &str,
+        mtime_secs: u64,
+        size: u64,
+        params: &ScanParams,
+    ) -> CacheResult {
+        if let Some(entry) = self.entries.get(&fast_key(file_path, params)) {
+            if now_secs().saturating_sub(entry.timestamp_secs) <= self.ttl_secs
+                && entry.file_meta.mtime_secs == mtime_secs
+                && entry.file_meta.size == size
+            {
+                return CacheResult::Hit(CacheHit {
+                    output: entry.output.clone(),
+                    input_was_sc: entry.input_was_sc,
+                });
+            }
+        }
+        CacheResult::Miss
+    }
+
+    /// Slow-path lookup using content hash.  Called after file is read.
+    /// Returns cached output if content hash matches (mtime changed but
+    /// content didn't, e.g. after `touch`).
+    pub fn check_content(
+        &self,
+        file_path: &str,
+        content: &[u8],
+        params: &ScanParams,
+    ) -> Option<CacheHit> {
+        let entry = self.entries.get(&fast_key(file_path, params))?;
+        if now_secs().saturating_sub(entry.timestamp_secs) > self.ttl_secs {
+            return None;
+        }
+        (entry.content_hash == blake3_hex(content)).then(|| CacheHit {
+            output: entry.output.clone(),
+            input_was_sc: entry.input_was_sc,
+        })
+    }
+
+    /// Store a scan result in the cache.
+    #[allow(clippy::too_many_arguments)]
+    pub fn put(
+        &mut self,
+        file_path: &str,
+        content: &[u8],
+        mtime_secs: u64,
+        size: u64,
+        params: &ScanParams,
+        output: ScanOutput,
+        input_was_sc: bool,
+    ) {
+        self.entries.insert(
+            fast_key(file_path, params),
+            CacheEntry {
+                file_path: file_path.to_owned(),
+                content_hash: blake3_hex(content),
+                file_meta: FileMeta { mtime_secs, size },
+                params: params.clone(),
+                output,
+                input_was_sc,
+                timestamp_secs: now_secs(),
+            },
+        );
+        self.dirty = true;
+    }
+
+    /// Flush dirty cache to disk.  Prunes expired and overflow entries
+    /// before writing.  Uses tempfile + rename for atomic writes.
+    /// Acquires an exclusive flock to prevent concurrent CLI processes
+    /// from clobbering each other's writes.
+    /// Errors are silently ignored (cache is best-effort).
+    pub fn flush(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        // Prune expired entries.
+        let now = now_secs();
+        let ttl = self.ttl_secs;
+        self.entries
+            .retain(|_, e| now.saturating_sub(e.timestamp_secs) <= ttl);
+
+        // Evict oldest entries if over the cap.
+        if self.entries.len() > MAX_ENTRIES {
+            let mut by_time: Vec<(String, u64)> = self
+                .entries
+                .iter()
+                .map(|(k, e)| (k.clone(), e.timestamp_secs))
+                .collect();
+            by_time.sort_by_key(|(_, ts)| *ts);
+            let to_remove = self.entries.len() - MAX_ENTRIES;
+            for (k, _) in by_time.into_iter().take(to_remove) {
+                self.entries.remove(&k);
+            }
+        }
+
+        let Some(parent) = self.path.parent() else {
+            return;
+        };
+        let _ = std::fs::create_dir_all(parent);
+
+        let entries_vec: Vec<&CacheEntry> = self.entries.values().collect();
+        let Ok(bytes) = bincode::serialize(&entries_vec) else {
+            return;
+        };
+
+        // Acquire exclusive lock on the cache file (or a .lock sidecar)
+        // to prevent concurrent CLI processes from clobbering writes.
+        let lock_path = self.path.with_extension("lock");
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&lock_path);
+
+        // Best-effort lock: if another process holds it, skip this flush
+        // but keep dirty=true so Drop retries.
+        let locked = lock_file
+            .as_ref()
+            .is_ok_and(|f| f.try_lock_exclusive().is_ok());
+
+        // Write without lock if lock file creation failed; skip entirely
+        // if lock is held by another process.
+        if (locked || lock_file.is_err()) && atomic_write(parent, &self.path, &bytes) {
+            self.dirty = false;
+        }
+
+        if let Ok(ref f) = lock_file {
+            let _ = f.unlock();
+        }
+    }
+}
+
+impl Drop for ScanCache {
+    fn drop(&mut self) {
+        self.flush();
+    }
+}
+
+/// Atomic write via tempfile + rename.  Returns true on success.
+/// Writes directly to the open fd (not re-opening by path).
+fn atomic_write(parent: &Path, dest: &Path, bytes: &[u8]) -> bool {
+    use std::io::Write;
+    tempfile::NamedTempFile::new_in(parent)
+        .is_ok_and(|mut tmp| tmp.write_all(bytes).is_ok() && tmp.persist(dest).is_ok())
+}
+
+/// Default cache file location: ~/.cache/zhtw-mcp/scan-cache.bin
+fn default_cache_path() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("zhtw-mcp")
+        .join("scan-cache.bin")
+}
+
+/// Lookup key combining file path + scan parameters.
+/// Hashes directly into blake3 without allocating an intermediate String.
+/// One entry per (file, params) tuple — mtime/content validated on lookup.
+fn fast_key(file_path: &str, params: &ScanParams) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(file_path.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(params.ruleset_hash.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(params.profile.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(params.content_type.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(params.fix_mode.as_bytes());
+    hasher.finalize().to_hex()[..32].to_string()
+}
+
+/// Extract mtime (seconds since epoch) from filesystem metadata.
+pub fn mtime_secs(meta: &std::fs::Metadata) -> u64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map_or(0, |d| d.as_secs())
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Load cache entries from disk.
+/// Falls back gracefully: if the file is missing or corrupt,
+/// returns an empty map.
+fn load_entries(path: &Path, ttl_secs: u64) -> HashMap<String, CacheEntry> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(_) => return HashMap::new(),
+    };
+
+    let entries: Vec<CacheEntry> = match bincode::deserialize(&bytes) {
+        Ok(v) => v,
+        Err(_) => return HashMap::new(),
+    };
+
+    let now = now_secs();
+    entries
+        .into_iter()
+        .filter(|e| now.saturating_sub(e.timestamp_secs) <= ttl_secs)
+        .map(|e| {
+            let key = fast_key(&e.file_path, &e.params);
+            (key, e)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::scan::ScanOutput;
+    use crate::engine::zhtype::ChineseType;
+    use tempfile::TempDir;
+
+    fn empty_output() -> ScanOutput {
+        ScanOutput {
+            issues: vec![],
+            detected_script: ChineseType::Traditional,
+        }
+    }
+
+    fn test_params() -> ScanParams {
+        ScanParams {
+            ruleset_hash: "rh".into(),
+            profile: "default".into(),
+            content_type: "md".into(),
+            fix_mode: "none".into(),
+        }
+    }
+
+    fn test_params_plain() -> ScanParams {
+        ScanParams {
+            ruleset_hash: "rh".into(),
+            profile: "default".into(),
+            content_type: "plain".into(),
+            fix_mode: "none".into(),
+        }
+    }
+
+    #[test]
+    fn fast_path_hit() {
+        let dir = TempDir::new().unwrap();
+        let mut cache = ScanCache::open(dir.path().join("c.bin"));
+        let p = test_params();
+
+        cache.put("a.md", b"hello", 1000, 5, &p, empty_output(), false);
+
+        // Same mtime+size = fast hit.
+        assert!(matches!(
+            cache.check_fast("a.md", 1000, 5, &p),
+            CacheResult::Hit(_)
+        ));
+
+        // Different mtime = miss.
+        assert!(matches!(
+            cache.check_fast("a.md", 2000, 5, &p),
+            CacheResult::Miss
+        ));
+
+        // Different size = miss.
+        assert!(matches!(
+            cache.check_fast("a.md", 1000, 99, &p),
+            CacheResult::Miss
+        ));
+
+        // Different profile = miss (different entry entirely).
+        let strict = ScanParams {
+            profile: "strict".into(),
+            ..p.clone()
+        };
+        assert!(matches!(
+            cache.check_fast("a.md", 1000, 5, &strict),
+            CacheResult::Miss
+        ));
+    }
+
+    #[test]
+    fn slow_path_content_check() {
+        let dir = TempDir::new().unwrap();
+        let mut cache = ScanCache::open(dir.path().join("c.bin"));
+        let p = test_params_plain();
+
+        cache.put("b.md", b"data", 1000, 4, &p, empty_output(), false);
+
+        // Same content despite mtime miss: slow-path hit.
+        assert!(cache.check_content("b.md", b"data", &p).is_some());
+
+        // Different content: slow-path miss.
+        assert!(cache.check_content("b.md", b"changed", &p).is_none());
+    }
+
+    #[test]
+    fn cache_persists_to_disk() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("c.bin");
+        let p = test_params_plain();
+
+        {
+            let mut cache = ScanCache::open(path.clone());
+            cache.put("f.md", b"x", 100, 1, &p, empty_output(), false);
+            cache.flush();
+        }
+
+        let cache = ScanCache::open(path);
+        assert!(matches!(
+            cache.check_fast("f.md", 100, 1, &p),
+            CacheResult::Hit(_)
+        ));
+    }
+
+    #[test]
+    fn expired_entries_pruned() {
+        let dir = TempDir::new().unwrap();
+        let mut cache = ScanCache::open(dir.path().join("c.bin"));
+        let p = test_params_plain();
+        cache.put("e.md", b"x", 100, 1, &p, empty_output(), false);
+        for entry in cache.entries.values_mut() {
+            entry.timestamp_secs = 0;
+        }
+        assert!(matches!(
+            cache.check_fast("e.md", 100, 1, &p),
+            CacheResult::Miss
+        ));
+    }
+
+    #[test]
+    fn overflow_evicts_oldest() {
+        let dir = TempDir::new().unwrap();
+        let mut cache = ScanCache::open(dir.path().join("c.bin"));
+        let p = test_params_plain();
+
+        for i in 0..MAX_ENTRIES + 10 {
+            let name = format!("file_{i}.md");
+            cache.put(&name, b"x", 100, 1, &p, empty_output(), false);
+            let key = fast_key(&name, &p);
+            if let Some(e) = cache.entries.get_mut(&key) {
+                e.timestamp_secs = i as u64 + 1_700_000_000;
+            }
+        }
+
+        assert!(cache.entries.len() > MAX_ENTRIES);
+        cache.flush();
+        assert!(cache.entries.len() <= MAX_ENTRIES);
+    }
+}

--- a/src/engine/scan/mod.rs
+++ b/src/engine/scan/mod.rs
@@ -52,7 +52,7 @@ use self::quotes::{fix_quote_pairing, validate_quote_hierarchy};
 /// detected during scanning.  Returning detected_script here eliminates the
 /// need for callers to run a second O(n) detect_chinese_type pass over the
 /// same text.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScanOutput {
     pub issues: Vec<Issue>,
     pub detected_script: ChineseType,
@@ -543,7 +543,7 @@ impl Scanner {
                 if let Some(&idx) = clue_map.get(s) {
                     idx
                 } else {
-                    let idx = clue_vec.len() as u16;
+                    let idx = u16::try_from(clue_vec.len()).expect("clue index overflow");
                     clue_map.insert(s.clone(), idx);
                     clue_vec.push(s.clone());
                     idx

--- a/src/engine/scan/spelling.rs
+++ b/src/engine/scan/spelling.rs
@@ -66,9 +66,10 @@ impl Scanner {
         issues: &mut Vec<Issue>,
         cfg: &ProfileConfig,
     ) {
-        // Pre-scan: build clue position index.  One O(n) AC pass replaces
-        // per-match MMSEG segmentation for context-clue checking.
-        let clue_hits = self.build_clue_hits(text, excluded);
+        // Lazy clue pre-scan: defer the O(n) clue AC pass until a matched
+        // rule actually needs context-clue checking.  Only ~7% of rules
+        // have context_clues, so most matches skip the clue AC entirely.
+        let mut clue_hits_cache: Option<ClueHits> = None;
 
         // Dispatch to charwise AC when available; fall back to bytewise.
         if let Some(ref cw_ac) = self.spelling_ac_charwise {
@@ -79,7 +80,7 @@ impl Scanner {
                     zh_type,
                     issues,
                     cfg,
-                    &clue_hits,
+                    &mut clue_hits_cache,
                     mat.start(),
                     mat.end(),
                     mat.value(),
@@ -93,7 +94,7 @@ impl Scanner {
                     zh_type,
                     issues,
                     cfg,
-                    &clue_hits,
+                    &mut clue_hits_cache,
                     mat.start(),
                     mat.end(),
                     mat.pattern().as_usize(),
@@ -113,7 +114,7 @@ impl Scanner {
         zh_type: ChineseType,
         issues: &mut Vec<Issue>,
         cfg: &ProfileConfig,
-        clue_hits: &ClueHits,
+        clue_hits_cache: &mut Option<ClueHits>,
         start: usize,
         end: usize,
         rule_idx: usize,
@@ -181,17 +182,18 @@ impl Scanner {
 
         // Context-clue gate via pre-scan hits.
         //
-        // Instead of MMSEG-segmenting a ±40-char window per match, we check
-        // the pre-built clue_hits list: binary-search for clue occurrences
-        // within the byte-offset window around this match.  This reduces
-        // per-match cost from O(W × L³) to O(C × log H) where C = number
-        // of clues for this rule and H = total clue hits in the text.
+        // The clue AC pass is deferred until a matched rule actually needs
+        // context-clue checking (~7% of rules).  This avoids the O(n) clue
+        // AC scan entirely for the 93% of matches that never check clues.
         let has_pos = self.rule_pos_clue_ids[rule_idx].is_some();
         let has_neg = self.rule_neg_clue_ids[rule_idx].is_some();
 
         if has_pos || has_neg {
+            let clue_hits =
+                clue_hits_cache.get_or_insert_with(|| self.build_clue_hits(text, excluded));
+
             // Compute byte-offset window matching surrounding_window_bounded
-            // semantics: ±CONTEXT_WINDOW_CHARS characters, clamped at excluded
+            // semantics: +-CONTEXT_WINDOW_CHARS characters, clamped at excluded
             // range boundaries.
             let (win_start, win_end) = context_byte_window(text, start, end, excluded);
 
@@ -242,12 +244,18 @@ fn context_byte_window(
     // Find paragraph boundaries (\n\n or \r\n\r\n) around the match.
     // Context clues from a different paragraph are semantically irrelevant
     // and can cause false triggers/suppressions.
+    //
+    // Clamp the search range to CONTEXT_WINDOW_CHARS * 4 bytes (max possible
+    // window extent for CJK text) to avoid O(N) scans per match.
+    let max_search = CONTEXT_WINDOW_CHARS * 4;
     let para_start = {
-        let search = &bytes[..match_start];
-        find_last_paragraph_break(search).map_or(0, |pos| pos + 1)
+        let search_start = match_start.saturating_sub(max_search);
+        let search = &bytes[search_start..match_start];
+        find_last_paragraph_break(search).map_or(0, |pos| search_start + pos + 1)
     };
     let para_end = {
-        let search = &bytes[match_end..];
+        let search_end = (match_end + max_search).min(text.len());
+        let search = &bytes[match_end..search_end];
         find_first_paragraph_break(search).map_or(text.len(), |pos| match_end + pos)
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audit;
 pub mod baseline;
+pub mod cache;
 pub mod config;
 pub mod engine;
 pub mod fixer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -459,8 +459,20 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
         &pack_store,
         params.active_packs,
     );
+    let ruleset_hash = zhtw_mcp::rules::loader::compute_ruleset_hash(&spelling_rules, &case_rules);
     let scanner = zhtw_mcp::engine::scan::Scanner::new(spelling_rules, case_rules);
     let s2t = zhtw_mcp::engine::s2t::S2TConverter::new();
+
+    // Scan cache: skip re-scanning unchanged files (lint-only, no fix).
+    // Disabled when --verify is active (calibrate_issues needs the full text).
+    // Wrapped in Mutex for rayon parallel scanning.
+    let mut use_cache = params.fix_mode == zhtw_mcp::fixer::FixMode::None;
+    #[cfg(feature = "translate")]
+    if params.verify {
+        use_cache = false;
+    }
+    let scan_cache =
+        use_cache.then(|| std::sync::Mutex::new(zhtw_mcp::cache::ScanCache::open_default()));
 
     // --diff-from: resolve changed files via git, use as file args.
     let diff_files: Vec<String>;
@@ -490,8 +502,21 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
     let mut baseline_count: usize = 0;
     let mut tabular_header_printed = false;
 
-    for file_arg in &resolved {
-        // Content type: explicit override > auto-detect from extension.
+    /// Maximum file size for CLI lint mode (16 MiB).
+    const MAX_CLI_FILE_BYTES: u64 = 16 * 1024 * 1024;
+
+    // Phase 1: Read + S2T + cache check + scan.
+    //
+    // This closure is shared between sequential and parallel (rayon) paths.
+    // It captures only &-refs to immutable state plus the Mutex-wrapped cache,
+    // making it Fn + Send + Sync.
+    let fix_mode_str = format!("{:?}", params.fix_mode);
+    let scan_file = |file_arg: &str| -> Result<(
+        String,
+        bool,
+        zhtw_mcp::engine::scan::ScanOutput,
+        zhtw_mcp::engine::scan::ContentType,
+    )> {
         let content_type = match params.content_type_override {
             Some("markdown") => zhtw_mcp::engine::scan::ContentType::Markdown,
             Some("markdown-scan-code") => zhtw_mcp::engine::scan::ContentType::MarkdownScanCode,
@@ -508,49 +533,146 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
             }
         };
 
-        /// Maximum file size for CLI lint mode (16 MiB).
-        const MAX_CLI_FILE_BYTES: u64 = 16 * 1024 * 1024;
+        let cache_params = zhtw_mcp::cache::ScanParams {
+            ruleset_hash: ruleset_hash.clone(),
+            profile: profile.name().to_owned(),
+            content_type: format!("{content_type:?}"),
+            fix_mode: fix_mode_str.clone(),
+        };
 
-        let mut text = if file_arg == "--" {
-            let mut buf = String::new();
-            std::io::stdin()
-                .take(MAX_CLI_FILE_BYTES + 1)
-                .read_to_string(&mut buf)
-                .context("read stdin")?;
-            anyhow::ensure!(
-                buf.len() as u64 <= MAX_CLI_FILE_BYTES,
-                "stdin input exceeds {MAX_CLI_FILE_BYTES} byte limit"
-            );
-            buf
-        } else {
-            let meta =
-                std::fs::metadata(file_arg).with_context(|| format!("stat file: {file_arg}"))?;
+        // Open file via fd, stat from the fd (TOCTOU-safe).
+        // Check cache BEFORE reading — fast path avoids file I/O entirely.
+        if file_arg != "--" {
+            let file =
+                std::fs::File::open(file_arg).with_context(|| format!("open file: {file_arg}"))?;
+            let meta = file
+                .metadata()
+                .with_context(|| format!("stat file: {file_arg}"))?;
             anyhow::ensure!(
                 meta.len() <= MAX_CLI_FILE_BYTES,
                 "{file_arg}: file too large ({} bytes, limit {MAX_CLI_FILE_BYTES})",
                 meta.len()
             );
-            std::fs::read_to_string(file_arg).with_context(|| format!("read file: {file_arg}"))?
-        };
 
-        // Auto-detect Simplified Chinese and convert to Traditional via S2T.
+            // Fast-path: check mtime+size before reading the file.
+            let fast_hit = scan_cache.as_ref().and_then(|mtx| {
+                let c = mtx.lock().ok()?;
+                let mtime = zhtw_mcp::cache::mtime_secs(&meta);
+                c.check_fast(file_arg, mtime, meta.len(), &cache_params)
+                    .into_hit()
+            });
+            if let Some(hit) = fast_hit {
+                if !hit.input_was_sc {
+                    // Cache hit for non-SC file — skip file read and scan.
+                    return Ok((String::new(), false, hit.output, content_type));
+                }
+                // SC files need the text for S2T write-back; fall through.
+            }
+
+            // Slow path: read file from the same fd.
+            let mut text = String::with_capacity(meta.len() as usize);
+            std::io::BufReader::new(file)
+                .read_to_string(&mut text)
+                .with_context(|| format!("read file: {file_arg}"))?;
+
+            let input_was_sc = zhtw_mcp::engine::zhtype::detect_chinese_type(&text)
+                == zhtw_mcp::engine::zhtype::ChineseType::Simplified;
+            if input_was_sc {
+                text = s2t.convert(&text);
+            }
+
+            // Slow-path cache: check content hash (mtime missed but content
+            // may be unchanged, e.g. after `touch`).
+            let content_hit = scan_cache.as_ref().and_then(|mtx| {
+                let c = mtx.lock().ok()?;
+                c.check_content(file_arg, text.as_bytes(), &cache_params)
+            });
+            let output = match content_hit {
+                Some(hit) => hit.output,
+                None => {
+                    let o = scanner.scan_for_content_type(&text, content_type, profile);
+                    if let Some(Ok(mut c)) = scan_cache.as_ref().map(|mtx| mtx.lock()) {
+                        let mtime = zhtw_mcp::cache::mtime_secs(&meta);
+                        c.put(
+                            file_arg,
+                            text.as_bytes(),
+                            mtime,
+                            meta.len(),
+                            &cache_params,
+                            o.clone(),
+                            input_was_sc,
+                        );
+                    }
+                    o
+                }
+            };
+
+            // Drop text eagerly when not needed for fix/write-back/verify
+            // to avoid accumulating all files' text in parallel scans.
+            let mut need_text = input_was_sc || params.fix_mode != zhtw_mcp::fixer::FixMode::None;
+            #[cfg(feature = "translate")]
+            if params.verify {
+                need_text = true;
+            }
+            if !need_text {
+                text = String::new();
+            }
+
+            return Ok((text, input_was_sc, output, content_type));
+        }
+
+        // stdin path.
+        let mut text = String::new();
+        std::io::stdin()
+            .take(MAX_CLI_FILE_BYTES + 1)
+            .read_to_string(&mut text)
+            .context("read stdin")?;
+        anyhow::ensure!(
+            text.len() as u64 <= MAX_CLI_FILE_BYTES,
+            "stdin input exceeds {MAX_CLI_FILE_BYTES} byte limit"
+        );
+
         let input_was_sc = zhtw_mcp::engine::zhtype::detect_chinese_type(&text)
             == zhtw_mcp::engine::zhtype::ChineseType::Simplified;
         if input_was_sc {
             text = s2t.convert(&text);
         }
+        let output = scanner.scan_for_content_type(&text, content_type, profile);
 
-        let scan = |input: &str| -> zhtw_mcp::engine::scan::ScanOutput {
-            scanner.scan_for_content_type(input, content_type, profile)
-        };
+        Ok((text, input_was_sc, output, content_type))
+    };
 
-        let output = scan(&text);
+    // Parallel scan when multiple files and no stdin pipe.
+    // Rayon parallelism gives N/cores speedup on multi-file lint.
+    let has_stdin = resolved.iter().any(|f| f == "--");
+    let scan_results: Vec<
+        Result<(
+            String,
+            bool,
+            zhtw_mcp::engine::scan::ScanOutput,
+            zhtw_mcp::engine::scan::ContentType,
+        )>,
+    > = if resolved.len() > 1 && !has_stdin {
+        use rayon::prelude::*;
+        resolved.par_iter().map(|f| scan_file(f)).collect()
+    } else {
+        resolved.iter().map(|f| scan_file(f)).collect()
+    };
+
+    // Phase 2: Fix + report (always sequential for ordered output).
+    for (file_arg, scan_result) in resolved.iter().zip(scan_results) {
+        let (text, input_was_sc, output, content_type) = scan_result?;
+
         let detected_script = if input_was_sc {
             "simplified"
         } else {
             output.detected_script.name()
         };
         let issues = output.issues;
+
+        let scan = |input: &str| -> zhtw_mcp::engine::scan::ScanOutput {
+            scanner.scan_for_content_type(input, content_type, profile)
+        };
 
         // Apply fixes if requested.
         let fix_result = if params.fix_mode != zhtw_mcp::fixer::FixMode::None {
@@ -590,9 +712,9 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
                 // Atomic write: tempfile + rename in the same directory.
                 let file_path = Path::new(file_arg);
                 let parent = file_path.parent().unwrap_or(Path::new("."));
-                let tmp = tempfile::NamedTempFile::new_in(parent)
+                let mut tmp = tempfile::NamedTempFile::new_in(parent)
                     .with_context(|| format!("create tempfile in {}", parent.display()))?;
-                std::fs::write(tmp.path(), output_text)
+                std::io::Write::write_all(&mut tmp, output_text.as_bytes())
                     .with_context(|| format!("write tempfile for {file_arg}"))?;
                 tmp.persist(file_path)
                     .with_context(|| format!("rename tempfile to {file_arg}"))?;
@@ -1009,6 +1131,13 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
             }]
         });
         println!("{}", serde_json::to_string_pretty(&sarif)?);
+    }
+
+    // Flush scan cache before potential process::exit (which skips Drop).
+    if let Some(ref cache_mtx) = scan_cache {
+        if let Ok(mut c) = cache_mtx.lock() {
+            c.flush();
+        }
     }
 
     // Exit 1 if total error-severity or warning-severity issues exceed thresholds.


### PR DESCRIPTION
This introduces two-tier lookup avoids re-scanning unchanged files:
1. Fast path: stat(mtime+size) check skips file read entirely
2. Slow path: blake3 content hash catches touch-without-edit

BLAKE3 for cache keys (~3x faster than SHA-256, SIMD-accelerated). Bincode serialization (95% smaller than JSON). Rayon par_iter for multi-file parallel scanning. TOCTOU-safe fd-based stat. fs2 flock on .lock sidecar prevents concurrent CLI process clobbering.

Cache disabled when --fix or --verify is active. TTL 24h, max 2000 entries with oldest-first eviction. Lazy clue AC pass deferred until amatched rule needs context clues (~7% of rules). Paragraph break search clamped to ±160 bytes to avoid O(N*M) per-match scans.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an incremental scan cache for CLI lint to skip re-scanning unchanged files and speed up multi-file runs. Also enables parallel scanning and reduces unnecessary reads and memory in lint-only runs.

- **New Features**
  - Incremental scan cache with two-tier lookup: fast path (mtime+size) and slow path (BLAKE3 content hash).
  - Persistent cache via `bincode`, TTL 24h, max 2000 entries with oldest-first eviction.
  - Atomic writes and `.lock` sidecar with `fs2`; TOCTOU-safe fd-based stat.
  - Disabled when `--fix` or `--verify` is used.
  - Parallel file scanning with `rayon`.
  - Keys include ruleset hash, profile, and content type; cache hit skips reads for non-SC files, while SC files still read so S2T write-back works. Cache flushes explicitly on exit.

- **Refactors**
  - `ScanOutput` is now `Clone` to support cache hits without rescanning.
  - Context-clue AC pass is lazy; only runs when a matched rule needs it.
  - Paragraph break search clamped to a small window to avoid per-match blowups.
  - Eagerly drop file text when not needed to limit memory in parallel runs; clue index uses checked u16 conversion to avoid overflow.

<sup>Written for commit e16812f7a3bc3fe7938ab3ad3b190e6986fc7e2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

