### PR TITLE
Implement confidence-based fix policy

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,8 +21,9 @@ zhtw-mcp lint -- --content-type markdown < input.md
 ## Auto-fix
 
 ```bash
-zhtw-mcp lint file.md --fix                 # safe mode (default)
-zhtw-mcp lint file.md --fix=aggressive      # context-clue-gated rules too
+zhtw-mcp lint file.md --fix                        # lexical_safe (default)
+zhtw-mcp lint file.md --fix=orthographic           # punctuation/spacing/case/variant/grammar only
+zhtw-mcp lint file.md --fix=lexical_contextual     # context-clue-gated rules too
 zhtw-mcp lint file.md --fix --dry-run       # preview without writing
 ```
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -9,7 +9,7 @@ Unified lint / fix / gate for zh-TW text.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string (required) | Text to check |
-| `fix_mode` | `"none"` / `"safe"` / `"aggressive"` | Fix mode (default: `"none"`) |
+| `fix_mode` | `"none"` / `"orthographic"` / `"lexical_safe"` / `"lexical_contextual"` | Fix mode (default: `"none"`) |
 | `max_errors` | integer | Reject if residual errors exceed threshold |
 | `max_warnings` | integer | Reject if residual warnings exceed threshold |
 | `profile` | `"default"` / `"strict_moe"` / `"ui_strings"` | Rule profile |
@@ -30,7 +30,7 @@ Returns issues with line/column position, matched term, suggestions, rule type, 
 Lint + fix + gate:
 
 ```json
-{"text": "請使用內存中的緩存數據", "max_errors": 0, "fix_mode": "safe"}
+{"text": "請使用內存中的緩存數據", "max_errors": 0, "fix_mode": "lexical_safe"}
 ```
 
 If residual errors exceed `max_errors` (or warnings exceed `max_warnings`), the response has `"accepted": false`. Otherwise `"accepted": true` with corrected text.
@@ -92,7 +92,7 @@ Lint this article with max_errors=0 and abort if any violations are found:
 [paste text]
 
 Act as a zh-TW copy editor. For every response you write in Chinese, run zhtw
