### PR TITLE
Add editorial profile with AI writing detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The tool enforces three official Taiwan standards:
 - [Standard Form of National Characters](https://language.moe.gov.tw/001/Upload/files/SITE_CONTENT/M0001/STD/F4.HTML) (《國字標準字體》) -- character shapes
 - Cross-strait vocabulary normalization, grounded in [OpenCC](https://github.com/BYVoid/OpenCC)'s TWPhrases/TWVariants datasets -- word choices
 
-Over 1000 vocabulary rules and 15 casing rules are compiled into the binary. For ambiguous terms, the server asks the AI assistant it runs inside for help deciding -- no extra API keys required.
+Over 1100 vocabulary rules and 15 casing rules are compiled into the binary. For ambiguous terms, the server asks the AI assistant it runs inside for help deciding -- no extra API keys required.
 
 ## Why this exists
 
@@ -47,7 +47,16 @@ Automatically check and correct zh-TW text produced by AI, catching cross-strait
 - Politically colored terms -- 祖國, 內地
 - Casing -- JavaScript, GitHub, macOS
 
-Three profiles (`default`, `strict_moe`, `ui_strings`) control which rules apply. See [docs/rules.md](docs/rules.md) for the full rule reference.
+These standards are enforced across four configuration profiles. The `editorial` profile extends the official rules with AI writing artifact detection:
+
+| Profile | Purpose |
+|---------|---------|
+| `default` | Cross-strait vocabulary, punctuation, casing, grammar, politically colored terms |
+| `strict_moe` | Full MoE enforcement: character variants (裏→裡), grammar (臺/台), all punctuation |
+| `ui_strings` | Relaxed for software UI: half-width colons, en dash ranges; grammar checks disabled |
+| `editorial` | AI writing review: base rules + filler phrase detection, semantic safety words, copula/passive voice checks |
+
+See [docs/rules.md](docs/rules.md) for the full rule reference.
 
 ## Naming convention: cn and tw
 
@@ -117,15 +126,18 @@ See [docs/cli.md](docs/cli.md) for the full CLI reference and [docs/mcp.md](docs
 
 ### Common prompts
 
-When running as an MCP server, you interact through natural language. The assistant translates your intent into `zhtw` tool calls.
+When running as an MCP server, you interact through natural language. The assistant translates your intent into `zhtw` tool calls:
 
-| Intent | Say | Result |
-|--------|-----|--------|
-| Lint text | *"Check this paragraph for mainland terms"* | Returns issues with location and suggestions |
-| Auto-fix | *"Fix the zh-TW issues in this document"* | Safe fixes applied, corrected text returned |
-| Quality gate | *"Reject if more than 3 zh-TW errors"* | Accept/reject verdict via `max_errors` |
-| Strict mode | *"Check this with strict MoE rules"* | Enables variant and full punctuation enforcement |
-| Markdown-aware | *"Lint this markdown, skip code blocks"* | Excludes fenced code and HTML |
+| Intent | Say | Maps to | What happens |
+|--------|-----|---------|--------------|
+| Lint text | *"Check this paragraph for mainland terms"* | `zhtw({ "text": "..." })` | Returns issues with line/column, suggestions, and rule type |
+| Auto-fix | *"Fix the zh-TW issues in this document"* | `zhtw({ "text": "...", "fix_mode": "lexical_safe" })` | Deterministic fixes applied; corrected text returned |
+| Quality gate | *"Reject if more than 3 zh-TW errors"* | `zhtw({ "text": "...", "max_errors": 3 })` | `accepted: true/false` verdict based on error count |
+| Strict MoE | *"Check this with strict MoE rules"* | `zhtw({ "text": "...", "profile": "strict_moe" })` | Adds character variant (裏→裡) and full punctuation enforcement |
+| AI writing review | *"Review this for AI writing artifacts"* | `zhtw({ "text": "...", "detect_ai": true })` | Flags filler phrases, semantic safety words, copula/passive overuse |
+| Markdown-aware | *"Lint this markdown, skip code blocks"* | `zhtw({ "text": "...", "content_type": "markdown" })` | Fenced code, inline code, and HTML blocks excluded from scanning |
+
+Each `zhtw` call is stateless -- parameters like `profile` are per-call, not session state. Omitting `profile` defaults to `default`.
 
 The server also exposes two read-only resources for assistants to consult: `zh-tw://style-guide/moe` (MoE standards) and `zh-tw://dictionary/ambiguous` (cross-strait term disambiguation). See [docs/mcp.md](docs/mcp.md) for the full prompt catalog.
 

--- a/assets/ruleset.json
+++ b/assets/ruleset.json
@@ -139,6 +139,24 @@
       "english": "download file"
     },
     {
+      "from": "不容忽視",
+      "to": [],
+      "type": "ai_filler",
+      "context": "AI filler phrase (不容忽視); flag as potential filler but do not auto-delete — it is a content-bearing predicate"
+    },
+    {
+      "from": "不容忽視的是",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase; delete"
+    },
+    {
+      "from": "不容忽視的是，",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase; delete"
+    },
+    {
       "from": "並口",
       "to": ["平行埠"],
       "type": "cross_strait",
@@ -604,6 +622,42 @@
       "english": "debit card"
     },
     {
+      "from": "值得一提的是",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase with zero information content; delete"
+    },
+    {
+      "from": "值得一提的是，",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase with zero information content; delete"
+    },
+    {
+      "from": "值得一提的是：",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase with zero information content; delete"
+    },
+    {
+      "from": "值得注意的是",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase with zero information content; delete"
+    },
+    {
+      "from": "值得注意的是，",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase with zero information content; delete"
+    },
+    {
+      "from": "值得注意的是：",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase with zero information content; delete"
+    },
+    {
       "from": "健壯",
       "to": ["強固", "穩健"],
       "type": "cross_strait",
@@ -668,6 +722,18 @@
       "to": ["儀表板"],
       "type": "cross_strait",
       "english": "dashboard"
+    },
+    {
+      "from": "儘管存在這些挑戰",
+      "to": [],
+      "type": "ai_filler",
+      "context": "Formulaic AI concession phrase; flag but do not auto-delete — it carries contrast meaning that requires rewriting, not deletion"
+    },
+    {
+      "from": "儘管存在這些挑戰，",
+      "to": [],
+      "type": "ai_filler",
+      "context": "Formulaic AI concession phrase; flag but do not auto-delete — it carries contrast meaning that requires rewriting, not deletion"
     },
     {
       "from": "優先級",
@@ -1476,6 +1542,13 @@
       "english": "read-only"
     },
     {
+      "from": "可以看到",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase (可以看到); delete or rephrase",
+      "context_clues": ["系統", "程式", "功能", "架構", "方法"]
+    },
+    {
       "from": "可行函數",
       "to": ["可行函式"],
       "type": "cross_strait",
@@ -1695,6 +1768,12 @@
       "english": "Enter key/carriage return"
     },
     {
+      "from": "因此我們可以看到",
+      "to": ["因此"],
+      "type": "ai_filler",
+      "context": "AI filler phrase; simplify to 因此"
+    },
+    {
       "from": "固件",
       "to": ["韌體"],
       "type": "cross_strait",
@@ -1782,10 +1861,40 @@
       "english": "potato"
     },
     {
+      "from": "在某種程度上",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI hedging phrase (在某種程度上); delete or be specific"
+    },
+    {
       "from": "在線",
       "to": ["線上"],
       "type": "cross_strait",
       "english": "online"
+    },
+    {
+      "from": "在這個過程中",
+      "to": ["過程中"],
+      "type": "ai_filler",
+      "context": "AI filler phrase; simplify to 過程中"
+    },
+    {
+      "from": "在這個過程中，",
+      "to": ["過程中，"],
+      "type": "ai_filler",
+      "context": "AI filler phrase; simplify to 過程中"
+    },
+    {
+      "from": "在這種情況下",
+      "to": [],
+      "type": "ai_filler",
+      "context": "AI filler phrase; flag but do not auto-fix — 此時 is temporal while the original is conditional, changing meaning"
+    },
+    {
+      "from": "在這種情況下，",
+      "to": [],
+      "type": "ai_filler",
+      "context": "AI filler phrase; flag but do not auto-fix — 此時 is temporal while the original is conditional, changing meaning"
     },
     {
       "from": "圭亞那",
@@ -2697,6 +2806,12 @@
       "english": "suffix"
     },
     {
+      "from": "從某種角度來看",
+      "to": [],
+      "type": "ai_filler",
+      "context": "AI hedging phrase (從某種角度來看); flag but do not auto-delete — it is a semantic hedge that may carry intended meaning"
+    },
+    {
       "from": "循環",
       "to": ["迴圈"],
       "type": "confusable",
@@ -3462,6 +3577,18 @@
       "english": "smartphone"
     },
     {
+      "from": "更重要的是",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI transition filler phrase; delete or rephrase"
+    },
+    {
+      "from": "更重要的是，",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI transition filler phrase; delete or rephrase"
+    },
+    {
       "from": "最底層派生類",
       "to": ["最末層衍生類別"],
       "type": "cross_strait",
@@ -3975,6 +4102,12 @@
       "to": ["冷盤"],
       "type": "cross_strait",
       "english": "cold dish/appetizer"
+    },
+    {
+      "from": "深刻影響",
+      "to": [],
+      "type": "ai_filler",
+      "context": "AI pattern indicator (深刻影響); flag but do not auto-fix — 深刻 encodes intensity that 影響 alone drops"
     },
     {
       "from": "添加",
@@ -5170,10 +5303,29 @@
       "english": "indent"
     },
     {
+      "from": "總的來說",
+      "to": ["總之"],
+      "type": "ai_filler",
+      "context": "AI summary filler (cn calque 总的来说); tw prefers 總之"
+    },
+    {
+      "from": "總的來說，",
+      "to": ["總之，"],
+      "type": "ai_filler",
+      "context": "AI summary filler (cn calque 总的来说); tw prefers 總之"
+    },
+    {
       "from": "總線",
       "to": ["匯流排"],
       "type": "cross_strait",
       "english": "bus"
+    },
+    {
+      "from": "總而言之，",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI summary filler; often redundant — delete or keep only if genuinely concluding",
+      "context_clues": ["系統", "程式", "功能", "架構", "方法"]
     },
     {
       "from": "繮",
@@ -6579,6 +6731,24 @@
       "to": ["電池芯"],
       "type": "cross_strait",
       "english": "battery cell"
+    },
+    {
+      "from": "需要注意的是",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase with zero information content; delete"
+    },
+    {
+      "from": "需要注意的是，",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase with zero information content; delete"
+    },
+    {
+      "from": "需要注意的是：",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "AI filler phrase with zero information content; delete"
     },
     {
       "from": "靈活性",

--- a/scripts/check-ruleset.py
+++ b/scripts/check-ruleset.py
@@ -40,6 +40,7 @@ VALID_RULE_TYPES = {
     "typo",
     "confusable",
     "political_coloring",
+    "ai_filler",
 }
 
 # All known spelling rule fields (anything else is an unknown key warning).
@@ -457,9 +458,12 @@ def detect_conflicts(spelling_rules: list[dict[str, Any]]) -> list[str]:
                     stack.append((target, path + [target]))
 
     # 2. Empty to requires non-empty english (use English form convention).
+    #    Exception: ai_filler rules use empty to intentionally (deletion).
     for rule in from_set.values():
         targets = [t for t in rule.get("to", []) if t]
         if not targets:
+            if rule.get("type") == "ai_filler":
+                continue
             english = rule.get("english", "")
             if not english:
                 warnings.append(

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -50,6 +50,10 @@ pub struct ScanParams {
     // Currently always "None" because caching is disabled when fix_mode
     // is active.  Kept for forward-compatibility.
     pub fix_mode: String,
+    // Whether AI detection is active — changes scan results.
+    pub detect_ai: bool,
+    // AI threshold level (formatted f32) — different multipliers produce different results.
+    pub ai_threshold: String,
 }
 
 /// A single cached entry.
@@ -82,7 +86,7 @@ pub struct CacheHit {
 /// Result of a cache lookup.
 pub enum CacheResult {
     /// Fast-path hit: mtime+size match, no file read needed.
-    Hit(CacheHit),
+    Hit(Box<CacheHit>),
     /// mtime changed or no entry: caller must read file and call `check_content`.
     Miss,
 }
@@ -91,7 +95,7 @@ impl CacheResult {
     /// Extract the cached hit, or None on miss.
     pub fn into_hit(self) -> Option<CacheHit> {
         match self {
-            CacheResult::Hit(h) => Some(h),
+            CacheResult::Hit(h) => Some(*h),
             CacheResult::Miss => None,
         }
     }
@@ -128,10 +132,10 @@ impl ScanCache {
                 && entry.file_meta.mtime_secs == mtime_secs
                 && entry.file_meta.size == size
             {
-                return CacheResult::Hit(CacheHit {
+                return CacheResult::Hit(Box::new(CacheHit {
                     output: entry.output.clone(),
                     input_was_sc: entry.input_was_sc,
-                });
+                }));
             }
         }
         CacheResult::Miss
@@ -285,6 +289,10 @@ fn fast_key(file_path: &str, params: &ScanParams) -> String {
     hasher.update(params.content_type.as_bytes());
     hasher.update(b"\0");
     hasher.update(params.fix_mode.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(if params.detect_ai { b"ai" } else { b"" });
+    hasher.update(b"\0");
+    hasher.update(params.ai_threshold.as_bytes());
     hasher.finalize().to_hex()[..32].to_string()
 }
 
@@ -339,6 +347,7 @@ mod tests {
         ScanOutput {
             issues: vec![],
             detected_script: ChineseType::Traditional,
+            ai_signature: None,
         }
     }
 
@@ -348,6 +357,8 @@ mod tests {
             profile: "default".into(),
             content_type: "md".into(),
             fix_mode: "none".into(),
+            detect_ai: false,
+            ai_threshold: "1.0".into(),
         }
     }
 
@@ -357,6 +368,8 @@ mod tests {
             profile: "default".into(),
             content_type: "plain".into(),
             fix_mode: "none".into(),
+            detect_ai: false,
+            ai_threshold: "1.0".into(),
         }
     }
 
@@ -393,6 +406,70 @@ mod tests {
         };
         assert!(matches!(
             cache.check_fast("a.md", 1000, 5, &strict),
+            CacheResult::Miss
+        ));
+    }
+
+    #[test]
+    fn detect_ai_changes_cache_key() {
+        let dir = TempDir::new().unwrap();
+        let mut cache = ScanCache::open(dir.path().join("c.bin"));
+        let p = test_params();
+
+        cache.put("a.md", b"hello", 1000, 5, &p, empty_output(), false);
+
+        // Same params with detect_ai=false: hit.
+        assert!(matches!(
+            cache.check_fast("a.md", 1000, 5, &p),
+            CacheResult::Hit(_)
+        ));
+
+        // Same file + mtime + size but detect_ai=true: miss (different key).
+        let p_ai = ScanParams {
+            detect_ai: true,
+            ..p.clone()
+        };
+        assert!(matches!(
+            cache.check_fast("a.md", 1000, 5, &p_ai),
+            CacheResult::Miss
+        ));
+    }
+
+    #[test]
+    fn ai_threshold_changes_cache_key() {
+        let dir = TempDir::new().unwrap();
+        let mut cache = ScanCache::open(dir.path().join("c.bin"));
+        let p = ScanParams {
+            detect_ai: true,
+            ai_threshold: "1.0".into(),
+            ..test_params()
+        };
+
+        cache.put("a.md", b"hello", 1000, 5, &p, empty_output(), false);
+
+        // Same threshold: hit.
+        assert!(matches!(
+            cache.check_fast("a.md", 1000, 5, &p),
+            CacheResult::Hit(_)
+        ));
+
+        // Different threshold (low sensitivity): miss.
+        let p_low = ScanParams {
+            ai_threshold: "0.5".into(),
+            ..p.clone()
+        };
+        assert!(matches!(
+            cache.check_fast("a.md", 1000, 5, &p_low),
+            CacheResult::Miss
+        ));
+
+        // Different threshold (high sensitivity): also miss.
+        let p_high = ScanParams {
+            ai_threshold: "1.5".into(),
+            ..p.clone()
+        };
+        assert!(matches!(
+            cache.check_fast("a.md", 1000, 5, &p_high),
             CacheResult::Miss
         ));
     }

--- a/src/engine/ai_score.rs
+++ b/src/engine/ai_score.rs
@@ -1,0 +1,709 @@
+// Document-level AI signature scoring.
+//
+// Aggregates per-occurrence issues, density data, and structural pattern counts
+// into a single composite score.  Deterministic, no ML.
+//
+// The score is a weighted sum of normalized density ratios and structural
+// indicators.  Each signal contributes proportionally to how far it exceeds
+// its human baseline threshold.
+
+use serde::{Deserialize, Serialize};
+
+use crate::engine::excluded::{is_excluded, ByteRange};
+use crate::rules::ruleset::{Issue, IssueType};
+
+// Density thresholds: (phrase, human_baseline, threshold, weight).
+// Weight controls contribution to the composite score.
+const DENSITY_SIGNALS: &[(&str, f32, f32, f32)] = &[
+    ("更重要的是", 0.3, 0.5, 1.0),
+    ("值得注意的是", 0.2, 0.3, 1.0),
+    ("這意味著", 0.3, 0.5, 0.8),
+    ("不容忽視", 0.1, 0.2, 0.7),
+    ("深刻影響", 0.2, 0.3, 0.8),
+    ("從某種意義上", 0.1, 0.2, 0.6),
+    ("從某種程度上", 0.1, 0.2, 0.6),
+    ("需要注意的是", 0.2, 0.3, 0.8),
+    ("在某種程度上", 0.1, 0.2, 0.6),
+    ("在這個過程中", 0.2, 0.3, 0.7),
+];
+
+/// A single signal contributing to the AI signature score.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiMarker {
+    pub pattern: String,
+    pub count: usize,
+    pub density: f32,
+    pub threshold: f32,
+    pub expected_baseline: f32,
+}
+
+/// Aggregated AI writing signature report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiSignatureReport {
+    /// Composite score: 0.0 = clearly human, 1.0 = strongly AI-generated.
+    pub score: f32,
+    /// Individual signals that contributed to the score.
+    pub markers: Vec<AiMarker>,
+    /// Top 3 contributing signal descriptions.
+    pub top_signals: Vec<String>,
+    /// Sentence length variability (standard deviation in chars).
+    /// Low values indicate AI monotony. None if too few sentences.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sentence_variability: Option<f32>,
+    /// Count of zero-width tokenizer artifacts detected.
+    pub zero_width_count: usize,
+    /// Punctuation density matrix with per-type CV.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub punctuation_profile: Option<PunctuationProfile>,
+}
+
+// Terminal punctuation marks that delimit Chinese sentences.
+const SENTENCE_TERMINATORS: &[char] = &['。', '！', '？', '!', '?'];
+
+// Zero-width codepoints injected by LLM tokenizers (BPE/WordPiece).
+const ZERO_WIDTH_CODEPOINTS: &[char] = &[
+    '\u{200B}', // zero-width space
+    '\u{200C}', // zero-width non-joiner
+    '\u{200D}', // zero-width joiner
+    '\u{FEFF}', // byte-order mark (mid-text = artifact)
+    '\u{200E}', // left-to-right mark
+    '\u{200F}', // right-to-left mark
+];
+
+/// Returns true if the character is a zero-width tokenizer artifact.
+pub fn is_zero_width(ch: char) -> bool {
+    ZERO_WIDTH_CODEPOINTS.contains(&ch)
+}
+
+// Punctuation types tracked in the density matrix.
+const PUNCT_MARKS: &[(char, &str)] = &[
+    ('，', "comma"),
+    ('。', "period"),
+    ('；', "semicolon"),
+    ('、', "dunhao"),
+];
+
+/// Per-type punctuation statistics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PunctuationStat {
+    pub count: usize,
+    /// Density per 1000 characters.
+    pub density: f32,
+    /// Coefficient of variation of inter-punctuation distances.
+    /// None if count < 10 (insufficient data for stable CV).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cv: Option<f32>,
+}
+
+/// Punctuation density matrix across major zh-TW mark types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PunctuationProfile {
+    pub comma: PunctuationStat,
+    pub period: PunctuationStat,
+    pub semicolon: PunctuationStat,
+    pub dunhao: PunctuationStat,
+    pub dash: PunctuationStat,
+}
+
+/// Compute CV (coefficient of variation) from inter-mark distances.
+/// Returns None if fewer than 10 occurrences (fewer than 9 distances).
+fn compute_cv(distances: &[usize]) -> Option<f32> {
+    if distances.len() < 9 {
+        return None;
+    }
+    let n = distances.len() as f64;
+    let mean = distances.iter().map(|&d| d as f64).sum::<f64>() / n;
+    if mean < 1.0 {
+        return None;
+    }
+    let variance = distances
+        .iter()
+        .map(|&d| (d as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n;
+    Some((variance.sqrt() / mean) as f32)
+}
+
+/// Compute punctuation density matrix, respecting exclusion zones.
+fn compute_punctuation_profile(
+    text: &str,
+    text_k: f32,
+    excluded: &[ByteRange],
+) -> PunctuationProfile {
+    // Collect positions using a visible-char index that only advances
+    // outside exclusion zones, so excluded content (code blocks, URLs)
+    // does not inflate inter-punctuation distances.
+    let mut positions: [Vec<usize>; 4] = [vec![], vec![], vec![], vec![]];
+    let mut dash_positions: Vec<usize> = Vec::new();
+
+    let mut byte_offset = 0;
+    let mut visible_idx: usize = 0;
+    let chars: Vec<char> = text.chars().collect();
+    for (char_idx, &ch) in chars.iter().enumerate() {
+        let ch_len = ch.len_utf8();
+        if !is_excluded(byte_offset, byte_offset + ch_len, excluded) {
+            for (slot, &(mark, _)) in PUNCT_MARKS.iter().enumerate() {
+                if ch == mark {
+                    positions[slot].push(visible_idx);
+                }
+            }
+            // Em-dash: two consecutive '—' chars.
+            if ch == '—' && char_idx + 1 < chars.len() && chars[char_idx + 1] == '—' {
+                dash_positions.push(visible_idx);
+            }
+            visible_idx += 1;
+        }
+        byte_offset += ch_len;
+    }
+
+    // Build stats for each type.
+    let build_stat = |pos: &[usize]| -> PunctuationStat {
+        let count = pos.len();
+        let density = count as f32 / text_k;
+        let distances: Vec<usize> = pos.windows(2).map(|w| w[1].saturating_sub(w[0])).collect();
+        let cv = compute_cv(&distances);
+        PunctuationStat { count, density, cv }
+    };
+
+    PunctuationProfile {
+        comma: build_stat(&positions[0]),
+        period: build_stat(&positions[1]),
+        semicolon: build_stat(&positions[2]),
+        dunhao: build_stat(&positions[3]),
+        dash: build_stat(&dash_positions),
+    }
+}
+
+/// Compute sentence length variability (standard deviation of char counts).
+///
+/// Splits on terminal punctuation, filters out fragments < 4 chars,
+/// requires >= 10 sentences for statistical significance.
+/// Characters whose byte offsets fall in `excluded` ranges are skipped.
+fn compute_sentence_variability(text: &str, excluded: &[ByteRange]) -> Option<f32> {
+    let mut lengths: Vec<usize> = Vec::new();
+    let mut current = 0usize;
+    let mut byte_offset = 0usize;
+    let mut was_excluded = false;
+    for ch in text.chars() {
+        let ch_len = ch.len_utf8();
+        let in_excluded = is_excluded(byte_offset, byte_offset + ch_len, excluded);
+        byte_offset += ch_len;
+        if in_excluded {
+            // Treat exclusion boundaries as sentence breaks so adjacent
+            // sentences are not fused when a code block sits between them.
+            if !was_excluded && current >= 4 {
+                lengths.push(current);
+                current = 0;
+            }
+            was_excluded = true;
+            continue;
+        }
+        was_excluded = false;
+        if SENTENCE_TERMINATORS.contains(&ch) {
+            if current >= 4 {
+                lengths.push(current);
+            }
+            current = 0;
+        } else {
+            current += 1;
+        }
+    }
+    if lengths.len() < 10 {
+        return None;
+    }
+    // Accumulate in f64 to avoid catastrophic cancellation on large documents.
+    let n = lengths.len() as f64;
+    let mean = lengths.iter().map(|&l| l as f64).sum::<f64>() / n;
+    let variance = lengths
+        .iter()
+        .map(|&l| (l as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n;
+    Some(variance.sqrt() as f32)
+}
+
+/// Count zero-width tokenizer artifact codepoints in text (excluding exclusion zones).
+fn count_zero_width(text: &str, excluded: &[ByteRange]) -> usize {
+    let mut count = 0;
+    let mut byte_offset = 0;
+    for ch in text.chars() {
+        let ch_len = ch.len_utf8();
+        if ZERO_WIDTH_CODEPOINTS.contains(&ch)
+            && !is_excluded(byte_offset, byte_offset + ch_len, excluded)
+        {
+            count += 1;
+        }
+        byte_offset += ch_len;
+    }
+    count
+}
+
+/// Compute AI signature report from text and post-scan issues.
+///
+/// Combines six signal sources:
+/// 1. Phrase density: count tracked phrases, compute density per 1000 chars.
+/// 2. Structural patterns: count AiStyle issues from structural detectors.
+/// 3. Per-occurrence: count non-structural/non-token AiStyle issues.
+/// 4. Sentence length variability: low stddev = AI monotony.
+/// 5. Zero-width tokenizer artifacts: BPE/WordPiece residue.
+/// 6. Punctuation density matrix: aggregate CV of inter-punctuation distances.
+///
+/// Returns None for texts too short to analyze (< 500 chars).
+pub fn compute_ai_score(
+    text: &str,
+    issues: &[Issue],
+    excluded: &[ByteRange],
+    threshold_multiplier: f32,
+) -> Option<AiSignatureReport> {
+    // Guard against zero/negative multiplier to prevent div-by-zero in thresholds.
+    let threshold_multiplier = if threshold_multiplier <= 0.0 {
+        1.0
+    } else {
+        threshold_multiplier
+    };
+    // Count only chars whose byte offsets fall outside excluded ranges.
+    let char_count = {
+        let mut count = 0usize;
+        let mut byte_offset = 0usize;
+        for ch in text.chars() {
+            let ch_len = ch.len_utf8();
+            if !is_excluded(byte_offset, byte_offset + ch_len, excluded) {
+                count += 1;
+            }
+            byte_offset += ch_len;
+        }
+        count
+    };
+    if char_count < 500 {
+        return None;
+    }
+    let text_k = char_count as f32 / 1000.0;
+
+    let mut markers = Vec::new();
+    let mut weighted_sum: f32 = 0.0;
+    let mut total_weight: f32 = 0.0;
+
+    // Signal 1: phrase density.  Apply threshold_multiplier so low/high
+    // sensitivity affects the composite score, not just per-issue generation.
+    for &(phrase, baseline, raw_threshold, weight) in DENSITY_SIGNALS {
+        let threshold = raw_threshold * threshold_multiplier;
+        let phrase_len = phrase.len();
+        let mut count: usize = 0;
+        let mut start = 0;
+        while let Some(pos) = text[start..].find(phrase) {
+            let abs = start + pos;
+            start = abs + phrase_len;
+            if !is_excluded(abs, abs + phrase_len, excluded) {
+                count += 1;
+            }
+        }
+        if count == 0 {
+            continue;
+        }
+        let density = count as f32 / text_k;
+        markers.push(AiMarker {
+            pattern: phrase.to_string(),
+            count,
+            density,
+            threshold,
+            expected_baseline: baseline,
+        });
+        if density > threshold {
+            // Normalized contribution: how far above threshold, capped at 1.0.
+            let excess = ((density - threshold) / threshold).min(2.0);
+            weighted_sum += excess * weight;
+        }
+        total_weight += weight;
+    }
+
+    // Signal 2: structural pattern count from existing issues.
+    let structural_count = issues
+        .iter()
+        .filter(|i| {
+            i.rule_type == IssueType::AiStyle
+                && i.context
+                    .as_ref()
+                    .is_some_and(|c| c.starts_with("AI structural:"))
+        })
+        .count();
+    // Each structural signal contributes 0.1 to score (max 0.4 for 4 signals).
+    // Rebalanced from 0.15/0.75 per 40.11: structural should not dominate phrase density.
+    let structural_contribution = (structural_count as f32 * 0.1).min(0.4);
+
+    // Signal 3: non-structural, non-zero-width AiStyle issue density.
+    // Excludes issues already counted by signals 1 (density phrases),
+    // 2 (structural), and 5 (zero-width) to avoid double-counting.
+    let ai_issue_count = issues
+        .iter()
+        .filter(|i| {
+            i.rule_type == IssueType::AiStyle
+                && !i
+                    .context
+                    .as_ref()
+                    .is_some_and(|c| c.starts_with("AI structural:") || c.starts_with("AI token:"))
+                && !DENSITY_SIGNALS
+                    .iter()
+                    .any(|&(phrase, _, _, _)| i.found == phrase)
+        })
+        .count();
+    let ai_issue_density = ai_issue_count as f32 / text_k;
+    // High density of AI issues is itself a signal.  Threshold: >2 per 1000 chars.
+    let issue_density_contribution = if ai_issue_density > 2.0 {
+        ((ai_issue_density - 2.0) / 5.0).min(0.3)
+    } else {
+        0.0
+    };
+
+    // Signal 4: sentence length variability (low stddev = AI monotony).
+    let sentence_variability = compute_sentence_variability(text, excluded);
+    let var_threshold = 5.0 * threshold_multiplier;
+    let variability_contribution = match sentence_variability {
+        Some(sigma) if sigma < var_threshold => {
+            // sigma below threshold is suspiciously uniform; max contribution 0.15.
+            ((var_threshold - sigma) / var_threshold * 0.15).min(0.15)
+        }
+        _ => 0.0,
+    };
+
+    // Signal 5: zero-width tokenizer artifacts.
+    let zero_width_count = count_zero_width(text, excluded);
+    let zw_scale = 3.0 * threshold_multiplier;
+    let zero_width_contribution = if zero_width_count > 0 {
+        // Any presence is suspicious; 3+ is strong signal. Max 0.2.
+        ((zero_width_count as f32) / zw_scale * 0.2).min(0.2)
+    } else {
+        0.0
+    };
+
+    // Signal 6: punctuation density matrix — aggregate CV.
+    let punctuation_profile = compute_punctuation_profile(text, text_k, excluded);
+    let punct_contribution = {
+        // Aggregate CV across types with sufficient samples (N >= 10),
+        // weighted by occurrence count.
+        let stats = [
+            &punctuation_profile.comma,
+            &punctuation_profile.period,
+            &punctuation_profile.semicolon,
+            &punctuation_profile.dunhao,
+            &punctuation_profile.dash,
+        ];
+        let mut weighted_cv_sum = 0.0f64;
+        let mut total_count = 0usize;
+        for stat in &stats {
+            if let Some(cv) = stat.cv {
+                weighted_cv_sum += cv as f64 * stat.count as f64;
+                total_count += stat.count;
+            }
+        }
+        if total_count > 0 {
+            let aggregate_cv = (weighted_cv_sum / total_count as f64) as f32;
+            // Low CV (< threshold) = uniform rhythm = AI signal.  Max 0.1.
+            let cv_threshold = 0.5 * threshold_multiplier;
+            ((cv_threshold - aggregate_cv).max(0.0) / cv_threshold * 0.1).min(0.1)
+        } else {
+            0.0
+        }
+    };
+
+    // Composite score: combine all six signals (rebalanced per 40.11).
+    // phrase ≤0.7, structural ≤0.4, issue ≤0.3, variability ≤0.15,
+    // zero-width ≤0.2, punctuation ≤0.1.  Max ~1.85 before clamp.
+    // No single signal exceeds 0.7; ≥0.8 requires ≥2 dimensions.
+    let phrase_score = if total_weight > 0.0 {
+        (weighted_sum / total_weight).min(1.0) * 0.7
+    } else {
+        0.0
+    };
+    let raw_score = phrase_score
+        + structural_contribution
+        + issue_density_contribution
+        + variability_contribution
+        + zero_width_contribution
+        + punct_contribution;
+    let score = raw_score.min(1.0);
+
+    // Build top signals list (sorted by density excess ratio).
+    markers.sort_by(|a, b| {
+        let a_ratio = a.density / a.threshold;
+        let b_ratio = b.density / b.threshold;
+        b_ratio
+            .partial_cmp(&a_ratio)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut top_signals: Vec<String> = markers
+        .iter()
+        .filter(|m| m.density > m.threshold)
+        .take(3)
+        .map(|m| {
+            format!(
+                "\u{300C}{}\u{300D} {:.1}次/千字 (閾值 {})",
+                m.pattern, m.density, m.threshold
+            )
+        })
+        .collect();
+    if structural_count > 0 {
+        top_signals.push(format!("{structural_count} 個結構性 AI 特徵"));
+    }
+    if let Some(sigma) = sentence_variability {
+        if sigma < var_threshold {
+            top_signals.push(format!("句長變異低 σ={sigma:.1}（疑似 AI 均質化）"));
+        }
+    }
+    if zero_width_count > 0 {
+        top_signals.push(format!("{zero_width_count} 個零寬字元（疑似分詞器殘留）"));
+    }
+    if punct_contribution > 0.0 {
+        top_signals.push("標點節奏過於均勻（疑似 AI 生成）".to_string());
+    }
+    top_signals.truncate(3);
+
+    let punctuation_profile =
+        if punctuation_profile.comma.cv.is_some() || punctuation_profile.period.cv.is_some() {
+            Some(punctuation_profile)
+        } else {
+            None
+        };
+
+    Some(AiSignatureReport {
+        score,
+        markers,
+        top_signals,
+        sentence_variability,
+        zero_width_count,
+        punctuation_profile,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_text_returns_none() {
+        let result = compute_ai_score("短文", &[], &[], 1.0);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn clean_text_low_score() {
+        let text = "台灣的半導體產業在全球市場中佔有重要地位。".repeat(30);
+        let result = compute_ai_score(&text, &[], &[], 1.0);
+        let report = result.unwrap();
+        assert!(
+            report.score <= 0.3,
+            "clean text should score low: {:.2}",
+            report.score
+        );
+    }
+
+    #[test]
+    fn ai_heavy_text_high_score() {
+        // Build text loaded with AI patterns.
+        let filler = "這是正常的技術段落。";
+        let mut text = String::new();
+        for i in 0..80 {
+            match i % 8 {
+                0 => text.push_str("更重要的是，這個技術非常關鍵。"),
+                1 => text.push_str("值得注意的是，我們發現了新的問題。"),
+                2 => text.push_str("這意味著我們需要重新評估方案。"),
+                3 => text.push_str("不容忽視的影響深遠。"),
+                4 => text.push_str("深刻影響了整個產業的發展。"),
+                _ => text.push_str(filler),
+            }
+        }
+        // Add some structural pattern issues.
+        let structural_issues: Vec<Issue> = (0..3)
+            .map(|i| {
+                Issue::new(
+                    i,
+                    1,
+                    "",
+                    vec![],
+                    IssueType::AiStyle,
+                    crate::rules::ruleset::Severity::Info,
+                )
+                .with_context("AI structural: test pattern")
+            })
+            .collect();
+        let result = compute_ai_score(&text, &structural_issues, &[], 1.0);
+        let report = result.unwrap();
+        assert!(
+            report.score >= 0.5,
+            "AI-heavy text should score high: {:.2}",
+            report.score
+        );
+        assert!(!report.markers.is_empty());
+        assert!(!report.top_signals.is_empty());
+    }
+
+    #[test]
+    fn sentence_variability_uniform_low() {
+        // All sentences nearly identical length -> low sigma -> contributes to score.
+        let sentence = "這是一段長度相同的句子內容";
+        let mut text = String::new();
+        for _ in 0..60 {
+            text.push_str(sentence);
+            text.push('。');
+        }
+        let result = compute_ai_score(&text, &[], &[], 1.0);
+        let report = result.unwrap();
+        assert!(
+            report.sentence_variability.is_some(),
+            "should compute variability for 60 sentences"
+        );
+        let sigma = report.sentence_variability.unwrap();
+        assert!(
+            sigma < 2.0,
+            "uniform sentences should have low sigma: {sigma:.1}"
+        );
+    }
+
+    #[test]
+    fn sentence_variability_varied_high() {
+        // Mix of short (>=4 chars) and very long sentences -> high sigma.
+        let mut text = String::new();
+        for i in 0..30 {
+            if i % 2 == 0 {
+                text.push_str("這是短句。");
+            } else {
+                text.push_str(
+                    &"這是一段非常非常非常非常非常冗長的句子用來增加長度變異性".repeat(3),
+                );
+                text.push('。');
+            }
+        }
+        let result = compute_ai_score(&text, &[], &[], 1.0);
+        let report = result.unwrap();
+        let sigma = report
+            .sentence_variability
+            .expect("should compute variability for varied sentences");
+        assert!(
+            sigma > 10.0,
+            "varied sentences should have high sigma: {sigma:.1}"
+        );
+    }
+
+    #[test]
+    fn zero_width_detection() {
+        let mut text = "台灣的半導體產業在全球市場中佔有重要地位。".repeat(30);
+        // Inject zero-width spaces.
+        text.push('\u{200B}');
+        text.push_str("更多文字");
+        text.push('\u{FEFF}');
+        text.push_str("結尾。");
+        let result = compute_ai_score(&text, &[], &[], 1.0);
+        let report = result.unwrap();
+        assert_eq!(
+            report.zero_width_count, 2,
+            "should detect 2 zero-width chars"
+        );
+    }
+
+    #[test]
+    fn zero_width_excluded() {
+        let mut text = "台灣的半導體產業在全球市場中佔有重要地位。".repeat(30);
+        let zw_offset = text.len();
+        text.push('\u{200B}');
+        let excluded = vec![ByteRange {
+            start: zw_offset,
+            end: zw_offset + 3,
+        }];
+        let result = compute_ai_score(&text, &[], &excluded, 1.0);
+        let report = result.unwrap();
+        assert_eq!(
+            report.zero_width_count, 0,
+            "excluded zero-width should not count"
+        );
+    }
+
+    #[test]
+    fn punctuation_profile_uniform_rhythm() {
+        // AI-like text: commas at perfectly regular intervals.
+        let clause = "這是一個測試，";
+        let mut text = String::new();
+        for _ in 0..80 {
+            text.push_str(clause);
+        }
+        // Add enough periods for the profile to be computed.
+        for _ in 0..15 {
+            text.push_str("這是句子結尾。");
+        }
+        let result = compute_ai_score(&text, &[], &[], 1.0);
+        let report = result.unwrap();
+        if let Some(ref profile) = report.punctuation_profile {
+            assert!(
+                profile.comma.count >= 10,
+                "should have enough commas: {}",
+                profile.comma.count
+            );
+            if let Some(cv) = profile.comma.cv {
+                assert!(
+                    cv < 0.3,
+                    "uniform comma spacing should have low CV: {cv:.2}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn punctuation_profile_varied_rhythm() {
+        // Human-like text: wildly varying clause lengths.
+        let mut text = String::new();
+        for i in 0..40 {
+            if i % 3 == 0 {
+                text.push_str("短，");
+            } else if i % 3 == 1 {
+                text.push_str("這是一段比較長的句子用來增加變異性，");
+            } else {
+                text.push_str(
+                    "這是一段非常非常非常非常冗長的句子，目的是讓逗號間距的變異係數升高，",
+                );
+            }
+        }
+        for _ in 0..15 {
+            text.push_str("結尾句子。");
+        }
+        let result = compute_ai_score(&text, &[], &[], 1.0);
+        let report = result.unwrap();
+        if let Some(ref profile) = report.punctuation_profile {
+            if let Some(cv) = profile.comma.cv {
+                assert!(
+                    cv >= 0.4,
+                    "varied comma spacing should have moderate-to-high CV: {cv:.2}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn punctuation_profile_sparse_no_cv() {
+        // Text with very few commas — CV should be None.
+        let text = "台灣的半導體產業在全球市場中佔有重要地位。".repeat(30);
+        let result = compute_ai_score(&text, &[], &[], 1.0);
+        let report = result.unwrap();
+        if let Some(ref profile) = report.punctuation_profile {
+            assert!(
+                profile.comma.cv.is_none(),
+                "sparse commas should yield no CV"
+            );
+        }
+    }
+
+    #[test]
+    fn excluded_ranges_respected() {
+        let mut text = String::new();
+        for _ in 0..60 {
+            text.push_str("更重要的是，這很重要。");
+        }
+        // Exclude entire text.
+        let excluded = vec![ByteRange {
+            start: 0,
+            end: text.len(),
+        }];
+        let result = compute_ai_score(&text, &[], &excluded, 1.0);
+        assert!(
+            result.is_none(),
+            "fully excluded text should return None (below char_count threshold)"
+        );
+    }
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,3 +1,4 @@
+pub mod ai_score;
 pub mod excluded;
 pub mod lineindex;
 pub mod markdown;

--- a/src/engine/scan/ellipsis.rs
+++ b/src/engine/scan/ellipsis.rs
@@ -1,4 +1,4 @@
-// Ellipsis normalization (9.3).
+// Ellipsis normalization.
 //
 // Detects non-standard ellipsis patterns adjacent to CJK text and suggests
 // the MoE-standard …… (two U+2026 HORIZONTAL ELLIPSIS characters).
@@ -8,7 +8,7 @@ use crate::rules::ruleset::{Issue, Severity};
 
 use super::{adjacent_cjk, punct_issue_sev};
 
-/// Ellipsis normalization (9.3).
+/// Ellipsis normalization.
 ///
 /// Detects non-standard ellipsis patterns adjacent to CJK text and suggests
 /// the MoE-standard …… (two U+2026 HORIZONTAL ELLIPSIS characters).

--- a/src/engine/scan/grammar.rs
+++ b/src/engine/scan/grammar.rs
@@ -688,6 +688,851 @@ pub(crate) fn scan_double_attribution(text: &str, excluded: &[ByteRange], issues
     }
 }
 
+// ========================================================================
+// AI writing detection: grammar-level patterns
+// ========================================================================
+
+// Helper to create an AI-style issue (IssueType::AiStyle instead of Grammar).
+fn ai_style_issue(
+    offset: usize,
+    found: &str,
+    suggestion: &str,
+    context: &str,
+    severity: Severity,
+) -> Issue {
+    Issue::new(
+        offset,
+        found.len(),
+        found,
+        if suggestion.is_empty() {
+            vec![]
+        } else {
+            vec![suggestion.into()]
+        },
+        IssueType::AiStyle,
+        severity,
+    )
+    .with_context(context)
+}
+
+// Context clues for definition sense of 意味著 → 表示.
+const YIWEIZHE_DEFINITION_CLUES: &[&str] =
+    &["定義", "是指", "就是", "即", "所謂", "稱為", "指的是"];
+
+// Context clues for consequence sense of 意味著 → 代表.
+const YIWEIZHE_CONSEQUENCE_CLUES: &[&str] = &[
+    "因此", "所以", "結果", "導致", "造成", "如果", "一旦", "將會", "可能",
+];
+
+// Context clues for explanation/paraphrase sense of 意味著 → 也就是說.
+const YIWEIZHE_EXPLANATION_CLUES: &[&str] =
+    &["換言之", "換句話說", "簡單來說", "簡言之", "具體來說"];
+
+// Detect overuse of 意味著 where native zh-TW would use context-appropriate
+// alternatives: 表示 (definition), 代表 (consequence), 也就是說 (explanation).
+// Emits a single disambiguated suggestion per occurrence (required by fixer.rs
+// which skips issues with >1 suggestion for non-orthographic types).
+// When disambiguation confidence is low, emits advisory-only (no suggestions).
+pub(crate) fn scan_ai_semantic_safety(text: &str, excluded: &[ByteRange], issues: &mut Vec<Issue>) {
+    let target = "意味著";
+    let target_len = target.len();
+    let mut search_start = 0;
+
+    while let Some(pos) = text[search_start..].find(target) {
+        let abs_pos = search_start + pos;
+        let end = abs_pos + target_len;
+        search_start = end;
+
+        if is_excluded(abs_pos, end, excluded) {
+            continue;
+        }
+
+        // Look at surrounding sentence for context clues to disambiguate.
+        // Use sentence boundaries (not clause boundaries) so that clues in
+        // an adjacent clause within the same sentence are still visible
+        // (e.g. '換言之，這意味著' — '換言之' is in the prior clause).
+        let sentence_start = text[..abs_pos]
+            .char_indices()
+            .rev()
+            .find(|&(_, ch)| is_sentence_end(ch))
+            .map(|(i, ch)| i + ch.len_utf8())
+            .unwrap_or(0);
+        let sentence_end = text[end..]
+            .find(|ch: char| is_sentence_end(ch))
+            .map(|i| end + i)
+            .unwrap_or(text.len());
+        let context_window = &text[sentence_start..sentence_end];
+
+        // Try disambiguation: definition > consequence > explanation.
+        let suggestion = if YIWEIZHE_DEFINITION_CLUES
+            .iter()
+            .any(|c| context_window.contains(c))
+        {
+            "表示"
+        } else if YIWEIZHE_CONSEQUENCE_CLUES
+            .iter()
+            .any(|c| context_window.contains(c))
+        {
+            "代表"
+        } else if YIWEIZHE_EXPLANATION_CLUES
+            .iter()
+            .any(|c| context_window.contains(c))
+        {
+            "也就是說"
+        } else {
+            // Low confidence: no clear context → advisory only (empty suggestion).
+            ""
+        };
+
+        issues.push(ai_style_issue(
+            abs_pos,
+            target,
+            suggestion,
+            "AI semantic safety word; native zh-TW prefers \
+             context-specific alternatives (\u{8868}\u{793a}/\u{4ee3}\u{8868}/\u{4e5f}\u{5c31}\u{662f}\u{8aaa})",
+            Severity::Info,
+        ));
+    }
+}
+
+// Copula-avoidance patterns: AI replaces simple 是/有 with inflated alternatives.
+// (inflated_form, simple_copula)
+const COPULA_AVOIDANCE_PATTERNS: &[(&str, &str)] = &[
+    ("作為", "是"),
+    ("標誌著", "是"),
+    ("充當", "是"),
+    ("擁有", "有"),
+    ("設有", "有"),
+];
+
+// Characters that, when adjacent to a copula pattern, indicate a compound
+// word rather than an inflated copula.  Matching these suppresses the issue.
+// 作為: preceded by 所 (有所作為) or 大 (大作為).
+// 擁有: followed by 權/者/感/量 (擁有權, 擁有者, 擁有感, 擁有量).
+fn is_copula_compound(text: &str, abs_pos: usize, end: usize, inflated: &str) -> bool {
+    if inflated == "作為" {
+        // Check preceding char.
+        if abs_pos >= 3 {
+            let prev_start = text.floor_char_boundary(abs_pos - 3);
+            let prev = &text[prev_start..abs_pos];
+            if prev.ends_with('所') || prev.ends_with('大') {
+                return true;
+            }
+        }
+    }
+    if inflated == "擁有" {
+        // Check following char.
+        if end < text.len() {
+            let next_end = text.ceil_char_boundary(end + 1);
+            let next = &text[end..next_end];
+            if next.starts_with('權')
+                || next.starts_with('者')
+                || next.starts_with('感')
+                || next.starts_with('量')
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// Context clues for technical prose (where copula avoidance is most suspicious).
+const COPULA_TECH_CONTEXT: &[&str] = &[
+    "系統",
+    "程式",
+    "函式",
+    "API",
+    "介面",
+    "模組",
+    "元件",
+    "架構",
+    "伺服器",
+    "資料庫",
+];
+
+// Detect AI copula avoidance: 作為/標誌著/充當 replacing 是, and 擁有/設有
+// replacing 有, in technical prose context.
+pub(crate) fn scan_ai_copula_avoidance(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+) {
+    for &(inflated, simple) in COPULA_AVOIDANCE_PATTERNS {
+        let inflated_len = inflated.len();
+        let mut search_start = 0;
+
+        while let Some(pos) = text[search_start..].find(inflated) {
+            let abs_pos = search_start + pos;
+            let end = abs_pos + inflated_len;
+            search_start = end;
+
+            if is_excluded(abs_pos, end, excluded) {
+                continue;
+            }
+
+            // Skip compound words where the pattern is part of a larger term.
+            if is_copula_compound(text, abs_pos, end, inflated) {
+                continue;
+            }
+
+            // Only flag in technical prose context to avoid false positives
+            // on literary/formal writing where these forms are natural.
+            let window_start = abs_pos.saturating_sub(80);
+            let window_end = text.len().min(end + 80);
+            let window =
+                &text[text.floor_char_boundary(window_start)..text.ceil_char_boundary(window_end)];
+
+            let in_tech_context = COPULA_TECH_CONTEXT.iter().any(|c| window.contains(c));
+            if !in_tech_context {
+                continue;
+            }
+
+            // Advisory only — no token-level suggestion.  Direct replacement
+            // (e.g. 作為→是) produces broken sentences because the surrounding
+            // syntax must change too.  The user must restructure manually.
+            let ctx = format!(
+                "AI copula avoidance: consider restructuring with '{simple}' \
+                 instead of '{inflated}'"
+            );
+            issues.push(ai_style_issue(abs_pos, inflated, "", &ctx, Severity::Info));
+        }
+    }
+}
+
+// Passive 被-constructions that have obvious active rewrites.
+// (被-pattern, active_rewrite)
+// Only patterns where dropping 被 is universally safe (adverb + verb).
+// Excluded: 被認為是/被稱為 (flips meaning with animate subject),
+// 被設計為/被用來/被用於 (changes construction when subject is affected entity).
+const PASSIVE_REWRITE_PATTERNS: &[(&str, &str)] = &[
+    ("被廣泛使用", "廣泛使用"),
+    ("被廣泛採用", "廣泛採用"),
+    ("被廣泛應用", "廣泛應用"),
+];
+
+// Detect passive voice overuse: 被 + verb where active voice is more natural.
+// Only flags patterns from a curated list to minimize false positives.
+pub(crate) fn scan_ai_passive(text: &str, excluded: &[ByteRange], issues: &mut Vec<Issue>) {
+    for &(pattern, rewrite) in PASSIVE_REWRITE_PATTERNS {
+        let pattern_len = pattern.len();
+        let mut search_start = 0;
+
+        while let Some(pos) = text[search_start..].find(pattern) {
+            let abs_pos = search_start + pos;
+            let end = abs_pos + pattern_len;
+            search_start = end;
+
+            if is_excluded(abs_pos, end, excluded) {
+                continue;
+            }
+
+            issues.push(ai_style_issue(
+                abs_pos,
+                pattern,
+                rewrite,
+                "AI passive voice overuse; active voice is more natural in zh-TW",
+                Severity::Info,
+            ));
+        }
+    }
+}
+
+// Didactic sentence patterns: AI-typical moralizing constructions
+// that are nearly 100% AI-generated in technical articles.
+// Pattern: 的(故事|案例|經驗|教訓|歷史)(告訴|提醒|啟示)(我們|後人|世人)
+pub(crate) fn scan_ai_didactic(text: &str, excluded: &[ByteRange], issues: &mut Vec<Issue>) {
+    // Use a simple multi-step search: find each 告訴我們/提醒我們/啟示我們
+    // then look backward for 的(故事|案例|經驗|教訓|歷史)
+    // This is more efficient than regex for CJK text.
+
+    const VERBS: &[&str] = &["告訴", "提醒", "啟示"];
+    const OBJECTS: &[&str] = &["我們", "後人", "世人"];
+    const NOUNS: &[&str] = &["故事", "案例", "經驗", "教訓", "歷史"];
+
+    for verb in VERBS {
+        for obj in OBJECTS {
+            let pattern = format!("{verb}{obj}");
+            let pattern_len = pattern.len();
+            let mut search_start = 0;
+
+            while let Some(pos) = text[search_start..].find(&pattern) {
+                let abs_pos = search_start + pos;
+                let end = abs_pos + pattern_len;
+                search_start = end;
+
+                if is_excluded(abs_pos, end, excluded) {
+                    continue;
+                }
+
+                // Look backward up to 30 bytes for 的 + noun
+                let lookback_start = abs_pos.saturating_sub(30);
+                let lookback_start = text.floor_char_boundary(lookback_start);
+                let lookback = &text[lookback_start..abs_pos];
+
+                let has_didactic_noun = NOUNS.iter().any(|noun| {
+                    let prefix = format!("的{noun}");
+                    lookback.contains(&prefix)
+                });
+
+                if has_didactic_noun {
+                    // Find the full span: from 的noun to verb+obj
+                    let full_start = NOUNS
+                        .iter()
+                        .filter_map(|noun| {
+                            let prefix = format!("的{noun}");
+                            lookback.rfind(&prefix).map(|i| lookback_start + i)
+                        })
+                        .min()
+                        .unwrap_or(abs_pos);
+
+                    let full_text = &text[full_start..end];
+
+                    issues.push(ai_style_issue(
+                        full_start,
+                        full_text,
+                        "",
+                        "AI didactic pattern; technical articles rarely use moralizing conclusions",
+                        Severity::Info,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+// Vague exaggeration patterns: AI-typical claims like "領先時代 N 年"
+// without technical substance.
+// Pattern: (領先|超前|超越)(時代|業界|同期)...N年
+pub(crate) fn scan_ai_vague_exaggeration(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+) {
+    const VERBS: &[&str] = &["領先", "超前", "超越"];
+    const OBJECTS: &[&str] = &["時代", "業界", "同期"];
+
+    for verb in VERBS {
+        let verb_len = verb.len();
+        let mut search_start = 0;
+
+        while let Some(pos) = text[search_start..].find(verb) {
+            let abs_pos = search_start + pos;
+            let verb_end = abs_pos + verb_len;
+            search_start = verb_end;
+
+            if is_excluded(abs_pos, verb_end, excluded) {
+                continue;
+            }
+
+            // Look forward up to 30 chars for object + optional gap + digits + 年
+            let lookahead_end = text.len().min(verb_end + 60);
+            let lookahead_end = text.ceil_char_boundary(lookahead_end);
+            let lookahead = &text[verb_end..lookahead_end];
+
+            let has_object = OBJECTS.iter().any(|obj| {
+                if let Some(obj_pos) = lookahead.find(obj) {
+                    // Check for digits followed by 年 after the object
+                    let after_obj = &lookahead[obj_pos + obj.len()..];
+                    // Skip up to 12 bytes of gap, then look for digit+年
+                    let win_end = after_obj.floor_char_boundary(after_obj.len().min(20));
+                    let check_window = &after_obj[..win_end];
+                    check_window.chars().any(|c| c.is_ascii_digit()) && check_window.contains('年')
+                } else {
+                    false
+                }
+            });
+
+            if has_object {
+                // Find the end of the pattern (up to 年)
+                let pattern_end = text[verb_end..lookahead_end]
+                    .find('年')
+                    .map(|i| verb_end + i + '年'.len_utf8())
+                    .unwrap_or(verb_end);
+                let full_text = &text[abs_pos..pattern_end];
+
+                issues.push(ai_style_issue(
+                    abs_pos,
+                    full_text,
+                    "",
+                    "AI vague exaggeration; replace with concrete technical comparison",
+                    Severity::Info,
+                ));
+            }
+        }
+    }
+}
+
+// Density thresholds for AI phrase detection.
+// Each entry: (phrase, threshold per 1000 chars, max_acceptable count suggestion).
+// Calibrated from x86.md field review data.
+const DENSITY_TRACKED_PHRASES: &[(&str, f32, u32)] = &[
+    ("更重要的是", 0.5, 5),
+    ("值得注意的是", 0.3, 3),
+    ("這意味著", 0.5, 5),
+    ("不容忽視", 0.2, 2),
+    ("深刻影響", 0.3, 3),
+    ("從某種意義上", 0.2, 2),
+    ("從某種程度上", 0.2, 2),
+    ("需要注意的是", 0.3, 3),
+    ("在某種程度上", 0.2, 2),
+    ("在這個過程中", 0.3, 3),
+];
+
+// Post-scan density pass: count tracked phrases across the full document.
+// When density (count / text_len_chars * 1000) exceeds the per-phrase threshold,
+// emit a single summary AiStyle issue at the first occurrence with density stats.
+// Does NOT duplicate per-occurrence ai_filler detection — this catches the
+// statistical signature that only becomes visible at document level.
+pub(crate) fn scan_ai_density(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    threshold_multiplier: f32,
+) {
+    let char_count = text.chars().count();
+    // Skip density analysis on short texts (< 500 chars) — not enough
+    // statistical signal to distinguish AI from human.
+    if char_count < 500 {
+        return;
+    }
+    let text_k = char_count as f32 / 1000.0;
+
+    for &(phrase, threshold, max_acceptable) in DENSITY_TRACKED_PHRASES {
+        let phrase_len = phrase.len();
+        let mut count: u32 = 0;
+        let mut first_offset: Option<usize> = None;
+        let mut search_start = 0;
+
+        while let Some(pos) = text[search_start..].find(phrase) {
+            let abs_pos = search_start + pos;
+            search_start = abs_pos + phrase_len;
+
+            if is_excluded(abs_pos, abs_pos + phrase_len, excluded) {
+                continue;
+            }
+            count += 1;
+            if first_offset.is_none() {
+                first_offset = Some(abs_pos);
+            }
+        }
+
+        if count == 0 {
+            continue;
+        }
+
+        let density = count as f32 / text_k;
+        let effective_threshold = threshold * threshold_multiplier;
+        if density > effective_threshold {
+            let offset = first_offset.unwrap();
+            let ctx = format!(
+                "AI density: \u{300C}{phrase}\u{300D} 在本文出現 {count} 次 \
+                 ({density:.1}次/千字，閾值 {effective_threshold:.1})，\
+                 疑似 AI 生成的轉折公式。建議減至 {max_acceptable} 次以內。"
+            );
+            issues.push(ai_style_issue(offset, phrase, "", &ctx, Severity::Warning));
+        }
+    }
+}
+
+// --- Structural AI pattern detectors ---
+
+/// Returns true if the byte range [start, end) is entirely within an exclusion zone.
+fn is_para_excluded(start: usize, end: usize, excluded: &[ByteRange]) -> bool {
+    excluded.iter().any(|r| r.start <= start && end <= r.end)
+}
+
+// Binary contrast density: AI overuses paired transition patterns.
+// Counts intra-sentence double turns, progressive, and concessive patterns.
+// Threshold: >5 per 1000 chars is AI-typical (human baseline: 2-3).
+pub(crate) fn scan_ai_binary_contrast(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    threshold_multiplier: f32,
+) {
+    let char_count = text.chars().count();
+    if char_count < 500 {
+        return;
+    }
+
+    // Split into sentences (approximate: split on sentence-ending punctuation).
+    let mut count: u32 = 0;
+    let mut first_offset: Option<usize> = None;
+
+    // Concessive: 雖然/儘管/即便 ... 但/卻/然而
+    let concessive_starts: &[&str] = &["雖然", "儘管", "即便", "即使"];
+    let concessive_turns: &[&str] = &["但", "卻", "然而", "不過"];
+
+    // Progressive: 不僅/不只/不單 ... 更/還/也/亦
+    let progressive_starts: &[&str] = &["不僅", "不只", "不單"];
+    let progressive_turns: &[&str] = &["更", "還", "也", "亦"];
+
+    // Scan paragraphs (split on double newline).
+    for para in text.split("\n\n") {
+        let para_start = para.as_ptr() as usize - text.as_ptr() as usize;
+        if is_para_excluded(para_start, para_start + para.len(), excluded) {
+            continue;
+        }
+        // Scan sentences within paragraph (split on 。！？).
+        for sentence in para.split(['。', '！', '？']) {
+            let sent_start = sentence.as_ptr() as usize - text.as_ptr() as usize;
+            // Check concessive pattern.
+            for &start_word in concessive_starts {
+                if let Some(pos) = sentence.find(start_word) {
+                    let after = &sentence[pos + start_word.len()..];
+                    for &turn in concessive_turns {
+                        if after.contains(turn) {
+                            count += 1;
+                            if first_offset.is_none() {
+                                first_offset = Some(sent_start + pos);
+                            }
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+            // Check progressive pattern.
+            for &start_word in progressive_starts {
+                if let Some(pos) = sentence.find(start_word) {
+                    let after = &sentence[pos + start_word.len()..];
+                    for &turn in progressive_turns {
+                        if after.contains(turn) {
+                            count += 1;
+                            if first_offset.is_none() {
+                                first_offset = Some(sent_start + pos);
+                            }
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    let text_k = char_count as f32 / 1000.0;
+    let density = count as f32 / text_k;
+    let effective_threshold = 5.0 * threshold_multiplier;
+    if density > effective_threshold && count >= 3 {
+        let offset = first_offset.unwrap_or(0);
+        let ctx = format!(
+            "AI structural: 二元對比句式出現 {count} 次 ({density:.1}次/千字，\
+             閾值 {effective_threshold:.1})，疑似 AI 慣用的對立轉折模式。"
+        );
+        issues.push(ai_style_issue(offset, "", "", &ctx, Severity::Info));
+    }
+}
+
+// Paragraph-ending formulaic declarations.
+// AI closes paragraphs with stock phrases like:
+//   這...證明/揭示...
+//   這...成為...的基礎/基石/起點
+//   正是這...讓...
+// Flag when 3+ paragraphs end with such patterns.
+pub(crate) fn scan_ai_paragraph_endings(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+) {
+    let paragraphs: Vec<&str> = text
+        .split("\n\n")
+        .filter(|p| {
+            if p.trim().is_empty() {
+                return false;
+            }
+            let start = p.as_ptr() as usize - text.as_ptr() as usize;
+            !is_para_excluded(start, start + p.len(), excluded)
+        })
+        .collect();
+    if paragraphs.len() < 5 {
+        return;
+    }
+
+    let ending_patterns: &[&str] = &[
+        "的基礎",
+        "的基石",
+        "的起點",
+        "的關鍵",
+        "的核心",
+        "證明了",
+        "揭示了",
+        "展示了",
+        "體現了",
+    ];
+    let prefix_patterns: &[&str] = &["正是這", "正是在", "這也正是"];
+
+    let mut match_count = 0;
+    let mut first_offset: Option<usize> = None;
+
+    for para in &paragraphs {
+        let trimmed = para.trim();
+        // Check last ~30 chars of paragraph (approximate ending).
+        let check_len = trimmed.len().min(90); // ~30 CJK chars
+        let tail_start = trimmed.len().saturating_sub(check_len);
+        let tail = &trimmed[trimmed.floor_char_boundary(tail_start)..];
+
+        let mut matched = false;
+        for &pat in ending_patterns {
+            if tail.contains(pat) {
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            for &pat in prefix_patterns {
+                if tail.contains(pat) {
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if matched {
+            match_count += 1;
+            if first_offset.is_none() {
+                let para_start = para.as_ptr() as usize - text.as_ptr() as usize;
+                first_offset = Some(para_start);
+            }
+        }
+    }
+
+    if match_count >= 3 {
+        let total = paragraphs.len();
+        let offset = first_offset.unwrap_or(0);
+        let ctx = format!(
+            "AI structural: {total} 個段落中 {match_count} 個以公式化宣言結尾 \
+             (的基礎/證明了/正是這...)，疑似 AI 總結模式。"
+        );
+        issues.push(ai_style_issue(offset, "", "", &ctx, Severity::Info));
+    }
+}
+
+// Dash overuse: flag when many paragraphs contain ≥3 em-dashes.
+// AI writing overuses parenthetical dashes for elaboration.
+pub(crate) fn scan_ai_dash_overuse(text: &str, excluded: &[ByteRange], issues: &mut Vec<Issue>) {
+    let paragraphs: Vec<&str> = text
+        .split("\n\n")
+        .filter(|p| {
+            if p.trim().is_empty() {
+                return false;
+            }
+            let start = p.as_ptr() as usize - text.as_ptr() as usize;
+            !is_para_excluded(start, start + p.len(), excluded)
+        })
+        .collect();
+    if paragraphs.len() < 3 {
+        return;
+    }
+
+    let mut heavy_dash_count = 0;
+    let mut first_offset: Option<usize> = None;
+
+    for para in &paragraphs {
+        let dash_count = para.matches('—').count();
+        if dash_count >= 3 {
+            heavy_dash_count += 1;
+            if first_offset.is_none() {
+                let para_start = para.as_ptr() as usize - text.as_ptr() as usize;
+                first_offset = Some(para_start);
+            }
+        }
+    }
+
+    // Flag when ≥3 paragraphs have heavy dash usage.
+    if heavy_dash_count >= 3 {
+        let total = paragraphs.len();
+        let offset = first_offset.unwrap_or(0);
+        let ctx = format!(
+            "AI structural: {total} 個段落中 {heavy_dash_count} 個含 ≥3 個破折號，\
+             疑似 AI 過度使用插入說明。"
+        );
+        issues.push(ai_style_issue(offset, "", "", &ctx, Severity::Info));
+    }
+}
+
+// Formulaic section headings: AI generates stereotyped heading patterns.
+// These are only meaningful in Markdown/structured text where headings
+// are explicit. Detects patterns in lines starting with # or ##.
+const FORMULAIC_HEADINGS: &[&str] = &[
+    "挑戰與未來展望",
+    "結論與展望",
+    "挑戰與機遇",
+    "問題與挑戰",
+    "優勢與劣勢",
+    "現狀與未來",
+    "回顧與展望",
+    "總結與展望",
+    "影響與意義",
+    "發展與演變",
+];
+
+pub(crate) fn scan_ai_formulaic_headings(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+) {
+    let mut match_count = 0;
+    let mut first_offset: Option<usize> = None;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        // Check lines that look like Markdown headings.
+        if !trimmed.starts_with('#') {
+            continue;
+        }
+        let line_start = line.as_ptr() as usize - text.as_ptr() as usize;
+        if is_para_excluded(line_start, line_start + line.len(), excluded) {
+            continue;
+        }
+        // Strip leading # and whitespace.
+        let heading_text = trimmed.trim_start_matches('#').trim();
+        for &pattern in FORMULAIC_HEADINGS {
+            if heading_text.contains(pattern) {
+                match_count += 1;
+                if first_offset.is_none() {
+                    let line_start = line.as_ptr() as usize - text.as_ptr() as usize;
+                    first_offset = Some(line_start);
+                }
+                break;
+            }
+        }
+    }
+
+    // A single formulaic heading might be legitimate; flag ≥2.
+    if match_count >= 2 {
+        let offset = first_offset.unwrap_or(0);
+        let ctx = format!(
+            "AI structural: 發現 {match_count} 個公式化標題 \
+             (挑戰與展望/結論與展望...)，疑似 AI 生成的章節結構。"
+        );
+        issues.push(ai_style_issue(offset, "", "", &ctx, Severity::Info));
+    }
+}
+
+// Enumerated list density: count list-containing paragraphs relative to total.
+// AI writing overuses bullet/numbered lists for organization.
+// Flag when list-paragraph ratio exceeds 40%.
+pub(crate) fn scan_ai_list_density(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    threshold_multiplier: f32,
+) {
+    let paragraphs: Vec<&str> = text
+        .split("\n\n")
+        .filter(|p| {
+            if p.trim().is_empty() {
+                return false;
+            }
+            let start = p.as_ptr() as usize - text.as_ptr() as usize;
+            !is_para_excluded(start, start + p.len(), excluded)
+        })
+        .collect();
+    if paragraphs.len() < 5 {
+        return;
+    }
+
+    let mut list_para_count = 0;
+    let mut first_offset: Option<usize> = None;
+
+    for para in &paragraphs {
+        let has_list = para.lines().any(|line| {
+            let t = line.trim();
+            // Markdown unordered list items.
+            t.starts_with("- ") || t.starts_with("* ")
+            // Markdown ordered list items.
+            || (t.len() > 2
+                && t.as_bytes()[0].is_ascii_digit()
+                && (t.contains(". ") && t.find(". ").unwrap() < 4))
+        });
+        if has_list {
+            list_para_count += 1;
+            if first_offset.is_none() {
+                let para_start = para.as_ptr() as usize - text.as_ptr() as usize;
+                first_offset = Some(para_start);
+            }
+        }
+    }
+
+    let total = paragraphs.len();
+    let ratio = list_para_count as f32 / total as f32;
+    let effective_threshold = 0.4 * threshold_multiplier;
+    if ratio > effective_threshold && list_para_count >= 3 {
+        let pct = (ratio * 100.0) as u32;
+        let offset = first_offset.unwrap_or(0);
+        let ctx = format!(
+            "AI structural: 全文 {total} 段落中 {list_para_count} 個含列表 \
+             ({pct}%)，疑似 AI 結構化傾向。"
+        );
+        issues.push(ai_style_issue(offset, "", "", &ctx, Severity::Info));
+    }
+}
+
+// Zero-width codepoints injected by LLM tokenizers (BPE/WordPiece).
+// Any occurrence mid-text is a tokenizer artifact; suggest empty string for auto-removal.
+const ZERO_WIDTH_CODEPOINTS: &[(char, &str)] = &[
+    ('\u{200B}', "U+200B zero-width space"),
+    ('\u{200C}', "U+200C zero-width non-joiner"),
+    ('\u{200D}', "U+200D zero-width joiner"),
+    ('\u{FEFF}', "U+FEFF byte-order mark"),
+    ('\u{200E}', "U+200E left-to-right mark"),
+    ('\u{200F}', "U+200F right-to-left mark"),
+];
+
+// Detect zero-width tokenizer artifacts and emit per-occurrence AiStyle issues.
+// Suggestion is empty string so the fixer strips them automatically.
+fn scan_ai_zero_width(text: &str, excluded: &[ByteRange], issues: &mut Vec<Issue>) {
+    let mut byte_offset = 0;
+    for ch in text.chars() {
+        let ch_len = ch.len_utf8();
+        if let Some(&(_, label)) = ZERO_WIDTH_CODEPOINTS.iter().find(|(c, _)| *c == ch) {
+            if !is_excluded(byte_offset, byte_offset + ch_len, excluded) {
+                let ctx = format!("AI token: 零寬字元 {label}，疑似 LLM 分詞器殘留。");
+                let found: String = ch.into();
+                issues.push(
+                    Issue::new(
+                        byte_offset,
+                        ch_len,
+                        &found,
+                        vec![String::new()],
+                        IssueType::AiStyle,
+                        Severity::Info,
+                    )
+                    .with_context(&ctx),
+                );
+            }
+        }
+        byte_offset += ch_len;
+    }
+}
+
+// Entry point: run all structural AI pattern checks.
+// Gated by ProfileConfig::ai_structural_patterns.
+pub(crate) fn scan_ai_structural(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    threshold_multiplier: f32,
+) {
+    scan_ai_binary_contrast(text, excluded, issues, threshold_multiplier);
+    scan_ai_paragraph_endings(text, excluded, issues);
+    scan_ai_dash_overuse(text, excluded, issues);
+    scan_ai_formulaic_headings(text, excluded, issues);
+    scan_ai_list_density(text, excluded, issues, threshold_multiplier);
+    scan_ai_zero_width(text, excluded, issues);
+}
+
+// Entry point for AI writing detection grammar checks.
+// Gated by ProfileConfig::ai_semantic_safety — NOT called from scan_grammar.
+pub(crate) fn scan_ai_grammar(text: &str, excluded: &[ByteRange], issues: &mut Vec<Issue>) {
+    scan_ai_semantic_safety(text, excluded, issues);
+    scan_ai_copula_avoidance(text, excluded, issues);
+    scan_ai_passive(text, excluded, issues);
+    scan_ai_didactic(text, excluded, issues);
+    scan_ai_vague_exaggeration(text, excluded, issues);
+}
+
 // Main entry point: run all grammar checks.
 pub(crate) fn scan_grammar(text: &str, excluded: &[ByteRange], issues: &mut Vec<Issue>) {
     scan_a_not_a_ma(text, excluded, issues);
@@ -1872,5 +2717,557 @@ mod tests {
     fn natural_genju_prepositional() {
         // 根據 as preposition with comma, no attribution verb in clause.
         assert!(scan("根據合約規定，雙方應遵守以下條款。").is_empty());
+    }
+
+    // =======================================================================
+    // AI writing detection
+    // =======================================================================
+
+    fn scan_ai(text: &str) -> Vec<Issue> {
+        let mut issues = Vec::new();
+        scan_ai_grammar(text, &[], &mut issues);
+        issues
+    }
+
+    // -- 意味著 semantic safety word --
+
+    #[test]
+    fn ai_yiweizhe_definition_context() {
+        let text = "這個定義意味著所有的值都必須為正";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].rule_type, IssueType::AiStyle);
+        assert_eq!(issues[0].found, "意味著");
+        assert_eq!(issues[0].suggestions, vec!["表示"]);
+    }
+
+    #[test]
+    fn ai_yiweizhe_consequence_context() {
+        let text = "如果記憶體不足，這意味著系統將會崩潰";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].suggestions, vec!["代表"]);
+    }
+
+    #[test]
+    fn ai_yiweizhe_explanation_context() {
+        let text = "換言之，這意味著我們需要重新設計";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].suggestions, vec!["也就是說"]);
+    }
+
+    #[test]
+    fn ai_yiweizhe_no_context_advisory_only() {
+        let text = "這意味著很多事情";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        // No clear context → advisory only (empty suggestions).
+        assert!(issues[0].suggestions.is_empty());
+    }
+
+    #[test]
+    fn ai_yiweizhe_in_excluded_region() {
+        let mut issues = Vec::new();
+        let excluded = vec![ByteRange { start: 0, end: 100 }];
+        scan_ai_semantic_safety("這意味著很多", &excluded, &mut issues);
+        assert!(issues.is_empty());
+    }
+
+    // -- Copula avoidance --
+
+    #[test]
+    fn ai_copula_zuowei_in_tech_context() {
+        let text = "此系統作為核心元件運作";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].found, "作為");
+        // Advisory only — no direct replacement (would break sentence).
+        assert!(issues[0].suggestions.is_empty());
+        assert!(issues[0].context.as_ref().unwrap().contains("是"));
+    }
+
+    #[test]
+    fn ai_copula_zuowei_not_in_tech_context() {
+        // No tech context clues → should not flag.
+        let text = "她作為一位母親非常偉大";
+        let issues = scan_ai(text);
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn ai_copula_yongyou_in_tech_context() {
+        let text = "這個模組擁有三個介面";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].found, "擁有");
+        // Advisory only — no direct replacement.
+        assert!(issues[0].suggestions.is_empty());
+        assert!(issues[0].context.as_ref().unwrap().contains("有"));
+    }
+
+    // -- Passive voice --
+
+    #[test]
+    fn ai_passive_bei_guangfan() {
+        let text = "這個框架被廣泛使用於各種專案中";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].found, "被廣泛使用");
+        assert_eq!(issues[0].suggestions, vec!["廣泛使用"]);
+        assert_eq!(issues[0].rule_type, IssueType::AiStyle);
+    }
+
+    #[test]
+    fn ai_passive_bei_chengwei_not_flagged() {
+        // 被稱為 removed: dropping 被 flips meaning with animate subjects.
+        let text = "這個演算法被稱為快速排序";
+        let issues = scan_ai(text);
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn ai_passive_bei_renwei_not_flagged() {
+        // 被認為是 removed: 他被認為是→他認為是 changes meaning.
+        let text = "他被認為是最好的程式設計師";
+        let issues = scan_ai(text);
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn ai_passive_no_match_unlisted() {
+        // 被打 is not in the curated list → no flag.
+        let text = "他被打了一頓";
+        let issues = scan_ai(text);
+        assert!(issues.is_empty());
+    }
+
+    // -- Copula compound word false-positive guards --
+
+    #[test]
+    fn ai_copula_yousuozuowei_not_flagged() {
+        // 有所作為 is a compound; 作為 should not be flagged.
+        let text = "這個系統必須有所作為才能改善效能";
+        let issues = scan_ai(text);
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn ai_copula_yongyouquan_not_flagged() {
+        // 擁有權 is a compound; 擁有 should not be flagged.
+        let text = "此模組的擁有權屬於核心架構";
+        let issues = scan_ai(text);
+        assert!(issues.is_empty());
+    }
+
+    // -- AI grammar does not interfere with base grammar --
+
+    #[test]
+    fn ai_grammar_does_not_produce_grammar_issues() {
+        let text = "此系統作為核心元件，這意味著我們需要因此重新設計";
+        let issues = scan_ai(text);
+        for issue in &issues {
+            assert_eq!(issue.rule_type, IssueType::AiStyle);
+        }
+    }
+
+    // -- Didactic sentence patterns --
+
+    #[test]
+    fn ai_didactic_pattern_detected() {
+        let text = "x86 的歷史告訴我們處理器設計需要平衡";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].rule_type, IssueType::AiStyle);
+        assert!(issues[0].found.contains("告訴我們"));
+    }
+
+    #[test]
+    fn ai_didactic_different_verb() {
+        let text = "這個案例的教訓提醒世人不要重蹈覆轍";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].found.contains("提醒世人"));
+    }
+
+    #[test]
+    fn ai_didactic_no_noun_prefix() {
+        // Without 的+noun before verb, should not flag.
+        let text = "老師告訴我們要認真學習";
+        let issues = scan_ai(text);
+        assert!(issues.is_empty());
+    }
+
+    // -- Vague exaggeration patterns --
+
+    #[test]
+    fn ai_vague_exaggeration_detected() {
+        let text = "這項技術領先時代至少20年";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].rule_type, IssueType::AiStyle);
+        assert!(issues[0].found.contains("領先"));
+    }
+
+    #[test]
+    fn ai_vague_exaggeration_different_verb() {
+        let text = "該設計超越同期產品約5年的技術水準";
+        let issues = scan_ai(text);
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].found.contains("超越"));
+    }
+
+    #[test]
+    fn ai_vague_exaggeration_no_year() {
+        // Without digits+年 following, should not flag.
+        let text = "這項技術領先業界的水準";
+        let issues = scan_ai(text);
+        assert!(issues.is_empty());
+    }
+
+    // -- IssueType::AiStyle plumbing --
+
+    // -- AI density detection tests --
+
+    fn scan_density(text: &str) -> Vec<Issue> {
+        let mut issues = Vec::new();
+        scan_ai_density(text, &[], &mut issues, 1.0);
+        issues
+    }
+
+    #[test]
+    fn ai_density_short_text_skipped() {
+        // Text under 500 chars should not trigger density analysis.
+        let text = "更重要的是".repeat(20); // ~100 chars
+        let issues = scan_density(&text);
+        assert!(issues.is_empty(), "short text should skip density check");
+    }
+
+    #[test]
+    fn ai_density_below_threshold_no_issue() {
+        // ~2600 chars of filler with 1 occurrence of tracked phrase.
+        // 1 / 2.6 ≈ 0.38/千字, below threshold 0.5 for '更重要的是'.
+        let mut text = "這是一段正常的中文技術文章。".repeat(200);
+        text.push_str("更重要的是，我們需要考慮效能。");
+        assert!(text.chars().count() >= 2000);
+        let issues = scan_density(&text);
+        assert!(
+            issues.is_empty(),
+            "single occurrence in long text should not exceed density: {} chars",
+            text.chars().count()
+        );
+    }
+
+    #[test]
+    fn ai_density_above_threshold_flags() {
+        // ~1000 chars with high density of '更重要的是' (threshold 0.5/千字).
+        // We need >0.5 per 1000 chars, so >1 in 2000 chars or >0.5 in 1000.
+        // Build ~1000 char text with 3 occurrences → density 3.0/千字.
+        let filler = "這是正常的技術內容段落。"; // 12 chars
+        let mut text = String::new();
+        for i in 0..80 {
+            if i % 25 == 0 {
+                text.push_str("更重要的是，我們需要重新評估。");
+            } else {
+                text.push_str(filler);
+            }
+        }
+        assert!(text.chars().count() >= 500);
+        let issues = scan_density(&text);
+        assert!(
+            !issues.is_empty(),
+            "high density should trigger: text has {} chars",
+            text.chars().count()
+        );
+        assert_eq!(issues[0].rule_type, IssueType::AiStyle);
+        assert!(issues[0].context.as_ref().unwrap().contains("次/千字"));
+        assert!(issues[0].context.as_ref().unwrap().contains("更重要的是"));
+    }
+
+    #[test]
+    fn ai_density_excluded_ranges_respected() {
+        // Occurrences in excluded ranges should not count toward density.
+        let filler = "這是正常的技術內容段落。";
+        let mut text = String::new();
+        for i in 0..80 {
+            if i % 25 == 0 {
+                text.push_str("更重要的是，我們需要重新評估。");
+            } else {
+                text.push_str(filler);
+            }
+        }
+        // Exclude the entire text — all occurrences should be skipped.
+        let excluded = vec![ByteRange {
+            start: 0,
+            end: text.len(),
+        }];
+        let mut issues = Vec::new();
+        scan_ai_density(&text, &excluded, &mut issues, 1.0);
+        assert!(issues.is_empty(), "excluded ranges should suppress density");
+    }
+
+    #[test]
+    fn ai_density_multiple_phrases_independent() {
+        // Two different phrases both above threshold — should get two issues.
+        let mut text = String::new();
+        for _ in 0..60 {
+            text.push_str("這是正常的技術內容。");
+        }
+        // Insert both phrases repeatedly.
+        for _ in 0..5 {
+            text.push_str("更重要的是，這個方法不容忽視。");
+        }
+        assert!(text.chars().count() >= 500);
+        let issues = scan_density(&text);
+        // At least one should fire (density depends on exact char count).
+        let density_contexts: Vec<_> = issues.iter().filter_map(|i| i.context.as_ref()).collect();
+        // Both phrases should be independently evaluated.
+        let has_gengyaojinaoshi = density_contexts.iter().any(|c| c.contains("更重要的是"));
+        let has_buronghushi = density_contexts.iter().any(|c| c.contains("不容忽視"));
+        // At least one should trigger given high density.
+        assert!(
+            has_gengyaojinaoshi || has_buronghushi,
+            "at least one high-density phrase should trigger: contexts={density_contexts:?}"
+        );
+    }
+
+    // -- AI structural pattern tests --
+
+    fn scan_structural(text: &str) -> Vec<Issue> {
+        let mut issues = Vec::new();
+        scan_ai_structural(text, &[], &mut issues, 1.0);
+        issues
+    }
+
+    #[test]
+    fn ai_structural_binary_contrast_below_threshold() {
+        // Short text or low density should not flag.
+        let text = "雖然困難很多，但我們還是做到了。這是正常的文章。".repeat(10);
+        let issues = scan_structural(&text);
+        // Only 10 concessive patterns in ~280 chars — below 500 char threshold.
+        assert!(
+            issues.is_empty()
+                || !issues
+                    .iter()
+                    .any(|i| i.context.as_ref().is_some_and(|c| c.contains("二元對比")))
+        );
+    }
+
+    #[test]
+    fn ai_structural_binary_contrast_high_density() {
+        let filler = "這是正常的技術段落。";
+        let mut text = String::new();
+        for i in 0..50 {
+            if i % 4 == 0 {
+                text.push_str("雖然這很困難，但我們可以克服。");
+            } else if i % 4 == 1 {
+                text.push_str("不僅要學習，更要實踐。");
+            } else {
+                text.push_str(filler);
+            }
+        }
+        let issues = scan_structural(&text);
+        let contrast_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("二元對比")))
+            .collect();
+        assert!(
+            !contrast_issues.is_empty(),
+            "high density binary contrast should trigger: {} chars, issues={:?}",
+            text.chars().count(),
+            issues
+        );
+    }
+
+    #[test]
+    fn ai_structural_paragraph_endings() {
+        let mut text = String::new();
+        for i in 0..8 {
+            if i % 2 == 0 {
+                text.push_str("這個技術的發展證明了人工智慧的潛力。");
+            } else {
+                text.push_str("正是這個突破讓研究人員重新思考。");
+            }
+            text.push_str("\n\n");
+        }
+        let issues = scan_structural(&text);
+        let ending_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("公式化宣言")))
+            .collect();
+        assert!(
+            !ending_issues.is_empty(),
+            "formulaic paragraph endings should trigger"
+        );
+    }
+
+    #[test]
+    fn ai_structural_dash_overuse() {
+        let mut text = String::new();
+        for _ in 0..5 {
+            text.push_str("這項技術—作為核心—非常重要—我們必須注意。\n\n");
+        }
+        let issues = scan_structural(&text);
+        let dash_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("破折號")))
+            .collect();
+        assert!(!dash_issues.is_empty(), "heavy dash usage should trigger");
+    }
+
+    #[test]
+    fn ai_structural_formulaic_headings() {
+        let text = "# 簡介\n\n內容\n\n## 挑戰與未來展望\n\n更多內容\n\n## 結論與展望\n\n結語";
+        let issues = scan_structural(text);
+        let heading_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("公式化標題")))
+            .collect();
+        assert!(
+            !heading_issues.is_empty(),
+            "formulaic headings should trigger"
+        );
+    }
+
+    #[test]
+    fn ai_structural_list_density() {
+        let mut text = String::new();
+        for i in 0..10 {
+            if i < 5 {
+                text.push_str("- 第一項\n- 第二項\n- 第三項");
+            } else {
+                text.push_str("這是一段正常的段落文字。");
+            }
+            text.push_str("\n\n");
+        }
+        let issues = scan_structural(&text);
+        let list_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("列表")))
+            .collect();
+        assert!(
+            !list_issues.is_empty(),
+            "high list density should trigger: 5/10 = 50%"
+        );
+    }
+
+    #[test]
+    fn ai_structural_normal_text_no_false_positive() {
+        // Normal text should not trigger any structural patterns.
+        let text = "台灣的技術產業在近年來快速發展。半導體製造是其中的核心。\n\n\
+                    台積電作為全球最大的晶圓代工廠，在先進製程上保持領先。\n\n\
+                    未來的發展方向包括三奈米和二奈米製程的量產。\n\n\
+                    除了硬體之外，軟體生態系統也在蓬勃發展中。\n\n\
+                    這些發展為台灣的經濟帶來了穩定的成長動力。";
+        let issues = scan_structural(text);
+        assert!(
+            issues.is_empty(),
+            "normal text should not trigger structural patterns: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_zero_width_detected() {
+        let text = "正常文字\u{200B}中間\u{FEFF}結尾";
+        let issues = scan_structural(text);
+        let zw: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("零寬字元")))
+            .collect();
+        assert_eq!(zw.len(), 2, "should detect 2 zero-width artifacts: {zw:?}");
+        // Suggestions should be empty string for auto-removal.
+        for issue in &zw {
+            assert_eq!(issue.suggestions.len(), 1);
+            assert!(issue.suggestions[0].is_empty());
+        }
+    }
+
+    #[test]
+    fn ai_zero_width_excluded() {
+        let text = "正常\u{200B}文字";
+        // Exclude the zero-width space (byte offset 6 for 2 CJK chars = 6 bytes).
+        let excluded = vec![ByteRange { start: 6, end: 9 }];
+        let mut issues = Vec::new();
+        scan_ai_structural(text, &excluded, &mut issues, 1.0);
+        let zw: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("零寬字元")))
+            .collect();
+        assert!(zw.is_empty(), "excluded zero-width should not be detected");
+    }
+
+    #[test]
+    fn ai_zero_width_no_false_positive() {
+        let text = "完全正常的文字，沒有任何零寬字元。";
+        let issues = scan_structural(text);
+        let zw: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("零寬字元")))
+            .collect();
+        assert!(zw.is_empty(), "clean text should have no zero-width issues");
+    }
+
+    #[test]
+    fn ai_style_serde_round_trip() {
+        let json = serde_json::to_string(&IssueType::AiStyle).unwrap();
+        assert_eq!(json, "\"ai_style\"");
+        let back: IssueType = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, IssueType::AiStyle);
+    }
+
+    #[test]
+    fn ai_style_sort_order_after_grammar() {
+        assert!(IssueType::AiStyle.sort_order() > IssueType::Grammar.sort_order());
+    }
+
+    #[test]
+    fn is_para_excluded_empty_exclusions() {
+        // Empty exclusion list never excludes anything.
+        assert!(!is_para_excluded(0, 100, &[]));
+    }
+
+    #[test]
+    fn is_para_excluded_fully_inside() {
+        let excluded = vec![ByteRange { start: 0, end: 200 }];
+        assert!(is_para_excluded(10, 50, &excluded));
+    }
+
+    #[test]
+    fn is_para_excluded_partial_overlap_not_excluded() {
+        // Paragraph extends beyond the exclusion zone — should NOT be excluded.
+        let excluded = vec![ByteRange { start: 0, end: 30 }];
+        assert!(!is_para_excluded(10, 50, &excluded));
+    }
+
+    #[test]
+    fn structural_detectors_skip_excluded_paragraphs() {
+        // Build text with a list-heavy "paragraph" that is fully excluded.
+        // Without exclusion it would trigger list_density; with exclusion it should not.
+        let mut text = String::new();
+        let code_start = 0;
+        // Fake code block paragraph with list items.
+        for _ in 0..10 {
+            text.push_str("- list item in code\n");
+        }
+        let code_end = text.len();
+        text.push_str("\n\n");
+        // Add non-list prose paragraphs to meet minimum paragraph count.
+        for _ in 0..6 {
+            text.push_str("這是正常的段落文字，沒有列表項目，用來充數。\n\n");
+        }
+        let excluded = vec![ByteRange {
+            start: code_start,
+            end: code_end,
+        }];
+        let mut issues = Vec::new();
+        scan_ai_list_density(&text, &excluded, &mut issues, 1.0);
+        let list_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("含列表")))
+            .collect();
+        assert!(
+            list_issues.is_empty(),
+            "excluded code paragraph should not inflate list density: {list_issues:?}"
+        );
     }
 }

--- a/src/engine/scan/mod.rs
+++ b/src/engine/scan/mod.rs
@@ -56,6 +56,11 @@ use self::quotes::{fix_quote_pairing, validate_quote_hierarchy};
 pub struct ScanOutput {
     pub issues: Vec<Issue>,
     pub detected_script: ChineseType,
+    /// AI writing signature report.  Present only when AI scoring is
+    /// requested (editorial profile or explicit detect_ai/ai_score).
+    /// Note: no skip_serializing_if — bincode requires all fields present.
+    #[serde(default)]
+    pub ai_signature: Option<crate::engine::ai_score::AiSignatureReport>,
 }
 
 /// Content type for determining exclusion strategy.
@@ -410,7 +415,7 @@ fn punct_issue(offset: usize, found: &str, suggestion: &str, context: &str) -> I
 ///
 /// Combines content-pattern exclusions (URLs, paths, mentions) with
 /// structural exclusions appropriate to the content type and inline
-/// suppression markers.  Shared between CLI and MCP pipelines (20.4).
+/// suppression markers.  Shared between CLI and MCP pipelines.
 pub fn build_exclusions_for_content_type(text: &str, content_type: ContentType) -> Vec<ByteRange> {
     let mut excluded = build_excluded_ranges(text);
     match content_type {
@@ -716,7 +721,7 @@ impl Scanner {
         } else {
             ContentType::Plain
         };
-        self.scan_nfc_with_content_type(text, None, profile, content_type)
+        self.scan_nfc_with_content_type(text, None, profile.config(), content_type)
     }
 
     /// Scan YAML text with key-token exclusion.
@@ -725,7 +730,7 @@ impl Scanner {
     /// in key-value separators do not trigger false-positive colon warnings.
     /// YAML values after the colon are scanned normally as prose.
     pub fn scan_profiled_yaml(&self, text: &str, profile: Profile) -> ScanOutput {
-        self.scan_nfc_with_content_type(text, None, profile, ContentType::Yaml)
+        self.scan_nfc_with_content_type(text, None, profile.config(), ContentType::Yaml)
     }
 
     /// Scan with NFC normalization, reusing pre-built excluded ranges.
@@ -744,7 +749,18 @@ impl Scanner {
         profile: Profile,
         content_type: ContentType,
     ) -> ScanOutput {
-        self.scan_nfc_with_content_type(text, Some(excluded), profile, content_type)
+        self.scan_nfc_with_content_type(text, Some(excluded), profile.config(), content_type)
+    }
+
+    /// Like scan_with_prebuilt_excluded but with explicit ProfileConfig.
+    pub fn scan_with_prebuilt_excluded_config(
+        &self,
+        text: &str,
+        excluded: &[ByteRange],
+        cfg: ProfileConfig,
+        content_type: ContentType,
+    ) -> ScanOutput {
+        self.scan_nfc_with_content_type(text, Some(excluded), cfg, content_type)
     }
 
     /// Scan text using the content-type-aware exclusion strategy.
@@ -757,31 +773,38 @@ impl Scanner {
         content_type: ContentType,
         profile: Profile,
     ) -> ScanOutput {
-        self.scan_nfc_with_content_type(text, None, profile, content_type)
+        self.scan_nfc_with_content_type(text, None, profile.config(), content_type)
+    }
+
+    /// Scan with content-type-aware exclusions and explicit ProfileConfig.
+    /// Use this when the caller needs to override individual config flags
+    /// (e.g. detect_ai enabling density detection on a non-editorial profile).
+    pub fn scan_for_content_type_with_config(
+        &self,
+        text: &str,
+        content_type: ContentType,
+        cfg: ProfileConfig,
+    ) -> ScanOutput {
+        self.scan_nfc_with_content_type(text, None, cfg, content_type)
     }
 
     /// Core NFC-normalize → build exclusions → scan → remap pipeline.
-    ///
-    /// When `prebuilt_excluded` is Some and the text is already NFC, reuses
-    /// the caller's exclusion ranges. Otherwise builds fresh exclusions
-    /// appropriate to the content type.
     fn scan_nfc_with_content_type(
         &self,
         text: &str,
         prebuilt_excluded: Option<&[ByteRange]>,
-        profile: Profile,
+        cfg: ProfileConfig,
         content_type: ContentType,
     ) -> ScanOutput {
         let norm = normalize_nfc(text);
         let scan_text = &norm.text;
         let nfc_changed = !norm.offset_map.is_empty();
 
-        // Reuse prebuilt exclusions only when NFC didn't shift byte offsets.
         let mut output = match prebuilt_excluded {
-            Some(excl) if !nfc_changed => self.scan_with_excluded(scan_text, excl, profile),
+            Some(excl) if !nfc_changed => self.scan_with_config(scan_text, excl, cfg),
             _ => {
                 let excl = build_exclusions_for_content_type(scan_text, content_type);
-                self.scan_with_excluded(scan_text, &excl, profile)
+                self.scan_with_config(scan_text, &excl, cfg)
             }
         };
 
@@ -821,6 +844,7 @@ impl Scanner {
             return ScanOutput {
                 issues: Vec::new(),
                 detected_script: ChineseType::Unknown,
+                ai_signature: None,
             };
         }
 
@@ -867,21 +891,59 @@ impl Scanner {
             grammar::scan_grammar(text, excluded, &mut issues);
         }
 
-        // Fix CN quotation mark pairing with depth-based nesting (2.4):
+        // AI writing detection grammar checks: semantic safety words,
+        // copula avoidance, passive voice overuse.  Separate from base grammar
+        // checks — gated by ai_semantic_safety profile flag.
+        if cfg.ai_semantic_safety {
+            grammar::scan_ai_grammar(text, excluded, &mut issues);
+        }
+
+        // Structural AI pattern detection: binary contrast density,
+        // paragraph endings, dash overuse, formulaic headings, list density.
+        if cfg.ai_structural_patterns {
+            grammar::scan_ai_structural(text, excluded, &mut issues, cfg.ai_threshold_multiplier);
+        }
+
+        // Density-based AI phrase detection: post-scan frequency pass counts
+        // tracked phrases across the full document and flags when density
+        // exceeds per-phrase thresholds.  Distinct from per-occurrence filler
+        // detection — catches the statistical signature of AI writing.
+        if cfg.ai_density_detection {
+            grammar::scan_ai_density(text, excluded, &mut issues, cfg.ai_threshold_multiplier);
+        }
+
+        // Fix CN quotation mark pairing with depth-based nesting:
         // well-formed quotes use character-based depth tracking; misordered
         // or all-same-char quotes fall back to positional alternation.
         // Paragraph breaks reset nesting depth.
         fix_quote_pairing(text, &mut issues);
 
-        // Validate structural nesting of existing TW bracket quotes (12.1):
+        // Validate structural nesting of existing TW bracket quotes:
         // checks for mismatched, interleaved, and unclosed quotes per paragraph.
         validate_quote_hierarchy(text, excluded, &mut issues);
+
+        // Compute AI signature score when any AI detection flag is active.
+        let ai_signature = if cfg.ai_filler_detection
+            || cfg.ai_semantic_safety
+            || cfg.ai_density_detection
+            || cfg.ai_structural_patterns
+        {
+            crate::engine::ai_score::compute_ai_score(
+                text,
+                &issues,
+                excluded,
+                cfg.ai_threshold_multiplier,
+            )
+        } else {
+            None
+        };
 
         // Skip O(n) line index construction when no issues found (common case).
         if issues.is_empty() {
             return ScanOutput {
                 issues,
                 detected_script: zh_type,
+                ai_signature,
             };
         }
 
@@ -893,7 +955,7 @@ impl Scanner {
             issue.col = col;
         }
 
-        // Deterministic output contract (1.7): issues are sorted by byte offset
+        // Deterministic output contract: issues are sorted by byte offset
         // ascending, then severity descending, then rule_type discriminant for
         // stable, diffable output.
         issues.sort_by(|a, b| {
@@ -906,6 +968,7 @@ impl Scanner {
         ScanOutput {
             issues,
             detected_script: zh_type,
+            ai_signature,
         }
     }
 }

--- a/src/engine/scan/punctuation.rs
+++ b/src/engine/scan/punctuation.rs
@@ -118,7 +118,7 @@ impl Scanner {
                     issues.push(punct_issue(i, found, suggestion, context));
                 }
                 b':' => {
-                    // Colon enforcement controlled by profile config (2.2).
+                    // Colon enforcement controlled by profile config.
                     if !cfg.colon_enforcement {
                         continue;
                     }
@@ -206,7 +206,7 @@ impl Scanner {
         }
     }
 
-    /// Enumeration comma (dunhao) detection (2.3).
+    /// Enumeration comma (dunhao) detection.
     ///
     /// Scans for sequences of short items separated by full-width ， that
     /// likely represent coordinate lists and should use 、 instead.
@@ -355,7 +355,7 @@ impl Scanner {
         }
     }
 
-    /// Range indicator normalization (2.5).
+    /// Range indicator normalization.
     ///
     /// Detects ~ or - used as range indicators in CJK context and suggests
     /// the profile-appropriate full-width form: ～ (wave dash) for prose,

--- a/src/engine/scan/quotes.rs
+++ b/src/engine/scan/quotes.rs
@@ -8,7 +8,7 @@ use crate::rules::ruleset::{Issue, Severity};
 
 use super::{has_paragraph_break, punct_issue_sev, split_paragraphs};
 
-/// Fix CN quotation mark pairing with depth-based nesting (2.4).
+/// Fix CN quotation mark pairing with depth-based nesting.
 ///
 /// CN text uses \u{201c} (opening) and \u{201d} (closing).  TW text uses
 /// 「 and 」 at depth 0, 『 and 』 at depth 1, alternating for deeper nesting.
@@ -113,7 +113,7 @@ pub(crate) fn fix_quote_pairing(text: &str, issues: &mut [Issue]) {
     //  this is a no-op unless future logic needs to adjust them.)
 }
 
-/// Stack-based quote hierarchy validator (12.1).
+/// Stack-based quote hierarchy validator.
 ///
 /// Walks text (skipping exclusion zones) and validates structural nesting of
 /// CJK quote marks: 「」 (primary), 『』 (secondary), 《》 (book title).

--- a/src/engine/scan/spelling.rs
+++ b/src/engine/scan/spelling.rs
@@ -130,6 +130,12 @@ impl Scanner {
             return;
         }
 
+        // AI filler rules are profile-gated: only fire when ai_filler_detection
+        // is enabled (de_ai / strict_moe profiles).
+        if rule.rule_type == RuleType::AiFiller && !cfg.ai_filler_detection {
+            return;
+        }
+
         // Political stance filtering: suppress political_coloring rules
         // based on the active stance sub-profile.
         if rule.rule_type == RuleType::PoliticalColoring

--- a/src/engine/segment.rs
+++ b/src/engine/segment.rs
@@ -2,7 +2,7 @@
 //
 // Scope: word boundaries only — NOT a full Chinese NLP toolkit. No POS
 // tagging, no parsing. Designed for heuristic analysis in dunhao detection
-// (2.3), ambiguity resolution (4.3), and variant context awareness (3.1).
+// dunhao detection, ambiguity resolution, and variant context awareness.
 //
 // Algorithm: MMSEG (Chih-Hao Tsai, 1996) 4-rule chunk scoring.
 // At each position, generate candidate 3-word chunks (up to max_word_len
@@ -892,7 +892,7 @@ mod tests {
         assert!(!token_contains_clue("下拉", "下拉菜單"));
     }
 
-    // --- General vocabulary supplement (17.2) tests ---
+    // --- General vocabulary supplement tests ---
 
     /// General vocab is included in from_rules() dict.
     #[test]

--- a/src/fixer.rs
+++ b/src/fixer.rs
@@ -171,10 +171,26 @@ pub fn apply_fixes_with_context(
         // Orthographic issue types can be fixed mechanically (no lexical
         // ambiguity).  Lexical types (CrossStrait, Typo, PoliticalColoring,
         // Confusable) need progressively higher fix tiers.
+        // AiStyle zero-width artifact removal (empty suggestion on invisible
+        // chars only) is safe for orthographic tier -- deletes invisible junk.
+        // The found-content check prevents future AiStyle rules with empty
+        // suggestions from being misclassified as orthographic.
+        // Narrower check than ai_score::is_zero_width: only ZWSP (U+200B)
+        // and mid-text BOM (U+FEFF) are pure tokenizer junk safe to strip
+        // unconditionally. ZWJ/ZWNJ/LRM/RLM have legitimate uses in bidi
+        // text and emoji sequences; the broader set in ai_score.rs is
+        // appropriate for detection/scoring but too aggressive for fixing.
+        let ai_zero_width_removal = issue.rule_type == IssueType::AiStyle
+            && issue.suggestions.len() == 1
+            && issue.suggestions[0].is_empty()
+            && !issue.found.is_empty()
+            && issue.found.chars().all(|ch| {
+                ch == '\u{200B}' || (ch == '\u{FEFF}' && issue.offset > 0) // preserve file-start BOM
+            });
         let orthographic = matches!(
             issue.rule_type,
             IssueType::Punctuation | IssueType::Case | IssueType::Variant | IssueType::Grammar
-        );
+        ) || ai_zero_width_removal;
 
         // Orthographic tier: skip all lexical issues.
         if mode == FixMode::Orthographic && !orthographic {
@@ -609,6 +625,51 @@ mod tests {
         )];
         let result = apply_fixes(text, &issues, FixMode::LexicalContextual, &[]);
         assert_eq!(result.text, text); // unchanged -- no segmenter, cannot verify clues
+        assert_eq!(result.skipped, 1);
+    }
+
+    // -- AiStyle tier exclusion tests --
+
+    fn make_ai_style_issue(offset: usize, found: &str, suggestions: Vec<&str>) -> Issue {
+        Issue::new(
+            offset,
+            found.len(),
+            found,
+            suggestions.into_iter().map(String::from).collect(),
+            IssueType::AiStyle,
+            Severity::Info,
+        )
+    }
+
+    #[test]
+    fn orthographic_skips_ai_style_issues() {
+        let text = "這個系統作為核心元件";
+        let offset = text.find("作為").unwrap();
+        let issues = vec![make_ai_style_issue(offset, "作為", vec!["是"])];
+        let result = apply_fixes(text, &issues, FixMode::Orthographic, &[]);
+        assert_eq!(result.text, text); // unchanged — AiStyle not orthographic
+        assert_eq!(result.skipped, 1);
+    }
+
+    #[test]
+    fn lexical_safe_applies_single_suggestion_ai_style() {
+        // Semantic safety words (意味著→表示) have a single suggestion
+        // and are eligible for lexical_safe auto-fix.
+        let text = "這個定義意味著所有值";
+        let offset = text.find("意味著").unwrap();
+        let issues = vec![make_ai_style_issue(offset, "意味著", vec!["表示"])];
+        let result = apply_fixes(text, &issues, FixMode::LexicalSafe, &[]);
+        assert_eq!(result.text, "這個定義表示所有值");
+        assert_eq!(result.applied, 1);
+    }
+
+    #[test]
+    fn lexical_safe_skips_ai_style_no_suggestions() {
+        let text = "這意味著很多事情";
+        let offset = text.find("意味著").unwrap();
+        let issues = vec![make_ai_style_issue(offset, "意味著", vec![])];
+        let result = apply_fixes(text, &issues, FixMode::LexicalSafe, &[]);
+        assert_eq!(result.text, text); // unchanged — no suggestion
         assert_eq!(result.skipped, 1);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn main() -> Result<()> {
     //   zhtw-mcp --pack <name>                  — activate a rule pack (repeatable)
     //   zhtw-mcp lint <file|--> [--format json|compact]  — lint file(s) or stdin
     //                           [--max-errors N]
-    //                           [--profile P]
+    //                           [--profile P] [--detect-ai]
     //                           [--content-type plain|markdown|yaml]
     //   zhtw-mcp setup <host>                   — generate agentic editor integration config
     //   zhtw-mcp pack import <file>             — install a pack
@@ -77,6 +77,8 @@ fn main() -> Result<()> {
     let mut fix_mode: Option<zhtw_mcp::fixer::FixMode> = None;
     let mut dry_run = false;
     let mut explain = false;
+    let mut detect_ai = false;
+    let mut ai_threshold_multiplier: f32 = 1.0;
     let mut baseline_path: Option<PathBuf> = None;
     let mut update_baseline = false;
     let mut diff_from: Option<String> = None;
@@ -202,6 +204,27 @@ fn main() -> Result<()> {
                                     .clone(),
                             );
                         }
+                        "--detect-ai" => {
+                            detect_ai = true;
+                            // Peek at next arg for optional threshold level.
+                            if let Some(next) = args.get(i + 1) {
+                                match next.as_str() {
+                                    "low" => {
+                                        ai_threshold_multiplier = 0.5;
+                                        i += 1;
+                                    }
+                                    "medium" => {
+                                        ai_threshold_multiplier = 1.0;
+                                        i += 1;
+                                    }
+                                    "high" => {
+                                        ai_threshold_multiplier = 1.5;
+                                        i += 1;
+                                    }
+                                    _ => {} // not a threshold level, leave for next iteration
+                                }
+                            }
+                        }
                         #[cfg(feature = "translate")]
                         "--verify" => {
                             verify = true;
@@ -304,8 +327,11 @@ fn main() -> Result<()> {
     let packs_dir = packs_dir.unwrap_or_else(zhtw_mcp::rules::store::default_packs_dir);
 
     // Setup subcommand: generate integration config for a host editor.
-    if let Some(host_str) = setup_host {
-        return run_setup(&host_str);
+    if let Some(ref host_str) = setup_host {
+        if host_str == "translation-guide" || host_str == "translation_guide" {
+            return run_translation_guide();
+        }
+        return run_setup(host_str);
     }
 
     // Pack subcommand: manage rule packs.
@@ -377,6 +403,8 @@ fn main() -> Result<()> {
             diff_from: diff_from.as_deref(),
             #[cfg(feature = "translate")]
             verify,
+            detect_ai,
+            ai_threshold_multiplier,
         });
     }
 
@@ -446,6 +474,8 @@ struct LintBatchParams<'a> {
     diff_from: Option<&'a str>,
     #[cfg(feature = "translate")]
     verify: bool,
+    detect_ai: bool,
+    ai_threshold_multiplier: f32,
 }
 
 fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
@@ -455,6 +485,16 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
         .profile_name
         .map(zhtw_mcp::rules::ruleset::Profile::from_str_lossy)
         .unwrap_or(zhtw_mcp::rules::ruleset::Profile::Default);
+
+    // Build effective config: profile base + detect_ai override.
+    let mut cfg = profile.config();
+    if params.detect_ai {
+        cfg.ai_filler_detection = true;
+        cfg.ai_semantic_safety = true;
+        cfg.ai_density_detection = true;
+        cfg.ai_structural_patterns = true;
+        cfg.ai_threshold_multiplier = params.ai_threshold_multiplier;
+    }
 
     // Build scanner once for all files, merging overrides + active packs.
     let ruleset = zhtw_mcp::rules::loader::load_embedded_ruleset()?;
@@ -547,6 +587,8 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
             profile: profile.name().to_owned(),
             content_type: format!("{content_type:?}"),
             fix_mode: fix_mode_str.clone(),
+            detect_ai: params.detect_ai,
+            ai_threshold: format!("{:.1}", params.ai_threshold_multiplier),
         };
 
         // Open file via fd, stat from the fd (TOCTOU-safe).
@@ -599,7 +641,7 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
             let output = match content_hit {
                 Some(hit) => hit.output,
                 None => {
-                    let o = scanner.scan_for_content_type(&text, content_type, profile);
+                    let o = scanner.scan_for_content_type_with_config(&text, content_type, cfg);
                     if let Some(Ok(mut c)) = scan_cache.as_ref().map(|mtx| mtx.lock()) {
                         let mtime = zhtw_mcp::cache::mtime_secs(&meta);
                         c.put(
@@ -646,7 +688,7 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
         if input_was_sc {
             text = s2t.convert(&text);
         }
-        let output = scanner.scan_for_content_type(&text, content_type, profile);
+        let output = scanner.scan_for_content_type_with_config(&text, content_type, cfg);
 
         Ok((text, input_was_sc, output, content_type))
     };
@@ -677,10 +719,11 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
         } else {
             output.detected_script.name()
         };
+        let mut ai_signature = output.ai_signature;
         let issues = output.issues;
 
         let scan = |input: &str| -> zhtw_mcp::engine::scan::ScanOutput {
-            scanner.scan_for_content_type(input, content_type, profile)
+            scanner.scan_for_content_type_with_config(input, content_type, cfg)
         };
 
         // Apply fixes if requested.
@@ -735,11 +778,21 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
         }
 
         // Count remaining issues after fix/S2T (rescan converted text).
+        // Single rescan serves both issue reporting and AI signature refresh.
         let report_issues = if has_text_changes && !params.dry_run {
             let rescan_text = fix_result
                 .as_ref()
                 .map_or(text.as_str(), |f| f.text.as_str());
-            let mut rescan = scan(rescan_text).issues;
+            let rescan_output = scan(rescan_text);
+            // Refresh AI signature from the fixed text (avoids a second scan).
+            let ai_active = cfg.ai_filler_detection
+                || cfg.ai_semantic_safety
+                || cfg.ai_density_detection
+                || cfg.ai_structural_patterns;
+            if ai_active {
+                ai_signature = rescan_output.ai_signature;
+            }
+            let mut rescan = rescan_output.issues;
             if let Some(ref fix) = fix_result {
                 // Suppress convergent-chain noise from the fixer's own replacements.
                 zhtw_mcp::fixer::suppress_convergent_issues(&mut rescan, &fix.applied_fixes);
@@ -824,6 +877,9 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
                     output["fixes_applied"] = serde_json::json!(fix.applied);
                     output["fixes_skipped"] = serde_json::json!(fix.skipped);
                 }
+                if let Some(ref sig) = ai_signature {
+                    output["ai_signature"] = serde_json::json!(sig);
+                }
                 if multi {
                     all_file_results.push(output);
                 } else {
@@ -884,6 +940,23 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
                         report_issues.len(),
                         c.reset
                     );
+                }
+                // AI signature score (when computed).
+                if let Some(ref sig) = ai_signature {
+                    let level = if sig.score >= 0.7 {
+                        "high"
+                    } else if sig.score >= 0.4 {
+                        "medium"
+                    } else {
+                        "low"
+                    };
+                    eprintln!(
+                        "{prefix}{}AI score:{} {:.2} ({level})",
+                        c.cyan, c.reset, sig.score
+                    );
+                    for signal in &sig.top_signals {
+                        eprintln!("  {}{signal}{}", c.dim, c.reset);
+                    }
                 }
             }
             LintFormat::Compact => {
@@ -1327,6 +1400,12 @@ fn run_setup(host_str: &str) -> Result<()> {
     };
 
     let output = setup::generate_for_host(host);
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn run_translation_guide() -> Result<()> {
+    let output = zhtw_mcp::mcp::setup::generate_translation_guide();
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())
 }

--- a/src/mcp/prompts.rs
+++ b/src/mcp/prompts.rs
@@ -135,6 +135,9 @@ fn get_lint_natural(args: &std::collections::HashMap<String, String>) -> PromptG
 From the instruction, extract:
 - `fix_mode`: "lexical_safe" if the user asks to fix/correct/repair; "lexical_contextual" if they want all fixes; "orthographic" for punctuation/spacing only; "none" otherwise
 - `profile`: "strict_moe" if they mention MoE/standard forms/variants; "ui_strings" for software UI; "default" otherwise
+- `detect_ai`: true if they mention AI writing/filler/naturalness review (can combine with any profile); false otherwise
+- `ai_threshold`: "low" if they want sensitive/strict AI detection; "high" if they want conservative/lenient AI detection; "medium" (default) otherwise. Only meaningful when `detect_ai` is true.
+- `max_errors`: integer if the user specifies a rejection threshold (e.g. "reject if more than 3 errors", "no errors allowed" = 0). Omit if no gate requested.
 - `political_stance`: "neutral" if they ask for neutral/apolitical; "international" for international style; "roc_centric" (default)
 - `ignore_terms`: any terms the user explicitly says to skip/ignore
 - `content_type`: "markdown" if the text contains Markdown; "plain" otherwise
@@ -179,7 +182,7 @@ fn get_editorial_review(args: &std::collections::HashMap<String, String>) -> Pro
 ## Workflow
 
 For each iteration (up to {max_iterations} total):
-1. Call `zhtw` with the current text: `{{ "text": "...", "fix_mode": "lexical_safe", "explain": true, "output": "compact", "content_type": "markdown" }}`
+1. Call `zhtw` with the current text: `{{ "text": "...", "detect_ai": true, "fix_mode": "lexical_safe", "explain": true, "output": "compact", "content_type": "markdown" }}`
 2. If `accepted: true` with 0 errors, the text is finalized. Present the clean text.
 3. If issues remain:
    a. Explain each issue in context — why MoE prefers the standard form, cultural background

--- a/src/mcp/sampling.rs
+++ b/src/mcp/sampling.rs
@@ -176,7 +176,7 @@ impl<'a> SamplingBridge<'a> {
         })
     }
 
-    /// Send a bulk anchor-confirmation request for multiple terms at once (32.6).
+    /// Send a bulk anchor-confirmation request for multiple terms at once.
     ///
     /// Sends a single `sampling/createMessage` with indexed terms as a JSON array.
     /// Asks the LLM to return a JSON object mapping each index to true/false.

--- a/src/mcp/setup.rs
+++ b/src/mcp/setup.rs
@@ -19,7 +19,7 @@ Read `zh-tw://style-guide/moe` resource for full conventions.
 
 - Terms: 軟體 (not 軟件), 資訊 (not 信息), 預設 (not 默認)
 - Punctuation: full-width ，。：；！？ in CJK prose; 「」 quotes, 『』 nested
-- Profiles: `default` | `strict_moe` (char variants) | `ui_strings` (relaxed)
+- Profiles: `default` | `strict_moe` (char variants) | `ui_strings` (relaxed) | `editorial` (AI writing review)
 
 ### Quality Gate
 
@@ -195,7 +195,8 @@ Use `zhtw` for linting, fixing, and gating zh-TW text:
 ## Profiles
 - `default`: Standard vocabulary + punctuation
 - `strict_moe`: Full MoE enforcement including character variants
-- `ui_strings`: Relaxed for software UI (half-width colons allowed)"#
+- `ui_strings`: Relaxed for software UI (half-width colons allowed)
+- `editorial`: AI writing review — detects filler phrases, semantic safety words, copula/passive overuse"#
         .to_string()
 }
 
@@ -208,7 +209,7 @@ The zhtw-mcp MCP server provides automated zh-TW linting and fixing.
 
 ## MCP Tool: zhtw
 - `zhtw({ "text": "...", "fix_mode": "lexical_safe", "max_errors": 0 })`
-- Profiles: default, strict_moe, ui_strings
+- Profiles: default, strict_moe, ui_strings, editorial (AI writing review)
 - Content types: plain, markdown
 
 ## Taiwan-Standard Terms
@@ -237,7 +238,7 @@ zhtw-mcp provides `zhtw` for Traditional Chinese (Taiwan) text enforcement.
 ## Quick Reference
 - Terms: 軟體/資訊/預設/程式/網路/硬體/品質/螢幕 (TW standard)
 - Punctuation: ，。：；！？ (full-width in CJK), 「」『』 (quotes)
-- Profiles: default | strict_moe | ui_strings"#
+- Profiles: default | strict_moe | ui_strings | editorial (AI writing review)"#
         .to_string()
 }
 
@@ -273,7 +274,7 @@ The single unified tool for linting, fixing, and gating zh-TW text.
 | text | string | (required) | Text to check |
 | fix_mode | string | "none" | "none", "orthographic", "lexical_safe", or "lexical_contextual" |
 | max_errors | integer | (none) | Gate: reject if errors exceed this |
-| profile | string | "default" | "default", "strict_moe", "ui_strings" |
+| profile | string | "default" | "default", "strict_moe", "ui_strings", "editorial" |
 | content_type | string | "plain" | "plain" or "markdown" |
 | political_stance | string | "roc_centric" | "roc_centric", "international", "neutral" |
 | ignore_terms | array | [] | Terms to downgrade to Info severity |
@@ -390,6 +391,92 @@ pub fn generate_for_host(host: Host) -> serde_json::Value {
     }
 }
 
+/// Generate a zh-TW translation style guide as a JSON setup object.
+///
+/// Returns a `serde_json::Value` following the same JSON contract as
+/// `generate_for_host()`: {host, file, instruction, content}.
+/// Designed to be injected into LLM system prompts to prevent common
+/// AI writing artifacts at generation time. Covers: cross-strait
+/// terminology, semantic safety alternatives, nominalization avoidance,
+/// filler prohibition, and verb-driven syntax.
+pub fn generate_translation_guide() -> serde_json::Value {
+    let guide = translation_guide_text();
+    serde_json::json!({
+        "host": "translation-guide",
+        "file": "(system prompt injection)",
+        "instruction": "Inject the following into your LLM system prompt:",
+        "content": guide,
+    })
+}
+
+/// The raw translation guide text content.
+fn translation_guide_text() -> String {
+    r#"# 繁體中文（台灣）翻譯風格指南
+
+## 目的
+本指南用於 LLM 系統提示，確保產出的繁體中文文本符合台灣教育部標準，
+避免常見的 AI 翻譯偽跡（translation artifact）。
+
+## 詞彙規範
+
+### 跨海峽術語
+使用台灣慣用譯名，避免中國大陸用語：
+- 軟體（非「軟件」）、硬體（非「硬件」）
+- 程式（非「程序」，指 program）、程式碼（非「代碼」）
+- 記憶體（非「內存」）、網路（非「網絡」）
+- 資料庫（非「數據庫」）、資料（非「數據」，指 data）
+- 伺服器（非「服務器」）、瀏覽器（非簡體「浏览器」）
+- 滑鼠（非「鼠標」）、列印（非「打印」）
+- 預設（非「默認」）、支援（非「支持」，指 support）
+
+### 語意安全詞
+避免直接翻譯「means」為「意味著」。根據語境選擇：
+- 定義語境 →「表示」（X 表示 Y）
+- 因果語境 →「代表」（這代表我們需要……）
+- 解釋語境 →「也就是說」
+
+### 避免繁複動詞
+- 避免「作為」「標誌著」「充當」等書面語堆疊，改以簡潔句式表達
+- 避免「擁有」「設有」等冗餘動詞（技術文件語境），直接敘述
+- 用主動語態取代「被廣泛使用」→「廣泛使用」
+
+## AI 寫作偽跡禁忌
+
+### 禁用填充詞
+以下片語在 AI 生成文本中出現頻率異常高，應避免或替換：
+- ❌ 值得注意的是 → ✅ 直接陳述事實
+- ❌ 需要注意的是 → ✅ 直接陳述事實
+- ❌ 更重要的是 → ✅ 精簡為直述句
+- ❌ 在某種程度上 → ✅ 刪除或改為具體程度
+- ❌ 不容忽視 → ✅ 用具體影響取代
+- ❌ 深刻影響 → ✅ 說明具體影響
+
+### 禁用說教句式
+- ❌ 讓我們……（祈使句開頭）
+- ❌ 我們需要理解……（居高臨下）
+- ❌ ……是非常重要的（空泛強調）
+
+### 結構限制
+- 避免過度使用列表：列表段落不應超過全文 40%
+- 避免公式化段落結尾：「這……證明了」「正是這……讓」
+- 避免二元對比堆疊：同一段落不要連續使用「雖然……但」「不僅……更」
+- 段落內破折號（——）不超過 2 個
+- 避免公式化標題：「挑戰與未來展望」「結論與展望」「核心優勢」
+
+## 標點符號
+- 使用全形標點：，。！？；：（）「」『』
+- 引號層級：外層「」，內層『』
+- 刪節號：使用「……」（兩個 U+2026），非「...」
+- 數字範圍：使用「～」或「–」，非「-」
+
+## 語法
+- CJK 與半形字母/數字間加一個半形空格
+- 避免 的/地/得 誤用
+- 句子以動詞驅動，減少名詞化（nominalization）
+"#
+    .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -483,6 +570,18 @@ mod tests {
         assert!(instructions.contains("max_errors"));
         assert!(instructions.contains("軟體"));
         assert!(instructions.contains("full-width"));
+    }
+
+    #[test]
+    fn translation_guide_json_contract() {
+        let guide = generate_translation_guide();
+        assert!(guide.is_object());
+        assert_eq!(guide["host"], "translation-guide");
+        assert_eq!(guide["file"], "(system prompt injection)");
+        let content = guide["content"].as_str().unwrap();
+        assert!(content.contains("繁體中文"));
+        assert!(content.contains("值得注意的是"));
+        assert!(content.len() > 500);
     }
 
     #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -307,18 +307,47 @@ impl Server {
         let verify = parse_verify(args);
 
         let stance_name = stance.unwrap_or(PoliticalStance::RocCentric).name();
+        let detect_ai = args
+            .get("detect_ai")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let ai_threshold = args.get("ai_threshold").and_then(|v| v.as_str());
+
+        // Build effective config: profile base + stance override + detect_ai override.
+        let mut cfg = profile.config();
+        if let Some(st) = stance {
+            cfg = cfg.with_stance(st);
+        }
+        if detect_ai {
+            cfg.ai_filler_detection = true;
+            cfg.ai_semantic_safety = true;
+            cfg.ai_density_detection = true;
+            cfg.ai_structural_patterns = true;
+            // Apply threshold level: low=0.5 (sensitive), medium=1.0, high=1.5 (conservative).
+            cfg.ai_threshold_multiplier = match ai_threshold {
+                Some("low") => 0.5,
+                Some("medium") | None => 1.0,
+                Some("high") => 1.5,
+                Some(other) => {
+                    return CallToolResult::error(format!(
+                        "invalid ai_threshold: '{other}'. Expected: low, medium, high"
+                    ));
+                }
+            };
+        }
 
         match fix_mode {
             FixMode::None => {
                 // Lint-only path.
-                let output = self
-                    .scanner
-                    .scan_for_content_type(text, content_type, profile);
+                let output =
+                    self.scanner
+                        .scan_for_content_type_with_config(text, content_type, cfg);
                 let detected_script = if s2t_converted.is_some() {
                     "simplified"
                 } else {
                     output.detected_script.name()
                 };
+                let ai_signature = output.ai_signature;
                 let mut issues = output.issues;
                 if let Some(st) = stance {
                     filter_by_stance(&mut issues, st);
@@ -359,16 +388,17 @@ impl Server {
                     fix_records: &[],
                     #[cfg(feature = "translate")]
                     calibrate_result,
+                    ai_signature: ai_signature.as_ref(),
                 })
             }
 
             mode @ (FixMode::Orthographic | FixMode::LexicalSafe | FixMode::LexicalContextual) => {
                 // Fix path: scan, apply fixes, re-scan for residual issues.
                 let excluded = build_exclusions_for_content_type(text, content_type);
-                let scan_out = self.scanner.scan_with_prebuilt_excluded(
+                let scan_out = self.scanner.scan_with_prebuilt_excluded_config(
                     text,
                     &excluded,
-                    profile,
+                    cfg,
                     content_type,
                 );
                 let detected_script = if s2t_converted.is_some() {
@@ -431,11 +461,14 @@ impl Server {
                     Some(self.scanner.segmenter()),
                 );
 
-                // Re-scan after fixes.
-                let mut remaining_issues = self
-                    .scanner
-                    .scan_for_content_type(&fix_result.text, content_type, profile)
-                    .issues;
+                // Re-scan after fixes — use post-fix ai_signature, not pre-fix.
+                let rescan_out = self.scanner.scan_for_content_type_with_config(
+                    &fix_result.text,
+                    content_type,
+                    cfg,
+                );
+                let ai_signature = rescan_out.ai_signature;
+                let mut remaining_issues = rescan_out.issues;
                 if let Some(st) = stance {
                     filter_by_stance(&mut remaining_issues, st);
                 }
@@ -498,6 +531,7 @@ impl Server {
                     fix_records: &fix_result.applied_fixes,
                     #[cfg(feature = "translate")]
                     calibrate_result,
+                    ai_signature: ai_signature.as_ref(),
                 })
             }
         }
@@ -645,7 +679,7 @@ fn parse_profile(args: &Value) -> Result<Profile, CallToolResult> {
         None => Ok(Profile::Default),
         Some(s) => Profile::from_str_strict(s).ok_or_else(|| {
             CallToolResult::error(format!(
-                "invalid 'profile': '{s}' (expected 'default', 'strict_moe', or 'ui_strings')"
+                "invalid 'profile': '{s}' (expected 'default', 'strict_moe', 'ui_strings', or 'editorial')"
             ))
         }),
     }
@@ -713,6 +747,10 @@ enum OutputMode {
     /// Eliminates JSON syntax tax (repeated keys, braces, quotes) that
     /// inflates BPE token count by 40-60% with zero semantic value.
     Tabular,
+    /// AI summary only: issue counts + AI signature report.
+    /// No individual issues, no text. Lets downstream tools quickly
+    /// decide whether to trigger a full review.
+    Summary,
 }
 
 /// Parse the optional "output" mode from tool arguments.
@@ -723,9 +761,10 @@ fn parse_output_mode(args: &Value, default: OutputMode) -> Result<OutputMode, Ca
         Some("compact") => Ok(OutputMode::Compact),
         Some("full") => Ok(OutputMode::Full),
         Some("tabular") => Ok(OutputMode::Tabular),
+        Some("summary") => Ok(OutputMode::Summary),
         None => Ok(default),
         Some(other) => Err(CallToolResult::error(format!(
-            "invalid 'output': '{other}' (expected 'full', 'compact', or 'tabular')"
+            "invalid 'output': '{other}' (expected 'full', 'compact', 'tabular', or 'summary')"
         ))),
     }
 }
@@ -868,11 +907,22 @@ fn build_explanation(issue: &Issue) -> Option<String> {
                 ));
             }
         }
+        IssueType::AiStyle => {
+            if let Some(ctx) = &issue.context {
+                parts.push(format!("'{}' — {}.", issue.found, ctx));
+            }
+            if !issue.suggestions.is_empty() {
+                let sugg = issue.suggestions.join(" / ");
+                parts.push(format!("Suggested: {sugg}."));
+            } else {
+                parts.push("Consider removing or rephrasing.".to_string());
+            }
+        }
     }
 
-    // Grammar issues already embed context in the main explanation;
+    // Grammar and AiStyle issues already embed context in the main explanation;
     // skip the shared Context: append to avoid duplication.
-    if issue.rule_type != IssueType::Grammar {
+    if !matches!(issue.rule_type, IssueType::Grammar | IssueType::AiStyle) {
         if let Some(ctx) = &issue.context {
             parts.push(format!("Context: {ctx}"));
         }
@@ -1009,6 +1059,8 @@ struct FullOutput<'a> {
     #[cfg(feature = "translate")]
     #[serde(skip_serializing_if = "Option::is_none")]
     verify: Option<VerifyStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ai_signature: Option<&'a crate::engine::ai_score::AiSignatureReport>,
 }
 
 /// Compact tool response (serialized directly, no intermediate Value).
@@ -1031,6 +1083,20 @@ struct CompactOutput<'a> {
     #[cfg(feature = "translate")]
     #[serde(skip_serializing_if = "Option::is_none")]
     verify: Option<VerifyStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ai_signature: Option<&'a crate::engine::ai_score::AiSignatureReport>,
+}
+
+/// Summary-only output: issue counts + AI signature, no individual issues or text.
+#[derive(Serialize)]
+struct SummaryOutput<'a> {
+    accepted: bool,
+    summary: &'a IssueSummary,
+    gate: GateInfo,
+    profile: &'a str,
+    detected_script: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ai_signature: Option<&'a crate::engine::ai_score::AiSignatureReport>,
 }
 
 /// Count issues by severity.