-with fix_mode "safe" and max_errors 0 before sending it to me.
+with fix_mode "lexical_safe" and max_errors 0 before sending it to me.
 ```
 
 ### Git / CI workflows

--- a/scripts/measure-tokens.py
+++ b/scripts/measure-tokens.py
@@ -183,7 +183,7 @@ def measure_fix_output():
                     "name": "zhtw",
                     "arguments": {
                         "text": text,
-                        "fix_mode": "safe",
+                        "fix_mode": "lexical_safe",
                         "fix_output": "full",
                     },
                 },
@@ -196,7 +196,7 @@ def measure_fix_output():
                     "name": "zhtw",
                     "arguments": {
                         "text": text,
-                        "fix_mode": "safe",
+                        "fix_mode": "lexical_safe",
                         "fix_output": "search_replace",
                     },
                 },
@@ -209,7 +209,7 @@ def measure_fix_output():
                     "name": "zhtw",
                     "arguments": {
                         "text": text,
-                        "fix_mode": "safe",
+                        "fix_mode": "lexical_safe",
                         "fix_output": "patch",
                     },
                 },
@@ -330,7 +330,7 @@ def measure_combined():
                     "arguments": {
                         "text": text,
                         "output": "full",
-                        "fix_mode": "safe",
+                        "fix_mode": "lexical_safe",
                         "fix_output": "full",
                     },
                 },
@@ -345,7 +345,7 @@ def measure_combined():
                     "arguments": {
                         "text": text,
                         "output": "tabular",
-                        "fix_mode": "safe",
+                        "fix_mode": "lexical_safe",
                         "fix_output": "search_replace",
                     },
                 },

--- a/scripts/test-mcp-qwen.py
+++ b/scripts/test-mcp-qwen.py
@@ -6,10 +6,7 @@ zhtw-mcp MCP tools, then checks stdout for expected keywords to confirm
 correct zh-TW output.
 
 Tools exercised:
-  - zh_check (lint, fix, gate, explain, compact, political_stance, aggressive)
-  - zh_list_packs
-  - zh_list_rules
-  - zh_add_rule / zh_remove_rule (round-trip)
+  - zhtw (lint, fix, gate, explain, compact, political_stance, lexical_contextual)
 
 Usage:
     python3 scripts/test-mcp-qwen.py            # run all tests
@@ -65,11 +62,11 @@ class TestCase:
 
 
 TESTS: list[TestCase] = [
-    # ---- zh_check: lint only (fix_mode absent -> none) ----
+    # ---- zhtw: lint only (fix_mode absent -> none) ----
     TestCase(
         name="lint_basic",
         prompt=(
-            "使用 zh_check 工具檢查以下文字（不要設 fix_mode），"
+            "使用 zhtw 工具檢查以下文字（不要設 fix_mode），"
             "只列出問題和建議修正，用表格格式回答：\n"
             "「軟體工程師需要優化數據庫的性能，通過調試程序來排查代碼中的問題。」"
         ),
@@ -77,33 +74,33 @@ TESTS: list[TestCase] = [
         expect_any=["數據庫", "性能", "調試", "代碼"],
         timeout=60,
     ),
-    # ---- zh_check: strict_moe profile ----
+    # ---- zhtw: strict_moe profile ----
     TestCase(
         name="lint_strict_moe",
         prompt=(
-            "使用 zh_check 工具，profile 設為 strict_moe，"
+            "使用 zhtw 工具，profile 設為 strict_moe，"
             "檢查：「應用程式需要讀取數據並進行網絡通訊。」\n"
             "只列出問題和建議。"
         ),
         expect_any=["資料", "數據", "網路", "網絡"],
         timeout=60,
     ),
-    # ---- zh_check: fix_mode safe ----
+    # ---- zhtw: fix_mode lexical_safe ----
     TestCase(
         name="fix_safe",
         prompt=(
-            "使用 zh_check 工具，fix_mode 設為 safe，修正以下文字：\n"
+            "使用 zhtw 工具，fix_mode 設為 lexical_safe，修正以下文字：\n"
             "「開發人員利用調試工具來優化軟件的性能。」\n"
             "只回答修正後的完整文字。"
         ),
         expect_all=["除錯", "軟體", "效能"],
         timeout=60,
     ),
-    # ---- zh_check: gate pass ----
+    # ---- zhtw: gate pass ----
     TestCase(
         name="gate_pass",
         prompt=(
-            "使用 zh_check 工具，fix_mode=safe，max_errors=0，"
+            "使用 zhtw 工具，fix_mode=lexical_safe，max_errors=0，"
             "處理：「軟體工程師使用資料庫來開發應用程式。」\n"
             "只回答 accepted 值（true/false）。"
         ),
@@ -111,22 +108,22 @@ TESTS: list[TestCase] = [
         reject_any=["false", "reject", "拒絕"],
         timeout=60,
     ),
-    # ---- zh_check: gate reject ----
+    # ---- zhtw: gate reject ----
     TestCase(
         name="gate_reject",
         prompt=(
-            "使用 zh_check 工具，fix_mode=safe，max_errors=0，"
+            "使用 zhtw 工具，fix_mode=lexical_safe，max_errors=0，"
             "處理：「開發人員優化軟件性能並調試代碼。」\n"
             "只回答 accepted 值和剩餘 errors 數量。"
         ),
         expect_any=["false", "reject", "拒絕", "error", "錯誤"],
         timeout=60,
     ),
-    # ---- zh_check: ignore_terms ----
+    # ---- zhtw: ignore_terms ----
     TestCase(
         name="ignore_terms",
         prompt=(
-            '使用 zh_check 工具，ignore_terms=["軟件"]，'
+            '使用 zhtw 工具，ignore_terms=["軟件"]，'
             "檢查：「這個軟件很好用」\n"
             "只回答軟件這個詞的 severity 值。"
         ),
@@ -134,11 +131,11 @@ TESTS: list[TestCase] = [
         reject_any=["warning"],
         timeout=60,
     ),
-    # ---- zh_check: markdown content_type ----
+    # ---- zhtw: markdown content_type ----
     TestCase(
         name="markdown_exclusion",
         prompt=(
-            "使用 zh_check 工具，content_type=markdown，"
+            "使用 zhtw 工具，content_type=markdown，"
             "檢查：「這個軟件很好用\n\n```\n軟件代碼\n```\n\n軟件很棒」\n"
             "回答：code block 內容是否被排除？共幾個 issues？"
         ),
@@ -147,11 +144,11 @@ TESTS: list[TestCase] = [
         # 3 occurrences exist but only 2 are issues after code-block exclusion.
         timeout=120,
     ),
-    # ---- zh_check: return shape ----
+    # ---- zhtw: return shape ----
     TestCase(
         name="return_shape",
         prompt=(
-            "使用 zh_check 工具，fix_mode=safe，max_errors=5，"
+            "使用 zhtw 工具，fix_mode=lexical_safe，max_errors=5，"
             "處理：「這個軟件用了很多內存」\n"
             "只列出回傳結果中 accepted、applied_fixes、summary、gate 的值。"
         ),
@@ -159,11 +156,11 @@ TESTS: list[TestCase] = [
         expect_all=["applied_fixes", "summary", "gate"],
         timeout=60,
     ),
-    # ---- zh_check: explain mode ----
+    # ---- zhtw: explain mode ----
     TestCase(
         name="explain_mode",
         prompt=(
-            "使用 zh_check 工具，explain=true，"
+            "使用 zhtw 工具，explain=true，"
             "檢查：「這個軟件的性能很差」\n"
             "列出每個 issue 的 explanation 欄位內容。"
         ),
@@ -180,33 +177,33 @@ TESTS: list[TestCase] = [
         ],
         timeout=60,
     ),
-    # ---- zh_check: political_stance neutral ----
+    # ---- zhtw: political_stance neutral ----
     TestCase(
         name="political_neutral",
         prompt=(
-            "使用 zh_check 工具，political_stance=neutral，"
+            "使用 zhtw 工具，political_stance=neutral，"
             "檢查：「大陸的經濟發展很快」\n"
             "只回答 issues 數量。"
         ),
         expect_any=["0", "沒有", "no issue", "無"],
         timeout=60,
     ),
-    # ---- zh_check: output compact ----
+    # ---- zhtw: output compact ----
     TestCase(
         name="output_compact",
         prompt=(
-            "使用 zh_check 工具，output=compact，"
+            "使用 zhtw 工具，output=compact，"
             "檢查：「軟件性能優化和數據庫調試」\n"
             "只列出每個 issue 的 found 和 suggestions，不要解釋。"
         ),
         expect_any=["軟體", "效能", "資料庫", "除錯"],
         timeout=60,
     ),
-    # ---- zh_check: fix_mode aggressive ----
+    # ---- zhtw: fix_mode lexical_contextual ----
     TestCase(
-        name="fix_aggressive",
+        name="fix_lexical_contextual",
         prompt=(
-            "使用 zh_check 工具，fix_mode=aggressive，"
+            "使用 zhtw 工具，fix_mode=lexical_contextual，"
             "修正：「軟件工程師優化數據庫性能並調試代碼」\n"
             "只回答修正後文字。"
         ),
@@ -215,37 +212,6 @@ TESTS: list[TestCase] = [
         expect_all=["效能", "除錯"],
         expect_any=["軟體", "程式碼", "資料庫", "最佳化"],
         timeout=60,
-    ),
-    # ---- zh_list_packs ----
-    TestCase(
-        name="list_packs",
-        prompt=(
-            "使用 zh_list_packs 工具列出所有 rule packs。" "只回答 pack 名稱列表。"
-        ),
-        expect_any=["pack", "packs", "default", "strict_moe", "規則", "rule"],
-        timeout=60,
-    ),
-    # ---- zh_list_rules ----
-    TestCase(
-        name="list_rules",
-        prompt=(
-            "使用 zh_list_rules 工具列出使用者自訂規則。" "只回答規則列表或「無規則」。"
-        ),
-        expect_any=["rule", "規則", "override", "覆寫", "無", "empty", "no ", "0"],
-        timeout=60,
-    ),
-    # ---- rule authoring round-trip: add -> check -> remove ----
-    TestCase(
-        name="rule_roundtrip",
-        prompt=(
-            "請依序執行以下三步：\n"
-            '1. 使用 zh_add_rule 新增規則：from="測試詞彙" to="正確詞彙"\n'
-            "2. 使用 zh_check 檢查「這是測試詞彙」確認規則生效\n"
-            "3. 使用 zh_remove_rule 刪除剛才新增的規則\n"
-            "每步只回答結果。"
-        ),
-        expect_any=["正確詞彙", "新增", "add", "remove", "刪除", "測試詞彙"],
-        timeout=120,
     ),
 ]
 
@@ -470,7 +436,7 @@ def mcp_health_check(timeout: int = 15) -> HealthResult:
     Tests the full protocol stack without requiring qwen:
     1. initialize handshake (protocol version, server capabilities)
     2. tools/list (verify all 5 tools registered)
-    3. tools/call zh_check with a known-bad input (verify issue detection)
+    3. tools/call zhtw with a known-bad input (verify issue detection)
     4. graceful shutdown
     """
     result = HealthResult(ok=False)
@@ -601,42 +567,38 @@ def mcp_health_check(timeout: int = 15) -> HealthResult:
             result.tools = [t.get("name", "") for t in tools]
 
             expected_tools = {
-                "zh_check",
-                "zh_list_packs",
-                "zh_add_rule",
-                "zh_remove_rule",
-                "zh_list_rules",
+                "zhtw",
             }
             missing = expected_tools - set(result.tools)
             if missing:
                 result.errors.append(f"missing tools: {sorted(missing)}")
                 return result
 
-            # Step 4: tools/call -- verify zh_check produces a valid issue
+            # Step 4: tools/call -- verify zhtw produces a valid issue
             send(
                 _jsonrpc_request(
                     "tools/call",
                     {
-                        "name": "zh_check",
+                        "name": "zhtw",
                         "arguments": {"text": "這個軟件很好用"},
                     },
                     req_id=3,
                 )
             )
-            resp = recv("tools/call zh_check")
+            resp = recv("tools/call zhtw")
             if "error" in resp:
-                result.errors.append(f"zh_check call error: {resp['error']}")
+                result.errors.append(f"zhtw call error: {resp['error']}")
                 return result
 
             content = resp.get("result", {}).get("content", [])
             if not content:
-                result.errors.append("zh_check returned empty content")
+                result.errors.append("zhtw returned empty content")
                 return result
 
             try:
                 output = json.loads(content[0].get("text", "{}"))
             except json.JSONDecodeError as e:
-                result.errors.append(f"zh_check output not valid JSON: {e}")
+                result.errors.append(f"zhtw output not valid JSON: {e}")
                 return result
 
             issues = output.get("issues", [])
@@ -650,7 +612,7 @@ def mcp_health_check(timeout: int = 15) -> HealthResult:
                     f"expected 軟件 issue, got {len(issues)} issue(s)"
                 )
                 # Not a fatal error -- tool responded, just unexpected output
-                result.errors.append(f"zh_check validation: {result.tool_check_detail}")
+                result.errors.append(f"zhtw validation: {result.tool_check_detail}")
 
             result.ok = len(result.errors) == 0
 
@@ -694,7 +656,7 @@ def print_health_report(hr: HealthResult) -> None:
         print(f"  [OK] protocol: {hr.protocol_version}")
         print(f"  [OK] tools: {', '.join(hr.tools)} ({len(hr.tools)} registered)")
         tag = "OK" if hr.tool_check_ok else "WARN"
-        print(f"  [{tag}] zh_check: {hr.tool_check_detail}")
+        print(f"  [{tag}] zhtw: {hr.tool_check_detail}")
         print(f"  [OK] healthy ({hr.elapsed:.1f}s)")
     else:
         for err in hr.errors:
@@ -754,8 +716,8 @@ def check_mcp_binary() -> tuple[bool, str]:
 
 
 def smoke_test(timeout: int = 45) -> tuple[bool, str]:
-    """Run a minimal zh_check invocation to verify MCP server connectivity."""
-    prompt = "使用 zh_check 工具檢查「測試」，只回答 issue 數量"
+    """Run a minimal zhtw invocation to verify MCP server connectivity."""
+    prompt = "使用 zhtw 工具檢查「測試」，只回答 issue 數量"
     try:
         with subprocess.Popen(
             ["qwen", "-y", "-p", prompt],

--- a/src/fixer.rs
+++ b/src/fixer.rs
@@ -1,11 +1,20 @@
 // Fix application: apply suggested corrections to source text.
 //
-// Three modes:
+// Four tiers (strict superset hierarchy):
 //   - None: lint only, no fixes applied.
-//   - Safe: only apply fixes where suggestions.len() == 1 (unambiguous)
-//     and no context_clues are present (or context is confirmed).
-//   - Aggressive: pick suggestions[0]; for rules with context_clues,
-//     check if 2+ clue words appear in surrounding text before applying.
+//   - Orthographic: punctuation, spacing, character forms, case, variant,
+//     ellipsis, grammar only.  Lexical term substitutions are skipped.
+//   - LexicalSafe: orthographic + deterministic term substitutions
+//     (exactly one suggestion, no context_clues).  When --verify
+//     calibration has run, issues with anchor_match == Some(false)
+//     are skipped; anchor_match == None applies unconditionally.
+//   - LexicalContextual: all above + context-clue-gated terms.  For
+//     rules with context_clues, apply only when a segmenter confirms
+//     enough clue words in surrounding text.  Non-clue lexical issues
+//     use the same single-suggestion constraint as LexicalSafe.
+//     Anchor rejection (Some(false)) is respected for non-clue issues
+//     but overridden for clue-gated issues (segmenter provides
+//     independent confirmation).
 //
 // Fixes are applied in a single forward pass (ascending offset order).
 
@@ -14,16 +23,22 @@ use crate::engine::scan::surrounding_window;
 use crate::engine::segment::Segmenter;
 use crate::rules::ruleset::{Issue, IssueType};
 
-/// Fix mode controlling ambiguity handling.
+/// Fix mode controlling which issue types are eligible for automatic correction.
+///
+/// Each tier is a strict superset: None < Orthographic < LexicalSafe < LexicalContextual.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FixMode {
-    /// Lint only — no fixes applied.
+    /// Lint only -- no fixes applied.
     None,
-    /// Only apply unambiguous fixes (exactly one suggestion, no context ambiguity).
-    Safe,
-    /// Always apply first suggestion; for ambiguous rules with context_clues,
-    /// apply only when context clues confirm the intended meaning.
-    Aggressive,
+    /// Orthographic fixes only: punctuation, spacing, character forms, case,
+    /// variant, ellipsis, grammar.  Lexical term substitutions are skipped.
+    Orthographic,
+    /// Orthographic + deterministic term substitutions (exactly one suggestion,
+    /// no context_clues).  Equivalent to old 'safe' mode.
+    LexicalSafe,
+    /// All above + context-clue-gated terms.  For rules with context_clues,
+    /// apply only when segmenter confirms enough clue words nearby.
+    LexicalContextual,
 }
 
 /// Record of a single fix applied to the text.
@@ -44,7 +59,7 @@ pub struct FixResult {
     pub text: String,
     /// Number of fixes applied.
     pub applied: usize,
-    /// Number of issues skipped (ambiguous in Safe mode, or in excluded regions).
+    /// Number of issues skipped (ineligible for the chosen fix tier, or in excluded regions).
     pub skipped: usize,
     /// Detailed record of each applied fix, stored in ascending offset
     /// order (forward pass). Used for position-based convergence
@@ -79,11 +94,17 @@ pub fn apply_fixes(
 /// applied in a single forward pass (ascending offset order): chunks of
 /// unchanged text are copied between replacement spans, yielding O(N).
 ///
-/// When a Segmenter is provided, rules with context_clues are checked
-/// against the surrounding text:
-///   - aggressive mode: apply if MIN_CLUE_MATCHES or more clue words
-///     are found in a window around the match; otherwise skip.
-///   - safe mode: always skip rules that have context_clues (ambiguous).
+/// Fix tiers control which issues are eligible:
+///   - Orthographic: only Punctuation/Case/Variant/Grammar issues.
+///   - LexicalSafe: above + lexical issues without context_clues,
+///     single suggestion only.  When `--verify` calibration has run,
+///     issues with `anchor_match == Some(false)` are skipped (calibration
+///     rejected the term).  `anchor_match == None` (no calibration)
+///     applies unconditionally.
+///   - LexicalContextual: all above + context-clue-gated lexical issues,
+///     verified by segmenter when available.  For non-clue issues, respects
+///     anchor rejections (no independent disambiguation).  For clue-gated
+///     issues, the segmenter overrides anchor rejection.
 pub fn apply_fixes_with_context(
     text: &str,
     issues: &[Issue],
@@ -91,12 +112,29 @@ pub fn apply_fixes_with_context(
     excluded_offsets: &[(usize, usize)],
     segmenter: Option<&Segmenter>,
 ) -> FixResult {
+    // Lint-only mode: no fixes attempted, nothing to skip.
+    if mode == FixMode::None {
+        return FixResult {
+            text: text.to_string(),
+            applied: 0,
+            skipped: 0,
+            applied_fixes: Vec::new(),
+        };
+    }
+
     let mut out = String::with_capacity(text.len());
     let mut applied = 0usize;
     let mut skipped = 0usize;
     let mut applied_fixes = Vec::new();
     // Byte position up to which we have already copied into `out`.
     let mut cursor: usize = 0;
+
+    // Pre-compute excluded ranges for context-clue window lookups (hoisted
+    // out of the per-issue loop to avoid redundant allocations).
+    let excluded_ranges: Vec<crate::engine::excluded::ByteRange> = excluded_offsets
+        .iter()
+        .map(|&(start, end)| crate::engine::excluded::ByteRange { start, end })
+        .collect();
 
     // Issues are already sorted ascending by offset and non-overlapping
     // (scanner's resolve_overlaps guarantees this).  Iterate forward,
@@ -128,51 +166,85 @@ pub fn apply_fixes_with_context(
             continue;
         }
 
-        // Context-clue check: rules with non-empty context_clues are ambiguous.
-        // Safe mode always skips them; aggressive mode applies only when a
-        // segmenter confirms enough clue words in the surrounding text.
+        // Tier-based fix eligibility.
         //
-        // Threshold is type-aware: confusable rules (both forms valid in
-        // different contexts) need 2 clues for confidence; cross-strait and
-        // other rules need only 1 (the match itself is a strong regional
-        // signal, one nearby clue is sufficient to confirm domain).
+        // Orthographic issue types can be fixed mechanically (no lexical
+        // ambiguity).  Lexical types (CrossStrait, Typo, PoliticalColoring,
+        // Confusable) need progressively higher fix tiers.
+        let orthographic = matches!(
+            issue.rule_type,
+            IssueType::Punctuation | IssueType::Case | IssueType::Variant | IssueType::Grammar
+        );
+
+        // Orthographic tier: skip all lexical issues.
+        if mode == FixMode::Orthographic && !orthographic {
+            skipped += 1;
+            continue;
+        }
+
+        // Pre-compute context-clue presence for gating decisions below.
         let has_clues = issue.context_clues.as_ref().is_some_and(|c| !c.is_empty());
-        if has_clues {
+
+        // Anchor-match gating for lexical issues: when calibration has
+        // run (--verify), anchor_match carries the verdict.  If calibration
+        // explicitly rejected the term (Some(false)), skip the fix —
+        // both LexicalSafe and LexicalContextual respect anchor rejection
+        // for non-clue issues (no independent disambiguation available).
+        // Context-clue-gated issues in LexicalContextual can override
+        // rejection because the segmenter provides independent confirmation.
+        // When anchor_match is None (no calibration), apply unconditionally.
+        if !orthographic && issue.anchor_match == Some(false) && !has_clues {
+            skipped += 1;
+            continue;
+        }
+
+        // Context-clue gating for lexical issues.
+        if has_clues && !orthographic {
+            // Only LexicalContextual can handle context-clue-gated terms.
+            if mode != FixMode::LexicalContextual {
+                skipped += 1;
+                continue;
+            }
+            // Threshold is type-aware: confusable rules (both forms valid in
+            // different contexts) need 2 clues for confidence; cross-strait and
+            // other rules need only 1 (the match itself is a strong regional
+            // signal, one nearby clue is sufficient to confirm domain).
             let min_clues = if issue.rule_type == IssueType::Confusable {
                 MIN_CLUE_MATCHES_CONFUSABLE
             } else {
                 MIN_CLUE_MATCHES_DEFAULT
             };
-            let confirmed = mode == FixMode::Aggressive
-                && segmenter.is_some_and(|seg| {
-                    let excluded_ranges: Vec<crate::engine::excluded::ByteRange> = excluded_offsets
-                        .iter()
-                        .map(|&(start, end)| crate::engine::excluded::ByteRange { start, end })
-                        .collect();
-                    let window = crate::engine::scan::surrounding_window_bounded(
-                        text,
-                        issue.offset,
-                        end,
-                        &excluded_ranges,
-                    );
-                    let clue_strs: Vec<&str> = issue
-                        .context_clues
-                        .as_ref()
-                        .unwrap()
-                        .iter()
-                        .map(|s| s.as_str())
-                        .collect();
-                    seg.count_context_clues(window, &clue_strs) >= min_clues
-                });
+            let confirmed = segmenter.is_some_and(|seg| {
+                let window = crate::engine::scan::surrounding_window_bounded(
+                    text,
+                    issue.offset,
+                    end,
+                    &excluded_ranges,
+                );
+                let clue_strs: Vec<&str> = issue
+                    .context_clues
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect();
+                seg.count_context_clues(window, &clue_strs) >= min_clues
+            });
             if !confirmed {
                 skipped += 1;
                 continue;
             }
         }
 
+        // Suggestion selection.
+        //   - Orthographic issues: always pick first suggestion (mechanical,
+        //     no lexical ambiguity).
+        //   - Lexical issues (both clue-gated and non-clue): single suggestion
+        //     only.  The segmenter confirms domain context but does not
+        //     disambiguate between multiple replacement candidates.
         let rep = match mode {
-            FixMode::Safe if issue.suggestions.len() == 1 => Some(&issue.suggestions[0]),
-            FixMode::Aggressive => issue.suggestions.first(),
+            _ if orthographic => issue.suggestions.first(),
+            _ if issue.suggestions.len() == 1 => Some(&issue.suggestions[0]),
             _ => None,
         };
         let Some(rep) = rep.filter(|_| end <= text.len()) else {
@@ -285,44 +357,56 @@ mod tests {
         .with_context_clues(clues.into_iter().map(String::from).collect())
     }
 
+    fn make_punctuation_issue(offset: usize, found: &str, suggestions: Vec<&str>) -> Issue {
+        Issue::new(
+            offset,
+            found.len(),
+            found,
+            suggestions.into_iter().map(String::from).collect(),
+            IssueType::Punctuation,
+            Severity::Warning,
+        )
+    }
+
     #[test]
-    fn safe_mode_single_suggestion() {
+    fn lexical_safe_single_suggestion() {
         let text = "這個軟件很好用";
         let issues = vec![make_issue(6, "軟件", vec!["軟體"])];
-        let result = apply_fixes(text, &issues, FixMode::Safe, &[]);
+        let result = apply_fixes(text, &issues, FixMode::LexicalSafe, &[]);
         assert_eq!(result.text, "這個軟體很好用");
         assert_eq!(result.applied, 1);
         assert_eq!(result.skipped, 0);
     }
 
     #[test]
-    fn safe_mode_multiple_suggestions_skipped() {
+    fn lexical_safe_multiple_suggestions_skipped() {
         let text = "這個視頻很好看";
         let issues = vec![make_issue(6, "視頻", vec!["影片", "影音"])];
-        let result = apply_fixes(text, &issues, FixMode::Safe, &[]);
+        let result = apply_fixes(text, &issues, FixMode::LexicalSafe, &[]);
         assert_eq!(result.text, text); // unchanged
         assert_eq!(result.applied, 0);
         assert_eq!(result.skipped, 1);
     }
 
     #[test]
-    fn aggressive_mode_picks_first() {
+    fn lexical_contextual_skips_multi_suggestion_non_clue() {
+        // Multi-suggestion lexical issue without context_clues: both
+        // LexicalSafe and LexicalContextual skip it (no disambiguation).
         let text = "這個視頻很好看";
         let issues = vec![make_issue(6, "視頻", vec!["影片", "影音"])];
-        let result = apply_fixes(text, &issues, FixMode::Aggressive, &[]);
-        assert_eq!(result.text, "這個影片很好看");
-        assert_eq!(result.applied, 1);
+        let result = apply_fixes(text, &issues, FixMode::LexicalContextual, &[]);
+        assert_eq!(result.text, text); // unchanged -- ambiguous, no clues
+        assert_eq!(result.skipped, 1);
     }
 
     #[test]
-    fn multiple_fixes_end_to_start() {
-        // "軟件" at byte 6, "內存" somewhere after.
+    fn multiple_fixes() {
         let text = "這個軟件的內存";
         let issues = vec![
             make_issue(6, "軟件", vec!["軟體"]),
             make_issue(15, "內存", vec!["記憶體"]),
         ];
-        let result = apply_fixes(text, &issues, FixMode::Safe, &[]);
+        let result = apply_fixes(text, &issues, FixMode::LexicalSafe, &[]);
         assert_eq!(result.text, "這個軟體的記憶體");
         assert_eq!(result.applied, 2);
     }
@@ -331,8 +415,7 @@ mod tests {
     fn excluded_offset_skipped() {
         let text = "這個軟件很好用";
         let issues = vec![make_issue(6, "軟件", vec!["軟體"])];
-        // Mark offset 6 as excluded (inside a code fence, say).
-        let result = apply_fixes(text, &issues, FixMode::Safe, &[(0, 21)]);
+        let result = apply_fixes(text, &issues, FixMode::LexicalSafe, &[(0, 21)]);
         assert_eq!(result.text, text);
         assert_eq!(result.skipped, 1);
     }
@@ -340,15 +423,125 @@ mod tests {
     #[test]
     fn empty_issues() {
         let text = "hello";
-        let result = apply_fixes(text, &[], FixMode::Safe, &[]);
+        let result = apply_fixes(text, &[], FixMode::LexicalSafe, &[]);
         assert_eq!(result.text, "hello");
         assert_eq!(result.applied, 0);
+    }
+
+    // -- Orthographic tier tests --
+
+    #[test]
+    fn orthographic_fixes_punctuation() {
+        let text = "你好,世界";
+        let issues = vec![make_punctuation_issue(6, ",", vec!["，"])];
+        let result = apply_fixes(text, &issues, FixMode::Orthographic, &[]);
+        assert_eq!(result.text, "你好，世界");
+        assert_eq!(result.applied, 1);
+    }
+
+    #[test]
+    fn orthographic_skips_lexical_issues() {
+        let text = "這個軟件很好用";
+        let issues = vec![make_issue(6, "軟件", vec!["軟體"])];
+        let result = apply_fixes(text, &issues, FixMode::Orthographic, &[]);
+        assert_eq!(result.text, text); // unchanged -- orthographic skips CrossStrait
+        assert_eq!(result.skipped, 1);
+    }
+
+    // -- Anchor-match gating tests --
+
+    #[test]
+    fn lexical_safe_skips_anchor_rejected() {
+        let text = "這個軟件很好用";
+        let mut issue = make_issue(6, "軟件", vec!["軟體"]);
+        issue.anchor_match = Some(false); // calibration rejected
+        let result = apply_fixes(text, &[issue], FixMode::LexicalSafe, &[]);
+        assert_eq!(result.text, text); // unchanged -- anchor rejected
+        assert_eq!(result.skipped, 1);
+    }
+
+    #[test]
+    fn lexical_safe_applies_anchor_confirmed() {
+        let text = "這個軟件很好用";
+        let mut issue = make_issue(6, "軟件", vec!["軟體"]);
+        issue.anchor_match = Some(true); // calibration confirmed
+        let result = apply_fixes(text, &[issue], FixMode::LexicalSafe, &[]);
+        assert_eq!(result.text, "這個軟體很好用");
+        assert_eq!(result.applied, 1);
+    }
+
+    #[test]
+    fn lexical_safe_applies_anchor_none() {
+        let text = "這個軟件很好用";
+        let issue = make_issue(6, "軟件", vec!["軟體"]);
+        // anchor_match == None (no calibration) -- should apply unconditionally
+        assert!(issue.anchor_match.is_none());
+        let result = apply_fixes(text, &[issue], FixMode::LexicalSafe, &[]);
+        assert_eq!(result.text, "這個軟體很好用");
+        assert_eq!(result.applied, 1);
+    }
+
+    #[test]
+    fn lexical_contextual_respects_anchor_rejection_for_non_clue() {
+        // Non-clue lexical issue with anchor rejection: LexicalContextual
+        // respects it because there is no independent disambiguation signal.
+        let text = "這個軟件很好用";
+        let mut issue = make_issue(6, "軟件", vec!["軟體"]);
+        issue.anchor_match = Some(false);
+        let result = apply_fixes(text, &[issue], FixMode::LexicalContextual, &[]);
+        assert_eq!(result.text, text); // unchanged -- anchor rejected, no clues
+        assert_eq!(result.skipped, 1);
+    }
+
+    // -- Combined anchor_match + context_clues tests --
+
+    #[test]
+    fn lexical_safe_skips_clue_rule_even_with_anchor_confirmed() {
+        // anchor_match == Some(true) but has context_clues → LexicalSafe
+        // still refuses because context-clue rules need LexicalContextual.
+        let text = "我需要編寫一個程序來執行";
+        let offset = text.find("程序").unwrap();
+        let mut issue = make_issue_with_clues(
+            offset,
+            "程序",
+            vec!["程式"],
+            vec!["編寫", "代碼", "執行", "開發"],
+        );
+        issue.anchor_match = Some(true);
+        let result = apply_fixes(text, &[issue], FixMode::LexicalSafe, &[]);
+        assert_eq!(result.text, text); // unchanged -- context_clues gate takes precedence
+        assert_eq!(result.skipped, 1);
+    }
+
+    #[test]
+    fn lexical_contextual_applies_clue_rule_despite_anchor_rejection() {
+        // anchor_match == Some(false) + context_clues present.
+        // LexicalContextual overrides anchor rejection and applies if
+        // segmenter confirms clues.
+        let text = "我需要編寫一個程序來執行";
+        let offset = text.find("程序").unwrap();
+        let mut issue = make_issue_with_clues(
+            offset,
+            "程序",
+            vec!["程式"],
+            vec!["編寫", "代碼", "執行", "開發"],
+        );
+        issue.anchor_match = Some(false);
+        let seg = Segmenter::new(
+            ["編寫", "代碼", "執行", "開發", "程序", "程式"]
+                .iter()
+                .map(|s| s.to_string()),
+        );
+        let result =
+            apply_fixes_with_context(text, &[issue], FixMode::LexicalContextual, &[], Some(&seg));
+        assert_eq!(result.text, "我需要編寫一個程式來執行");
+        assert_eq!(result.applied, 1);
     }
 
     // -- Context clue tests --
 
     #[test]
-    fn safe_mode_skips_issues_with_context_clues() {
+    fn lexical_safe_skips_issues_with_context_clues() {
         let text = "我需要編寫一個程序來執行";
         let offset = text.find("程序").unwrap();
         let issues = vec![make_issue_with_clues(
@@ -357,14 +550,13 @@ mod tests {
             vec!["程式"],
             vec!["編寫", "代碼", "執行", "開發"],
         )];
-        let result = apply_fixes(text, &issues, FixMode::Safe, &[]);
-        assert_eq!(result.text, text); // unchanged -- safe mode refuses context-clue rules
+        let result = apply_fixes(text, &issues, FixMode::LexicalSafe, &[]);
+        assert_eq!(result.text, text); // unchanged -- lexical_safe refuses context-clue rules
         assert_eq!(result.skipped, 1);
     }
 
     #[test]
-    fn aggressive_with_segmenter_applies_when_clues_match() {
-        // "程序" with context clues; surrounding text contains "編寫" and "執行"
+    fn lexical_contextual_with_segmenter_applies_when_clues_match() {
         let text = "我需要編寫一個程序來執行";
         let offset = text.find("程序").unwrap();
         let issues = vec![make_issue_with_clues(
@@ -378,14 +570,14 @@ mod tests {
                 .iter()
                 .map(|s| s.to_string()),
         );
-        let result = apply_fixes_with_context(text, &issues, FixMode::Aggressive, &[], Some(&seg));
+        let result =
+            apply_fixes_with_context(text, &issues, FixMode::LexicalContextual, &[], Some(&seg));
         assert_eq!(result.text, "我需要編寫一個程式來執行");
         assert_eq!(result.applied, 1);
     }
 
     #[test]
-    fn aggressive_with_segmenter_skips_when_clues_insufficient() {
-        // "程序" but surrounding text has zero matching clues
+    fn lexical_contextual_with_segmenter_skips_when_clues_insufficient() {
         let text = "這個程序很重要";
         let offset = text.find("程序").unwrap();
         let issues = vec![make_issue_with_clues(
@@ -399,15 +591,14 @@ mod tests {
                 .iter()
                 .map(|s| s.to_string()),
         );
-        let result = apply_fixes_with_context(text, &issues, FixMode::Aggressive, &[], Some(&seg));
+        let result =
+            apply_fixes_with_context(text, &issues, FixMode::LexicalContextual, &[], Some(&seg));
         assert_eq!(result.text, text); // unchanged -- insufficient clues
         assert_eq!(result.skipped, 1);
     }
 
     #[test]
-    fn aggressive_without_segmenter_skips_clue_rules() {
-        // Without a segmenter, aggressive mode cannot verify context clues
-        // and skips the rule (same as safe mode).
+    fn lexical_contextual_without_segmenter_skips_clue_rules() {
         let text = "這個程序很重要";
         let offset = text.find("程序").unwrap();
         let issues = vec![make_issue_with_clues(
@@ -416,7 +607,7 @@ mod tests {
             vec!["程式"],
             vec!["編寫", "代碼", "執行", "開發"],
         )];
-        let result = apply_fixes(text, &issues, FixMode::Aggressive, &[]);
+        let result = apply_fixes(text, &issues, FixMode::LexicalContextual, &[]);
         assert_eq!(result.text, text); // unchanged -- no segmenter, cannot verify clues
         assert_eq!(result.skipped, 1);
     }
@@ -456,12 +647,12 @@ mod tests {
 
     #[test]
     fn empty_context_clues_vec_treated_as_no_clues() {
-        // Issue with context_clues: Some(vec![]) should NOT be skipped in safe mode
-        // because the empty vec means no ambiguity (the !clues.is_empty() guard).
+        // Issue with context_clues: Some(vec![]) should NOT be skipped in
+        // lexical_safe because the empty vec means no ambiguity.
         let text = "這個軟件很好用";
         let mut issue = make_issue(6, "軟件", vec!["軟體"]);
         issue.context_clues = Some(vec![]);
-        let result = apply_fixes(text, &[issue], FixMode::Safe, &[]);
+        let result = apply_fixes(text, &[issue], FixMode::LexicalSafe, &[]);
         assert_eq!(result.text, "這個軟體很好用");
         assert_eq!(result.applied, 1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,11 +164,20 @@ fn main() -> Result<()> {
                             exclude_patterns
                                 .push(args.get(i).context("--exclude requires a pattern")?.clone());
                         }
-                        "--fix" | "--fix=safe" => {
-                            fix_mode = Some(zhtw_mcp::fixer::FixMode::Safe);
+                        "--fix" | "--fix=lexical_safe" => {
+                            fix_mode = Some(zhtw_mcp::fixer::FixMode::LexicalSafe);
                         }
-                        "--fix=aggressive" => {
-                            fix_mode = Some(zhtw_mcp::fixer::FixMode::Aggressive);
+                        "--fix=orthographic" => {
+                            fix_mode = Some(zhtw_mcp::fixer::FixMode::Orthographic);
+                        }
+                        "--fix=lexical_contextual" => {
+                            fix_mode = Some(zhtw_mcp::fixer::FixMode::LexicalContextual);
+                        }
+                        arg if arg.starts_with("--fix=") => {
+                            anyhow::bail!(
+                                "unknown fix mode: {} (expected 'orthographic', 'lexical_safe', or 'lexical_contextual')",
+                                &arg[6..]
+                            );
                         }
                         "--dry-run" => {
                             dry_run = true;
@@ -1240,7 +1249,7 @@ fn run_convert(
         let fix_result = apply_fixes_with_context(
             &text,
             &issues,
-            FixMode::Aggressive,
+            FixMode::LexicalContextual,
             &excluded_pairs,
             Some(scanner.segmenter()),
         );

--- a/src/mcp/prompts.rs
+++ b/src/mcp/prompts.rs
@@ -133,7 +133,7 @@ fn get_lint_natural(args: &std::collections::HashMap<String, String>) -> PromptG
 ## Parameter Extraction Rules
 
 From the instruction, extract:
-- `fix_mode`: "safe" if the user asks to fix/correct/repair; "aggressive" if they want all fixes; "none" otherwise
+- `fix_mode`: "lexical_safe" if the user asks to fix/correct/repair; "lexical_contextual" if they want all fixes; "orthographic" for punctuation/spacing only; "none" otherwise
 - `profile`: "strict_moe" if they mention MoE/standard forms/variants; "ui_strings" for software UI; "default" otherwise
 - `political_stance`: "neutral" if they ask for neutral/apolitical; "international" for international style; "roc_centric" (default)
 - `ignore_terms`: any terms the user explicitly says to skip/ignore
@@ -179,7 +179,7 @@ fn get_editorial_review(args: &std::collections::HashMap<String, String>) -> Pro
 ## Workflow
 
 For each iteration (up to {max_iterations} total):
-1. Call `zhtw` with the current text: `{{ "text": "...", "fix_mode": "safe", "explain": true, "output": "compact", "content_type": "markdown" }}`
+1. Call `zhtw` with the current text: `{{ "text": "...", "fix_mode": "lexical_safe", "explain": true, "output": "compact", "content_type": "markdown" }}`
 2. If `accepted: true` with 0 errors, the text is finalized. Present the clean text.
 3. If issues remain:
    a. Explain each issue in context — why MoE prefers the standard form, cultural background

--- a/src/mcp/setup.rs
+++ b/src/mcp/setup.rs
@@ -24,7 +24,7 @@ Read `zh-tw://style-guide/moe` resource for full conventions.
 ### Quality Gate
 
 ```
-zhtw({ "text": "...", "fix_mode": "safe", "max_errors": 0, "output": "compact" })
+zhtw({ "text": "...", "fix_mode": "lexical_safe", "max_errors": 0, "output": "compact" })
 ```
 
 Re-run until `accepted: true`. Use `output: "compact"` to save context tokens."#
@@ -52,7 +52,7 @@ steps:
     tool: zhtw
     arguments:
       text: "{{content}}"
-      fix_mode: "safe"
+      fix_mode: "lexical_safe"
       max_errors: 0
       content_type: "{{if file_ext == 'md'}}markdown{{else}}plain{{end}}"
       profile: "default"
@@ -94,7 +94,7 @@ Use Taiwan-standard terms, not Mainland China equivalents:
 
 ## MCP Server
 The zhtw-mcp server provides automated zh-TW linting and fixing.
-Use `zhtw` with `fix_mode: "safe"` and `max_errors: 0` as a quality gate before committing Chinese text."#
+Use `zhtw` with `fix_mode: "lexical_safe"` and `max_errors: 0` as a quality gate before committing Chinese text."#
         .to_string();
 
     let vscode_settings = r#"{
@@ -183,7 +183,7 @@ The zhtw-mcp MCP server is available for automated enforcement.
 ## Tool Usage
 Use `zhtw` for linting, fixing, and gating zh-TW text:
 - Lint: `zhtw({ "text": "...", "content_type": "markdown" })`
-- Fix:  `zhtw({ "text": "...", "fix_mode": "safe", "max_errors": 0 })`
+- Fix:  `zhtw({ "text": "...", "fix_mode": "lexical_safe", "max_errors": 0 })`
 - Gate: `zhtw({ "text": "...", "max_errors": 0 })` — fails if errors > 0
 
 ## Key Conventions