@@ -1074,6 +1140,7 @@ struct CheckOutputParams<'a> {
     fix_records: &'a [crate::fixer::AppliedFix],
     #[cfg(feature = "translate")]
     calibrate_result: Option<crate::engine::translate::CalibrateResult>,
+    ai_signature: Option<&'a crate::engine::ai_score::AiSignatureReport>,
 }
 
 /// Build the unified zhtw JSON response and wrap it in a CallToolResult.
@@ -1152,6 +1219,7 @@ fn build_check_output(params: &CheckOutputParams<'_>) -> CallToolResult {
                 fix_output_mode: fix_mode_label,
                 #[cfg(feature = "translate")]
                 verify,
+                ai_signature: params.ai_signature,
             };
             serialize_output(&output)
         }
@@ -1174,6 +1242,7 @@ fn build_check_output(params: &CheckOutputParams<'_>) -> CallToolResult {
                 fix_output_mode: fix_mode_label,
                 #[cfg(feature = "translate")]
                 verify,
+                ai_signature: params.ai_signature,
             };
             serialize_output(&output)
         }
@@ -1189,6 +1258,17 @@ fn build_check_output(params: &CheckOutputParams<'_>) -> CallToolResult {
                 fix_mode_label,
             );
             Ok(tsv)
+        }
+        OutputMode::Summary => {
+            let output = SummaryOutput {
+                accepted,
+                summary: &summary,
+                gate,
+                profile: params.profile.name(),
+                detected_script: params.detected_script,
+                ai_signature: params.ai_signature,
+            };
+            serialize_output(&output)
         }
     };
 
@@ -1614,7 +1694,7 @@ fn tool_definitions() -> Vec<ToolDef> {
             props.insert("max_warnings".into(), json!({ "type": "integer" }));
             props.insert("profile".into(), json!({
                 "type": "string",
-                "enum": ["default", "strict_moe", "ui_strings"]
+                "enum": ["default", "strict_moe", "ui_strings", "editorial"]
             }));
             props.insert("content_type".into(), json!({
                 "type": "string",
@@ -1641,7 +1721,17 @@ fn tool_definitions() -> Vec<ToolDef> {
             }));
             props.insert("output".into(), json!({
                 "type": "string",
-                "enum": ["full", "compact", "tabular"]
+                "enum": ["full", "compact", "tabular", "summary"],
+                "description": "Output mode. 'summary' returns only issue counts + AI signature (no individual issues)"
+            }));
+            props.insert("detect_ai".into(), json!({
+                "type": "boolean",
+                "description": "Enable AI writing artifact detection (density + grammar patterns) regardless of profile"
+            }));
+            props.insert("ai_threshold".into(), json!({
+                "type": "string",
+                "enum": ["low", "medium", "high"],
+                "description": "AI detection sensitivity: 'low' (sensitive, catches more), 'medium' (balanced), 'high' (conservative). Only effective with detect_ai=true"
             }));
             json!({
                 "type": "object",

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -4,13 +4,20 @@ use serde::{Deserialize, Serialize};
 ///
 /// Default is the baseline (current behavior). StrictMoe enables the full
 /// Ministry of Education standard (variants, colon, 臺). UiStrings is
-/// relaxed for software UI contexts (half-width : allowed).
+/// relaxed for software UI contexts (half-width : allowed). Editorial
+/// enables AI writing artifact detection (filler phrases, semantic safety
+/// words, copula avoidance, passive voice overuse) on top of base rules.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Profile {
     Default,
     StrictMoe,
     UiStrings,
+    /// Editorial review: base rules + AI writing artifact detection.
+    /// Flags discourse-level patterns statistically overrepresented in
+    /// LLM-generated zh-TW text (filler phrases, semantic safety words,
+    /// inflated copulas, passive voice overuse).
+    Editorial,
 }
 
 /// Processing chain configuration for a profile.
@@ -40,6 +47,22 @@ pub struct ProfileConfig {
     pub range_en_dash: bool,
     /// Enable grammar checks (interlingual transfer, A-not-A + 嗎 clash).
     pub grammar_checks: bool,
+    /// Enable AI filler phrase detection (值得注意的是, 在這種情況下, etc.).
+    pub ai_filler_detection: bool,
+    /// Enable AI semantic safety word detection (意味著 disambiguation,
+    /// copula avoidance, passive voice overuse).
+    pub ai_semantic_safety: bool,
+    /// Enable density-based AI phrase detection.  Counts tracked phrases
+    /// across the full document and flags when density exceeds per-phrase
+    /// thresholds (count per thousand characters).
+    pub ai_density_detection: bool,
+    /// Enable structural AI pattern detection: binary contrast density,
+    /// paragraph-ending declarations, dash overuse, formulaic headings.
+    pub ai_structural_patterns: bool,
+    /// AI detection threshold multiplier: <1.0 = sensitive (catches more),
+    /// 1.0 = balanced (default), >1.0 = conservative (fewer false positives).
+    /// Maps to ai_threshold levels: low=0.5, medium=1.0, high=1.5.
+    pub ai_threshold_multiplier: f32,
     /// Political stance sub-profile. Controls which PoliticalColoring rules fire.
     pub political_stance: PoliticalStance,
 }
@@ -54,7 +77,12 @@ impl ProfileConfig {
 
 impl Profile {
     /// All defined profiles.
-    pub const ALL: &'static [Profile] = &[Profile::Default, Profile::StrictMoe, Profile::UiStrings];
+    pub const ALL: &'static [Profile] = &[
+        Profile::Default,
+        Profile::StrictMoe,
+        Profile::UiStrings,
+        Profile::Editorial,
+    ];
 
     /// Human-readable name.
     pub fn name(self) -> &'static str {
@@ -62,6 +90,7 @@ impl Profile {
             Profile::Default => "default",
             Profile::StrictMoe => "strict_moe",
             Profile::UiStrings => "ui_strings",
+            Profile::Editorial => "editorial",
         }
     }
 
@@ -71,6 +100,7 @@ impl Profile {
             Profile::Default => "Base zh-TW rules: cross-strait vocabulary, political coloring, casing, basic punctuation, grammar",
             Profile::StrictMoe => "Full MoE enforcement: all punctuation, character variants, 臺 normalization, grammar",
             Profile::UiStrings => "Relaxed for software UI: half-width colon allowed, en dash for ranges, strict vocabulary, no grammar",
+            Profile::Editorial => "AI writing review: base rules + filler phrase detection, semantic safety words, copula/passive checks",
         }
     }
 
@@ -88,6 +118,11 @@ impl Profile {
                 ellipsis_normalization: true,
                 range_en_dash: false,
                 grammar_checks: true,
+                ai_filler_detection: false,
+                ai_semantic_safety: false,
+                ai_density_detection: false,
+                ai_structural_patterns: false,
+                ai_threshold_multiplier: 1.0,
                 political_stance: PoliticalStance::RocCentric,
             },
             Profile::StrictMoe => ProfileConfig {
@@ -101,6 +136,11 @@ impl Profile {
                 ellipsis_normalization: true,
                 range_en_dash: false,
                 grammar_checks: true,
+                ai_filler_detection: false,
+                ai_semantic_safety: false,
+                ai_density_detection: false,
+                ai_structural_patterns: false,
+                ai_threshold_multiplier: 1.0,
                 political_stance: PoliticalStance::RocCentric,
             },
             Profile::UiStrings => ProfileConfig {
@@ -114,6 +154,31 @@ impl Profile {
                 ellipsis_normalization: true,
                 range_en_dash: true,
                 grammar_checks: false,
+                ai_filler_detection: false,
+                ai_semantic_safety: false,
+                ai_density_detection: false,
+                ai_structural_patterns: false,
+                ai_threshold_multiplier: 1.0,
+                political_stance: PoliticalStance::RocCentric,
+            },
+            // Editorial: base rules + all AI writing artifact detection.
+            // Targets discourse-level patterns overrepresented in LLM output.
+            Profile::Editorial => ProfileConfig {
+                spelling: true,
+                casing: true,
+                basic_punctuation: true,
+                colon_enforcement: true,
+                dunhao_detection: true,
+                range_normalization: true,
+                variant_normalization: false,
+                ellipsis_normalization: true,
+                range_en_dash: false,
+                grammar_checks: true,
+                ai_filler_detection: true,
+                ai_semantic_safety: true,
+                ai_density_detection: true,
+                ai_structural_patterns: true,
+                ai_threshold_multiplier: 1.0,
                 political_stance: PoliticalStance::RocCentric,
             },
         }
@@ -124,6 +189,7 @@ impl Profile {
         match s {
             "strict_moe" => Profile::StrictMoe,
             "ui_strings" => Profile::UiStrings,
+            "editorial" => Profile::Editorial,
             _ => Profile::Default,
         }
     }
@@ -134,6 +200,7 @@ impl Profile {
             "default" => Some(Profile::Default),
             "strict_moe" => Some(Profile::StrictMoe),
             "ui_strings" => Some(Profile::UiStrings),
+            "editorial" => Some(Profile::Editorial),
             _ => None,
         }
     }
@@ -237,6 +304,9 @@ pub enum RuleType {
     /// Character variant: MoE standard form differs from non-standard glyph
     /// (e.g. 裏->裡, 綫->線). Curated from OpenCC TWVariants.txt.
     Variant,
+    /// AI filler phrase: zero-information hedging/emphasis inserted by LLMs.
+    /// Fixed-string AC matches; deletions or simple substitutions.
+    AiFiller,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -272,6 +342,7 @@ impl RuleType {
         match self {
             RuleType::PoliticalColoring | RuleType::Typo => Severity::Error,
             RuleType::CrossStrait | RuleType::Confusable | RuleType::Variant => Severity::Warning,
+            RuleType::AiFiller => Severity::Info,
         }
     }
 }
@@ -445,7 +516,7 @@ impl Issue {
     }
 }
 
-/// Issue classification — covers spelling, case, punctuation, and grammar checks.
+/// Issue classification — covers spelling, case, punctuation, grammar, and AI style checks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IssueType {
@@ -457,6 +528,10 @@ pub enum IssueType {
     Punctuation,
     Variant,
     Grammar,
+    /// AI writing artifact: filler phrases, semantic safety words, copula
+    /// avoidance, passive voice overuse.  NOT eligible for orthographic-tier
+    /// fixes — requires lexical_contextual or none.
+    AiStyle,
 }
 
 impl IssueType {
@@ -471,6 +546,7 @@ impl IssueType {
             IssueType::Punctuation => 5,
             IssueType::Variant => 6,
             IssueType::Grammar => 7,
+            IssueType::AiStyle => 8,
         }
     }
 
@@ -485,6 +561,7 @@ impl IssueType {
             IssueType::Punctuation => "punctuation",
             IssueType::Variant => "variant",
             IssueType::Grammar => "grammar",
+            IssueType::AiStyle => "ai_style",
         }
     }
 }