@@ -207,7 +207,7 @@ All Chinese text must follow Taiwan MoE (教育部) standards.
 The zhtw-mcp MCP server provides automated zh-TW linting and fixing.
 
 ## MCP Tool: zhtw
-- `zhtw({ "text": "...", "fix_mode": "safe", "max_errors": 0 })`
+- `zhtw({ "text": "...", "fix_mode": "lexical_safe", "max_errors": 0 })`
 - Profiles: default, strict_moe, ui_strings
 - Content types: plain, markdown
 
@@ -231,7 +231,7 @@ zhtw-mcp provides `zhtw` for Traditional Chinese (Taiwan) text enforcement.
 
 ## Workflow
 1. When generating Chinese text, use Taiwan-standard vocabulary
-2. Before finalizing, run: `zhtw({ "text": "...", "fix_mode": "safe", "max_errors": 0 })`
+2. Before finalizing, run: `zhtw({ "text": "...", "fix_mode": "lexical_safe", "max_errors": 0 })`
 3. If `accepted: false`, fix remaining issues and re-check
 
 ## Quick Reference
@@ -271,7 +271,7 @@ The single unified tool for linting, fixing, and gating zh-TW text.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | text | string | (required) | Text to check |
-| fix_mode | string | "none" | "none", "safe", or "aggressive" |
+| fix_mode | string | "none" | "none", "orthographic", "lexical_safe", or "lexical_contextual" |
 | max_errors | integer | (none) | Gate: reject if errors exceed this |
 | profile | string | "default" | "default", "strict_moe", "ui_strings" |
 | content_type | string | "plain" | "plain" or "markdown" |