@@ -524,6 +601,7 @@ impl From<RuleType> for IssueType {
             RuleType::Typo => IssueType::Typo,
             RuleType::Confusable => IssueType::Confusable,
             RuleType::Variant => IssueType::Variant,
+            RuleType::AiFiller => IssueType::AiStyle,
         }
     }
 }

--- a/tests/cli_lint.rs
+++ b/tests/cli_lint.rs
@@ -803,3 +803,52 @@ fn cli_lint_fix_bogus_rejected() {
         "should report unknown fix mode, got: {stderr}"
     );
 }
+
+#[test]
+fn cli_lint_detect_ai_enables_density_detection() {
+    // Build text with high density of a tracked phrase.
+    let filler = "這是正常的技術內容段落。";
+    let mut text = String::new();
+    for i in 0..100 {
+        if i % 20 == 0 {
+            text.push_str("更重要的是，我們需要重新評估這個方案。");
+        } else {
+            text.push_str(filler);
+        }
+    }
+    // Without --detect-ai (default profile): no ai_style density issues.
+    let output_default = run_lint_stdin(&["--format", "json"], &text);
+    let stdout = String::from_utf8_lossy(&output_default.stdout);
+    let json_default: serde_json::Value =
+        serde_json::from_str(&stdout).expect("default output should be valid JSON");
+    let has_ai_density_default = json_default["issues"].as_array().map_or(false, |arr| {
+        arr.iter().any(|i| {
+            i["rule_type"] == "ai_style"
+                && i["context"]
+                    .as_str()
+                    .map_or(false, |c| c.contains("次/千字"))
+        })
+    });
+    assert!(
+        !has_ai_density_default,
+        "default profile should not report ai_style density issues: {stdout}"
+    );
+
+    // With --detect-ai: ai_style density issues should appear.
+    let output_ai = run_lint_stdin(&["--detect-ai", "--format", "json"], &text);
+    let stdout_ai = String::from_utf8_lossy(&output_ai.stdout);
+    let json_ai: serde_json::Value =
+        serde_json::from_str(&stdout_ai).expect("--detect-ai output should be valid JSON");
+    let has_ai_density = json_ai["issues"].as_array().map_or(false, |arr| {
+        arr.iter().any(|i| {
+            i["rule_type"] == "ai_style"
+                && i["context"]
+                    .as_str()
+                    .map_or(false, |c| c.contains("次/千字"))
+        })
+    });
+    assert!(
+        has_ai_density,
+        "--detect-ai should report ai_style density issues: {stdout_ai}"
+    );
+}

--- a/tests/scanner_integration.rs
+++ b/tests/scanner_integration.rs
@@ -5,7 +5,7 @@
 // code block exclusion, URL/path exclusion, @mention exclusion, case rules,
 // punctuation normalization, and alternatives handling.
 
-use zhtw_mcp::engine::scan::Scanner;
+use zhtw_mcp::engine::scan::{ContentType, Scanner};
 use zhtw_mcp::rules::ruleset::{CaseRule, Profile, RuleType, SpellingRule};
 
 // ---------------------------------------------------------------------------
@@ -880,4 +880,144 @@ fn grammar_clean_text_produces_no_issues() {
         .iter()
         .any(|i| i.rule_type == zhtw_mcp::rules::ruleset::IssueType::Grammar);
     assert!(!has_grammar, "clean text should not trigger grammar checks");
+}
+
+// ---------------------------------------------------------------------------
+// AI writing detection (40.1)
+// ---------------------------------------------------------------------------
+
+use zhtw_mcp::rules::ruleset::IssueType;
+
+fn ai_filler_rule(from: &str, to: &[&str]) -> SpellingRule {
+    SpellingRule {
+        from: from.into(),
+        to: to.iter().map(|s| s.to_string()).collect(),
+        rule_type: RuleType::AiFiller,
+        disabled: false,
+        context: None,
+        english: None,
+        exceptions: None,
+        context_clues: None,
+        negative_context_clues: None,
+        tags: None,
+    }
+}
+
+#[test]
+fn ai_filler_rules_suppressed_in_default_profile() {
+    let rules = vec![ai_filler_rule("值得注意的是，", &[""])];
+    let scanner = Scanner::new(rules, vec![]);
+    let output =
+        scanner.scan_with_config("值得注意的是，系統需要重啟", &[], Profile::Default.config());
+    // Default profile has ai_filler_detection: false → no issues.
+    let ai_issues: Vec<_> = output
+        .issues
+        .iter()
+        .filter(|i| i.rule_type == IssueType::AiStyle)
+        .collect();
+    assert!(
+        ai_issues.is_empty(),
+        "default profile should suppress AI filler rules"
+    );
+}
+
+#[test]
+fn ai_filler_rules_fire_when_profile_enabled() {
+    let rules = vec![ai_filler_rule("值得注意的是，", &[""])];
+    let scanner = Scanner::new(rules, vec![]);
+    let mut cfg = Profile::Default.config();
+    cfg.ai_filler_detection = true;
+    let output = scanner.scan_with_config("值得注意的是，系統需要重啟", &[], cfg);
+    let ai_issues: Vec<_> = output
+        .issues
+        .iter()
+        .filter(|i| i.rule_type == IssueType::AiStyle)
+        .collect();
+    assert_eq!(ai_issues.len(), 1);
+    assert_eq!(ai_issues[0].found, "值得注意的是，");
+}
+
+#[test]
+fn ai_semantic_safety_fires_when_profile_enabled() {
+    let scanner = Scanner::new(vec![], vec![]);
+    let mut cfg = Profile::Default.config();
+    cfg.ai_semantic_safety = true;
+    let output = scanner.scan_with_config("這個定義意味著所有的值都必須為正", &[], cfg);
+    let ai_issues: Vec<_> = output
+        .issues
+        .iter()
+        .filter(|i| i.rule_type == IssueType::AiStyle)
+        .collect();
+    assert_eq!(ai_issues.len(), 1);
+    assert_eq!(ai_issues[0].found, "意味著");
+}
+
+#[test]
+fn ai_semantic_safety_suppressed_in_default_profile() {
+    let scanner = Scanner::new(vec![], vec![]);
+    let output = scanner.scan("這個定義意味著所有的值都必須為正");
+    let ai_issues: Vec<_> = output
+        .issues
+        .iter()
+        .filter(|i| i.rule_type == IssueType::AiStyle)
+        .collect();
+    assert!(
+        ai_issues.is_empty(),
+        "default profile should suppress AI semantic safety"
+    );
+}
+
+#[test]
+fn ai_density_detection_fires_with_editorial_profile() {
+    let scanner = Scanner::new(vec![], vec![]);
+    // Build a ~1200 char text with high density of '更重要的是'.
+    let filler = "這是正常的技術內容段落。";
+    let mut text = String::new();
+    for i in 0..100 {
+        if i % 20 == 0 {
+            text.push_str("更重要的是，我們需要重新評估這個方案。");
+        } else {
+            text.push_str(filler);
+        }
+    }
+    let output = scanner.scan_for_content_type(&text, ContentType::Plain, Profile::Editorial);
+    let density_issues: Vec<_> = output
+        .issues
+        .iter()
+        .filter(|i| {
+            i.rule_type == IssueType::AiStyle
+                && i.context.as_ref().is_some_and(|c| c.contains("次/千字"))
+        })
+        .collect();
+    assert!(
+        !density_issues.is_empty(),
+        "editorial profile should detect high density AI phrases"
+    );
+}
+
+#[test]
+fn ai_density_detection_suppressed_in_default_profile() {
+    let scanner = Scanner::new(vec![], vec![]);
+    let filler = "這是正常的技術內容段落。";
+    let mut text = String::new();
+    for i in 0..100 {
+        if i % 20 == 0 {
+            text.push_str("更重要的是，我們需要重新評估這個方案。");
+        } else {
+            text.push_str(filler);
+        }
+    }
+    let output = scanner.scan_for_content_type(&text, ContentType::Plain, Profile::Default);
+    let density_issues: Vec<_> = output
+        .issues
+        .iter()
+        .filter(|i| {
+            i.rule_type == IssueType::AiStyle
+                && i.context.as_ref().is_some_and(|c| c.contains("次/千字"))
+        })
+        .collect();
+    assert!(
+        density_issues.is_empty(),
+        "default profile should NOT run density detection"
+    );
 }