@@ -281,7 +281,7 @@ The single unified tool for linting, fixing, and gating zh-TW text.
 
 ### Workflow
 1. Lint: `zhtw({ "text": "...", "content_type": "markdown" })`
-2. Fix:  `zhtw({ "text": "...", "fix_mode": "safe" })`
+2. Fix:  `zhtw({ "text": "...", "fix_mode": "lexical_safe" })`
 3. Gate: `zhtw({ "text": "...", "max_errors": 0 })` — accepted=false if errors>0
 
 ### MCP Resources

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -362,7 +362,7 @@ impl Server {
                 })
             }
 
-            mode @ (FixMode::Safe | FixMode::Aggressive) => {
+            mode @ (FixMode::Orthographic | FixMode::LexicalSafe | FixMode::LexicalContextual) => {
                 // Fix path: scan, apply fixes, re-scan for residual issues.
                 let excluded = build_exclusions_for_content_type(text, content_type);
                 let scan_out = self.scanner.scan_with_prebuilt_excluded(
@@ -614,11 +614,12 @@ fn require_str<'a>(args: &'a Value, field: &str) -> Result<&'a str, CallToolResu
 /// Returns an error for unrecognized values instead of silently defaulting.
 fn parse_fix_mode(args: &Value) -> Result<FixMode, CallToolResult> {
     match args.get("fix_mode").and_then(|v| v.as_str()) {
-        Some("safe") => Ok(FixMode::Safe),
-        Some("aggressive") => Ok(FixMode::Aggressive),
+        Some("orthographic") => Ok(FixMode::Orthographic),
+        Some("lexical_safe") => Ok(FixMode::LexicalSafe),
+        Some("lexical_contextual") => Ok(FixMode::LexicalContextual),
         None | Some("none") => Ok(FixMode::None),
         Some(other) => Err(CallToolResult::error(format!(
-            "invalid 'fix_mode': '{other}' (expected 'none', 'safe', or 'aggressive')"
+            "invalid 'fix_mode': '{other}' (expected 'none', 'orthographic', 'lexical_safe', or 'lexical_contextual')"
         ))),
     }
 }
@@ -1607,7 +1608,7 @@ fn tool_definitions() -> Vec<ToolDef> {
             props.insert("text".into(), json!({ "type": "string" }));
             props.insert("fix_mode".into(), json!({
                 "type": "string",
-                "enum": ["none", "safe", "aggressive"]
+                "enum": ["none", "orthographic", "lexical_safe", "lexical_contextual"]
             }));
             props.insert("max_errors".into(), json!({ "type": "integer" }));
             props.insert("max_warnings".into(), json!({ "type": "integer" }));

--- a/tests/cli_lint.rs
+++ b/tests/cli_lint.rs
@@ -789,3 +789,17 @@ fn cli_lint_grammar_disabled_in_ui_strings_profile() {
         "ui_strings profile should not produce grammar issues: {stdout}"
     );
 }
+
+#[test]
+fn cli_lint_fix_bogus_rejected() {
+    let output = run_lint_args(&["--fix=bogus", "dummy.txt"]);
+    assert!(
+        !output.status.success(),
+        "--fix=bogus should fail with non-zero exit"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown fix mode"),
+        "should report unknown fix mode, got: {stderr}"
+    );
+}

--- a/tests/e2e_mcp.rs
+++ b/tests/e2e_mcp.rs
@@ -194,7 +194,7 @@ fn e2e_initialize_and_tools_list() {
                 "name": "zhtw",
                 "arguments": {
                     "text": "這個軟體很好用",
-                    "fix_mode": "safe",
+                    "fix_mode": "lexical_safe",
                     "max_errors": 0
                 }
             }
@@ -219,7 +219,7 @@ fn e2e_initialize_and_tools_list() {
                 "name": "zhtw",
                 "arguments": {
                     "text": "這個軟件用了很多內存",
-                    "fix_mode": "safe"
+                    "fix_mode": "lexical_safe"
                 }
             }
         }),