### PR DESCRIPTION
This introduces Profile::Editorial enabling AI filler phrase detection and grammar-level checks for semantic safety words (意味著 disambiguation), copula avoidance (作為/擁有→是/有), and passive voice overuse (被廣泛使用→ 廣泛使用).

New IssueType::AiStyle keeps AI-artifact rules out of the orthographic fix tier in fixer.rs, preventing unsafe auto-rewrites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `editorial` profile and a deterministic document‑level signature score to flag model‑style writing in zh‑TW. Detection is opt‑in and tunable via profile, CLI, or MCP; defaults are unchanged.

- **New Features**
  - `editorial` profile: enables `ai_filler_detection`, `ai_semantic_safety`, `ai_density_detection`, and `ai_structural_patterns`.
    - Filler phrases in `assets/ruleset.json` (e.g., 值得一提的是／更重要的是／不容忽視的是); three content‑bearing phrases (`不容忽視`, `從某種角度來看`, `深刻影響`) are flagged with `to: []` and never auto‑deleted.
    - Semantic‑safety disambiguation: 意味著 → 表示／代表／也就是說 (context‑aware); copula avoidance in technical context: 作為／擁有 → 是／有; passive overuse: 被廣泛使用／採用／應用 → 廣泛使用／採用／應用.
  - Document‑level signature score (0.0–1.0), deterministic: aggregates six signals (phrase density, structural patterns, issue density without double‑counting density phrases, sentence variability, zero‑width artifacts, punctuation CV); excludes code/URLs from counts; off‑by‑one in variability fixed; sensitivity via `ai_threshold_multiplier` and `--detect-ai [low|medium|high]`.
  - New issue type `ai_style`: excluded from orthographic fixes; safe exception limited to zero‑width deletion of ZWSP/BOM only; `lexical_safe` applies single‑suggestion edits; advisory‑only when confidence is low.
  - CLI/MCP: `--detect-ai [low|medium|high]` and tool args `detect_ai`/`ai_threshold` enable detection in any profile; outputs include an `ai_signature` report and a compact summary; prompt parses `detect_ai` and `ai_threshold` instead of forcing `editorial`; setup docs list `editorial`.
  - Scanner/cache: `ScanOutput` includes optional `ai_signature`; signature recomputed after fixes via a merged rescan; cache keys include both `detect_ai` and `ai_threshold`; tests added (CLI gating and pattern detection); README updated; vocabulary rules now exceed 1100.

- **Migration**
  - To enable: use `profile: "editorial"`, or `--detect-ai` (CLI) / `detect_ai` + `ai_threshold` (MCP).
  - If parsing JSON, add support for `ai_signature` and the `ai_style` issue type.
  - Orthographic mode won’t rewrite `ai_style` issues (except ZWSP/BOM deletion); use `fix_mode: "lexical_safe"` or review manually.

<sup>Written for commit c6c8843cc3fab798f9695758d4f8fb3c1fca2e85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