@@ -424,7 +424,9 @@ fn e2e_initialize_and_tools_list() {
     assert_eq!(output["gate"]["enabled"], true);
     assert!(output["gate"]["residual_errors"].as_u64().unwrap() > 0);
 
-    // -- E2E: fix_mode: "aggressive" --
+    // -- E2E: fix_mode: "lexical_contextual" --
+    // Uses 代碼 (clue-gated: needs 編譯/函式/函數 nearby) + 軟件 (non-clue).
+    // lexical_safe would fix 軟件 but skip 代碼; lexical_contextual fixes both.
 
     let resp = send_recv(
         &mut stdin,
@@ -436,8 +438,8 @@ fn e2e_initialize_and_tools_list() {
             "params": {
                 "name": "zhtw",
                 "arguments": {
-                    "text": "這個軟件和視頻很好",
-                    "fix_mode": "aggressive"
+                    "text": "編譯這個軟件的代碼",
+                    "fix_mode": "lexical_contextual"
                 }
             }
         }),
@@ -446,8 +448,14 @@ fn e2e_initialize_and_tools_list() {
     let content_text = resp["result"]["content"][0]["text"].as_str().unwrap();
     let output: Value = serde_json::from_str(content_text).unwrap();
     let fixed = output["text"].as_str().unwrap();
-    assert!(fixed.contains("軟體"), "aggressive should fix 軟件→軟體");
-    assert!(fixed.contains("影片"), "aggressive should fix 視頻→影片");
+    assert!(
+        fixed.contains("軟體"),
+        "lexical_contextual should fix 軟件→軟體"
+    );
+    assert!(
+        fixed.contains("程式碼"),
+        "lexical_contextual should fix 代碼→程式碼 (clue-gated, 編譯 present)"
+    );
     assert!(output["applied_fixes"].as_u64().unwrap() >= 2);
 
     // -- E2E: oversized request rejected by MAX_TEXT_BYTES --
@@ -619,7 +627,7 @@ fn e2e_initialize_and_tools_list() {
                 "arguments": {
                     "text": "這個軟件很好",
                     "output": "compact",
-                    "fix_mode": "safe"
+                    "fix_mode": "lexical_safe"
                 }
             }
         }),

--- a/tests/fix_tier_benchmark.rs
+++ b/tests/fix_tier_benchmark.rs
@@ -1,0 +1,203 @@
+// Benchmark for fix tier precision (35.4).
+//
+// Demonstrates how each fix tier applies progressively more fixes on
+// realistic mixed-issue text.  Measures: issues detected, fixes applied,
+// fixes skipped, and residual issues per tier.
+//
+// Run:
+//   cargo test --test fix_tier_benchmark -- --nocapture
+
+use std::time::Instant;
+use zhtw_mcp::engine::scan::Scanner;
+use zhtw_mcp::engine::segment::Segmenter;
+use zhtw_mcp::fixer::{apply_fixes_with_context, FixMode};
+use zhtw_mcp::rules::ruleset::Ruleset;
+
+fn load_scanner() -> (Scanner, Segmenter) {
+    let json_str = include_str!("../assets/ruleset.json");
+    let ruleset: Ruleset = serde_json::from_str(json_str).unwrap();
+    let segmenter = Segmenter::from_rules(&ruleset.spelling_rules);
+    let scanner = Scanner::new(ruleset.spelling_rules, ruleset.case_rules);
+    (scanner, segmenter)
+}
+
+// Mixed text with orthographic issues (punctuation, spacing) and lexical
+// issues (cross-strait terms, confusable terms with context clues).
+const MIXED_TEXT: &str = "\
+軟體工程師需要優化數據庫的性能,通過調試程序來排查代碼中的問題。\
+這個操作系統支持並行計算,能夠充分利用多核處理器的性能優勢。\
+請使用內存中的緩存數據進行網絡通訊。\
+開發人員利用調試工具來優化軟件的性能。\
+我需要編寫一個程序來執行。\
+(括號內容)該應用需要響應式設計。";
+
+// Clean zh-TW text -- no issues expected.
+const CLEAN_TEXT: &str = "\
+軟體工程師需要最佳化資料庫的效能，透過除錯程式來排查程式碼中的問題。\
+請使用記憶體中的快取資料進行網路通訊。\
+這個作業系統支援平行計算，能夠充分利用多核處理器的效能優勢。";
+
+// Large text: repeat MIXED_TEXT to ~10KB for latency measurement.
+fn make_large_text() -> String {
+    MIXED_TEXT.repeat(20)
+}
+
+#[derive(Debug)]
+struct TierResult {
+    tier: &'static str,
+    issues_detected: usize,
+    fixes_applied: usize,
+    fixes_skipped: usize,
+    residual_issues: usize,
+    elapsed_us: u128,
+}
+
+fn run_tier(
+    scanner: &Scanner,
+    segmenter: &Segmenter,
+    text: &str,
+    mode: FixMode,
+    tier_name: &'static str,
+) -> TierResult {
+    let start = Instant::now();
+
+    let scan_out = scanner.scan(text);
+    let issues_detected = scan_out.issues.len();
+
+    let excluded_pairs: Vec<(usize, usize)> = Vec::new();
+    let fix_result = apply_fixes_with_context(
+        text,
+        &scan_out.issues,
+        mode,
+        &excluded_pairs,
+        Some(segmenter),
+    );
+
+    // Re-scan fixed text to count residual issues.
+    let rescan = scanner.scan(&fix_result.text);
+    let elapsed = start.elapsed();
+
+    TierResult {
+        tier: tier_name,
+        issues_detected,
+        fixes_applied: fix_result.applied,
+        fixes_skipped: fix_result.skipped,
+        residual_issues: rescan.issues.len(),
+        elapsed_us: elapsed.as_micros(),
+    }
+}
+
+#[test]
+fn fix_tier_precision_gradient() {
+    let (scanner, segmenter) = load_scanner();
+
+    println!();
+    println!("=== Fix Tier Precision Benchmark (35.4) ===");
+    println!();
+
+    // Run all tiers on the mixed text.
+    let tiers = [
+        (FixMode::None, "none"),
+        (FixMode::Orthographic, "orthographic"),
+        (FixMode::LexicalSafe, "lexical_safe"),
+        (FixMode::LexicalContextual, "lexical_contextual"),
+    ];
+
+    println!("--- Mixed text ({} bytes) ---", MIXED_TEXT.len());
+    println!(
+        "{:<22} {:>8} {:>8} {:>8} {:>10} {:>10}",
+        "tier", "detected", "applied", "skipped", "residual", "time_us"
+    );
+    println!("{}", "-".repeat(72));
+
+    let mut results = Vec::new();
+    for (mode, name) in &tiers {
+        let r = run_tier(&scanner, &segmenter, MIXED_TEXT, *mode, name);
+        println!(
+            "{:<22} {:>8} {:>8} {:>8} {:>10} {:>10}",
+            r.tier,
+            r.issues_detected,
+            r.fixes_applied,
+            r.fixes_skipped,
+            r.residual_issues,
+            r.elapsed_us
+        );
+        results.push(r);
+    }
+
+    // Verify the strict superset property: each tier applies strictly more
+    // than the previous (catches regressions where tiers collapse).
+    for i in 1..results.len() {
+        assert!(
+            results[i].fixes_applied > results[i - 1].fixes_applied,
+            "{} did not apply strictly more fixes ({}) than {} ({})",
+            results[i].tier,
+            results[i].fixes_applied,
+            results[i - 1].tier,
+            results[i - 1].fixes_applied,
+        );
+    }
+
+    // Verify the residual monotonicity: each tier leaves strictly fewer
+    // residual issues than the previous.
+    for i in 1..results.len() {
+        assert!(
+            results[i].residual_issues < results[i - 1].residual_issues,
+            "{} did not leave strictly fewer residual issues ({}) than {} ({})",
+            results[i].tier,
+            results[i].residual_issues,
+            results[i - 1].tier,
+            results[i - 1].residual_issues,
+        );
+    }
+
+    println!();
+    println!("--- Clean text ({} bytes) ---", CLEAN_TEXT.len());
+    let clean_result = run_tier(
+        &scanner,
+        &segmenter,
+        CLEAN_TEXT,
+        FixMode::LexicalContextual,
+        "lexical_contextual",
+    );
+    println!(
+        "  detected={}, applied={}, residual={}, time={}us",
+        clean_result.issues_detected,
+        clean_result.fixes_applied,
+        clean_result.residual_issues,
+        clean_result.elapsed_us
+    );
+    // Clean text should have 0 issues.
+    assert_eq!(
+        clean_result.issues_detected, 0,
+        "clean zh-TW text should have 0 issues, got {}",
+        clean_result.issues_detected
+    );
+
+    println!();
+    println!(
+        "--- Large text (~10KB, {} bytes) ---",
+        make_large_text().len()
+    );
+    let large = make_large_text();
+    println!(
+        "{:<22} {:>8} {:>8} {:>8} {:>10} {:>10}",
+        "tier", "detected", "applied", "skipped", "residual", "time_us"
+    );
+    println!("{}", "-".repeat(72));
+    for (mode, name) in &tiers[1..] {
+        let r = run_tier(&scanner, &segmenter, &large, *mode, name);
+        println!(
+            "{:<22} {:>8} {:>8} {:>8} {:>10} {:>10}",
+            r.tier,
+            r.issues_detected,
+            r.fixes_applied,
+            r.fixes_skipped,
+            r.residual_issues,
+            r.elapsed_us
+        );
+    }
+
+    println!();
+    println!("Key: detected=issues before fix, applied=fixes made, skipped=fixes refused, residual=issues after fix");
+}

--- a/tests/vocabulary_expansion.rs
+++ b/tests/vocabulary_expansion.rs
@@ -218,23 +218,22 @@ fn context_clues_propagated_to_issue() {
 }
 
 #[test]
-fn fixer_safe_mode_skips_context_clue_rules() {
+fn fixer_lexical_safe_skips_context_clue_rules() {
     use zhtw_mcp::fixer::{apply_fixes, FixMode};
 
     let scanner = full_scanner();
     let text = "我需要編寫一個程序來執行";
     let issues = scanner.scan(text).issues;
-    // Safe mode should skip 程序 because it has context_clues
-    let result = apply_fixes(text, &issues, FixMode::Safe, &[]);
-    // 程序 should NOT be replaced in safe mode (ambiguous)
+    // LexicalSafe should skip 程序 because it has context_clues
+    let result = apply_fixes(text, &issues, FixMode::LexicalSafe, &[]);
     assert!(
         result.text.contains("程序"),
-        "Safe mode should not replace 程序 (has context_clues)"
+        "LexicalSafe should not replace 程序 (has context_clues)"
     );
 }
 
 #[test]
-fn fixer_aggressive_with_segmenter_applies_when_clues_match() {
+fn fixer_lexical_contextual_with_segmenter_applies_when_clues_match() {
     use zhtw_mcp::engine::segment::Segmenter;
     use zhtw_mcp::fixer::{apply_fixes_with_context, FixMode};
 
@@ -243,19 +242,23 @@ fn fixer_aggressive_with_segmenter_applies_when_clues_match() {
     let scanner = Scanner::new(ruleset.spelling_rules.clone(), ruleset.case_rules);
     let segmenter = Segmenter::from_rules(&ruleset.spelling_rules);
 
-    // Text with enough clue words: 編寫 and 執行 are both clues for 程序->程式
     let text = "我需要編寫一個程序來執行";
     let issues = scanner.scan(text).issues;
-    let result =
-        apply_fixes_with_context(text, &issues, FixMode::Aggressive, &[], Some(&segmenter));
+    let result = apply_fixes_with_context(
+        text,
+        &issues,
+        FixMode::LexicalContextual,
+        &[],
+        Some(&segmenter),
+    );
     assert!(
         result.text.contains("程式"),
-        "Aggressive mode with segmenter should replace 程序->程式 when clues match"
+        "LexicalContextual with segmenter should replace 程序->程式 when clues match"
     );
 }
 
 #[test]
-fn fixer_aggressive_with_segmenter_skips_when_no_clues() {
+fn fixer_lexical_contextual_with_segmenter_skips_when_no_clues() {
     use zhtw_mcp::engine::segment::Segmenter;
     use zhtw_mcp::fixer::{apply_fixes_with_context, FixMode};
 
@@ -264,15 +267,18 @@ fn fixer_aggressive_with_segmenter_skips_when_no_clues() {
     let scanner = Scanner::new(ruleset.spelling_rules.clone(), ruleset.case_rules);
     let segmenter = Segmenter::from_rules(&ruleset.spelling_rules);
 
-    // Text without clue words -- "程序" in a non-programming context
     let text = "這個程序很複雜";
     let issues = scanner.scan(text).issues;
-    let result =
-        apply_fixes_with_context(text, &issues, FixMode::Aggressive, &[], Some(&segmenter));
-    // Should NOT replace because insufficient context clues
+    let result = apply_fixes_with_context(
+        text,
+        &issues,
+        FixMode::LexicalContextual,
+        &[],
+        Some(&segmenter),
+    );
     assert!(
         result.text.contains("程序"),
-        "Aggressive mode should skip 程序 when context clues are insufficient"
+        "LexicalContextual should skip 程序 when context clues are insufficient"
     );
 }
 


### PR DESCRIPTION
This replaces FixMode::Safe/Aggressive with four-tier hierarchy: None < Orthographic < LexicalSafe < LexicalContextual.

Orthographic fixes punctuation, spacing, case, variant, grammar only. LexicalSafe adds deterministic single-suggestion term substitutions, with anchor_match gating when --verify calibration is active (Some(false) skips, None applies unconditionally). LexicalContextual adds context-clue-gated terms verified by segmenter, overriding anchor rejections.

Early return for FixMode::None avoids iterating issues unnecessarily. All call sites, tests, docs, and scripts updated; old safe/aggressive names fully removed. New benchmark test validates strict superset property and residual monotonicity across all tiers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the old Safe/Aggressive modes with a confidence-based four-tier policy: None → Orthographic → LexicalSafe → LexicalContextual. Updated CLI and `zhtw` MCP tool to use the new `fix_mode` values with strict validation, added a benchmark, and sped up lint-only runs.

- **New Features**
  - Tiers: `orthographic` (punctuation/spacing/case/variant/grammar), `lexical_safe` (single-suggestion lexical), `lexical_contextual` (segmenter-verified context-clue lexical).
  - Anchor calibration: `lexical_safe` skips when `anchor_match: Some(false)`; `None` applies; `lexical_contextual` can override for clue-gated rules.
  - CLI: `--fix` or `--fix=lexical_safe` (default), `--fix=orthographic`, `--fix=lexical_contextual`; unknown modes now error out.
  - MCP `zhtw`: `fix_mode` accepts `"none" | "orthographic" | "lexical_safe" | "lexical_contextual"` (default `"none"`); schema and prompts/docs updated; E2E/tests and scripts switched to `lexical_*` and `zhtw`; new `fix_tier_benchmark.rs` validates superset and residual monotonicity.

- **Migration**
  - Replace `safe` → `lexical_safe`, `aggressive` → `lexical_contextual`; use `orthographic` for punctuation/spacing-only flows.
  - Update any scripts/docs/prompts using `fix_mode` (e.g., `scripts/*`, MCP examples); `--fix` now maps to `lexical_safe`.

<sup>Written for commit 543f8be0560cb2046343a9c7a1529fcd6ba3fbd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

