### PR TITLE
Expand with new terms and structured annotations

### DIFF
--- a/assets/ruleset.json
+++ b/assets/ruleset.json
@@ -4,14 +4,14 @@
       "from": "32 位架構",
       "to": ["32 位元架構"],
       "type": "cross_strait",
-      "context": "cn 「位」兼作量詞易混淆；tw 用「位元」明確表示 bit",
+      "context": "@domain IT。cn 「位」兼作量詞易混淆；tw 用「位元」明確表示 bit",
       "english": "32-bit architecture"
     },
     {
       "from": "32位",
       "to": ["32 位元"],
       "type": "cross_strait",
-      "context": "cn 「位」兼作量詞易混淆；tw 用「位元」明確表示 bit",
+      "context": "@domain IT。cn 「位」兼作量詞易混淆；tw 用「位元」明確表示 bit",
       "english": "32-bit",
       "context_clues": ["架構", "處理器", "CPU", "ARM", "作業系統", "定址", "位址"]
     },
@@ -19,123 +19,158 @@
       "from": "64 位架構",
       "to": ["64 位元架構"],
       "type": "cross_strait",
-      "context": "cn 「位」兼作量詞易混淆；tw 用「位元」明確表示 bit",
+      "context": "@domain IT。cn 「位」兼作量詞易混淆；tw 用「位元」明確表示 bit",
       "english": "64-bit architecture"
     },
     {
       "from": "64位",
       "to": ["64 位元"],
       "type": "cross_strait",
-      "context": "cn 「位」兼作量詞易混淆；tw 用「位元」明確表示 bit",
+      "context": "@domain IT。cn 「位」兼作量詞易混淆；tw 用「位元」明確表示 bit",
       "english": "64-bit",
       "context_clues": ["架構", "處理器", "CPU", "ARM", "作業系統", "定址", "位址"]
+    },
+    {
+      "from": "B超",
+      "to": ["超音波"],
+      "type": "cross_strait",
+      "context": "@domain 醫學",
+      "english": "ultrasound",
+      "context_clues": ["檢查", "醫院", "胎兒", "診斷"]
     },
     {
       "from": "CPU 核心",
       "to": ["CPU 核"],
       "type": "cross_strait",
-      "context": "區分 core (核) 和 kernel (核心)；processor core 譯為「核」",
+      "context": "@domain 硬體。區分 core (核) 和 kernel (核心)；processor core 譯為「核」",
       "english": "CPU core"
     },
     {
       "from": "CPU核心",
       "to": ["CPU 核"],
       "type": "cross_strait",
-      "context": "區分 core (核) 和 kernel (核心)；processor core 譯為「核」",
+      "context": "@domain 硬體。區分 core (核) 和 kernel (核心)；processor core 譯為「核」",
       "english": "CPU core"
     },
     {
       "from": "PN結",
       "to": ["PN接面"],
       "type": "cross_strait",
+      "context": "@domain 電子",
       "english": "PN junction"
     },
     {
       "from": "SQL注入",
       "to": ["SQL隱碼攻擊"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "SQL injection"
     },
     {
       "from": "SQL注入攻擊",
       "to": ["SQL隱碼攻擊"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "SQL injection attack"
     },
     {
       "from": "U盤",
       "to": ["隨身碟"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "USB flash drive"
     },
     {
       "from": "X Window 系統",
       "to": ["X 視窗系統"],
       "type": "cross_strait",
-      "context": "tw 慣用「視窗」而非直接使用 Window",
+      "context": "@domain IT。tw 慣用「視窗」而非直接使用 Window",
       "english": "X Window System"
     },
     {
       "from": "一元操作符",
       "to": ["一元運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "unary operator"
     },
     {
       "from": "一切皆文件",
       "to": ["一切皆為檔案"],
       "type": "cross_strait",
-      "context": "Unix 哲學 'everything is a file'；cn「文件」= file, tw「檔案」= file",
+      "context": "@domain IT。Unix 哲學 'everything is a file'；cn「文件」= file, tw「檔案」= file",
       "english": "everything is a file"
     },
     {
       "from": "一次性",
       "to": ["拋棄式"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "disposable"
     },
     {
       "from": "一鍵",
       "to": ["單鍵"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "one-click"
+    },
+    {
+      "from": "七天無理由",
+      "to": ["七天鑑賞期"],
+      "type": "cross_strait",
+      "context": "@domain 電商",
+      "english": "7-day return policy",
+      "context_clues": ["退貨", "退款", "購物", "消費"]
     },
     {
       "from": "三極管",
       "to": ["三極體"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "triode"
+    },
+    {
+      "from": "下劃線",
+      "to": ["底線"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "underline/underscore",
+      "context_clues": ["文字", "格式", "字元", "CSS", "HTML", "樣式"]
     },
     {
       "from": "下拉列表",
       "to": ["下拉式清單"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "dropdown list"
     },
     {
       "from": "下拉菜單",
       "to": ["下拉式選單"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "dropdown menu"
     },
     {
       "from": "下標操作符",
       "to": ["下標運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "subscript operator"
     },
     {
       "from": "下溢",
       "to": ["下限溢位"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "underflow"
     },
     {
       "from": "下載文件",
       "to": ["下載檔案"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "download file"
     },
     {
@@ -160,6 +195,7 @@
       "from": "並口",
       "to": ["平行埠"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "parallel port"
     },
     {
@@ -180,7 +216,7 @@
       "from": "並行",
       "to": ["平行"],
       "type": "cross_strait",
-      "context": "tw: 並行=concurrency, 平行=parallelism。僅在 parallelism 語境替換",
+      "context": "@domain 程式設計。tw: 並行=concurrency, 平行=parallelism。僅在 parallelism 語境替換",
       "english": "parallelism",
       "context_clues": ["多核", "多處理器", "GPU", "SIMD", "MIMD", "加速", "throughput", "向量化"],
       "exceptions": ["並行任務"]
@@ -198,62 +234,70 @@
       "from": "並行計算",
       "to": ["平行運算"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "parallel computing"
     },
     {
       "from": "並集",
       "to": ["聯集"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "union (set theory)"
     },
     {
       "from": "中間件",
       "to": ["中介層", "中介軟體"],
       "type": "cross_strait",
-      "context": "架構層次概念 vs 軟體產品 (如 message broker)",
+      "context": "@domain 網路。架構層次概念 vs 軟體產品 (如 message broker)",
       "english": "middleware"
     },
     {
       "from": "串口",
-      "to": ["串列埠"],
+      "to": ["串列埠", "序列埠"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "serial port"
     },
     {
       "from": "串行",
       "to": ["序列"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "serial"
     },
     {
       "from": "串行端口",
       "to": ["序列埠"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "serial port"
     },
     {
       "from": "主引導記錄",
       "to": ["主開機記錄"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "master boot record (MBR)"
     },
     {
       "from": "主板",
       "to": ["主機板"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "motherboard"
     },
     {
       "from": "主線程",
       "to": ["主執行緒"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "main thread"
     },
     {
       "from": "乍得",
       "to": ["查德"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Chad"
     },
     {
@@ -266,14 +310,14 @@
       "from": "也門",
       "to": ["葉門"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Yemen"
     },
     {
       "from": "事務",
       "to": ["交易"],
       "type": "cross_strait",
-      "context": "限資料庫語境。一般用法「事務」(affairs) 為正確 tw 用法",
+      "context": "@domain 資料庫。限資料庫語境。一般用法「事務」(affairs) 為正確 tw 用法",
       "english": "transaction",
       "context_clues": ["資料庫", "SQL", "commit", "rollback", "ACID", "交易"]
     },
@@ -281,50 +325,63 @@
       "from": "二元操作符",
       "to": ["二元運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "binary operator"
     },
     {
       "from": "二分查找",
       "to": ["二分搜尋法"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "binary search"
     },
     {
       "from": "二叉樹",
       "to": ["二元樹"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "binary tree"
     },
     {
       "from": "二極管",
       "to": ["二極體"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "diode"
+    },
+    {
+      "from": "二維碼",
+      "to": ["二維條碼"],
+      "type": "cross_strait",
+      "context": "@domain 程式設計",
+      "english": "QR code"
     },
     {
       "from": "二進制",
       "to": ["二進位", "二進位制"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "binary"
     },
     {
       "from": "互聯網",
       "to": ["網際網路"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "Internet"
     },
     {
       "from": "亞像素",
       "to": ["子像素"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "subpixel"
     },
     {
       "from": "交互",
       "to": ["互動"],
       "type": "cross_strait",
-      "context": "限 HCI/UI 語境。「交互連接」(interconnect) 和「交互作用」(interaction/effect) 為正確用法",
+      "context": "@domain UI。限 HCI/UI 語境。「交互連接」(interconnect) 和「交互作用」(interaction/effect) 為正確用法",
       "english": "interact",
       "context_clues": ["介面", "接口", "UI", "使用者", "用戶", "設計", "網頁", "操作"],
       "exceptions": ["交互連接", "交互連線", "交互作用"]
@@ -333,25 +390,36 @@
       "from": "交互式",
       "to": ["互動式"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "interactive"
+    },
+    {
+      "from": "交換機",
+      "to": ["交換器"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "switch",
+      "context_clues": ["網路", "路由", "封包", "VLAN"]
     },
     {
       "from": "人工智能",
       "to": ["人工智慧"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "artificial intelligence (AI)"
     },
     {
       "from": "仙童半導體",
       "to": ["快捷半導體"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "Fairchild Semiconductor"
     },
     {
       "from": "代碼",
       "to": ["程式碼"],
       "type": "cross_strait",
-      "context": "限程式設計語境。source code 常被簡寫為 code，因此要翻譯為程式碼。非 IT 語境則該有對應的翻譯",
+      "context": "@domain 程式設計。限程式設計語境。source code 常被簡寫為 code，因此要翻譯為程式碼。非 IT 語境則該有對應的翻譯",
       "english": "code",
       "context_clues": ["編譯", "函式", "函數", "軟體", "軟件", "開發", "程式", "編寫", "原始碼", "除錯"]
     },
@@ -359,74 +427,114 @@
       "from": "代碼生成",
       "to": ["程式碼產生"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "code generation"
     },
     {
       "from": "代碼頁",
       "to": ["內碼表"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "code page"
+    },
+    {
+      "from": "代金券",
+      "to": ["折價券"],
+      "type": "cross_strait",
+      "context": "@domain 電商",
+      "english": "voucher",
+      "context_clues": ["購物", "消費", "折扣", "優惠"]
     },
     {
       "from": "令牌",
       "to": ["權杖", "代幣", "詞元"],
       "type": "cross_strait",
-      "context": "區分驗證/授權、加密貨幣、NLP 分詞 (tokenization) 等不同語境",
+      "context": "@domain 資安。區分驗證/授權、加密貨幣、NLP 分詞 (tokenization) 等不同語境",
       "english": "token"
     },
     {
       "from": "以太",
       "to": ["乙太"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "Ethernet"
     },
     {
       "from": "以太網",
       "to": ["乙太網"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "Ethernet"
     },
     {
       "from": "以成員為單位",
       "to": ["以成員為單元"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "memberwise"
     },
     {
       "from": "以成員為單位的複製",
       "to": ["以成員為單元複製"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "memberwise copy"
     },
     {
       "from": "任務欄",
       "to": ["工作列"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "taskbar"
     },
     {
       "from": "任務管理器",
       "to": ["工作管理員"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "task manager"
     },
     {
       "from": "仿真",
       "to": ["模擬"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "simulation/emulation"
+    },
+    {
+      "from": "伊斯坦布爾",
+      "to": ["伊斯坦堡"],
+      "type": "cross_strait",
+      "context": "@geo city (城市)",
+      "english": "Istanbul"
+    },
+    {
+      "from": "休斯敦",
+      "to": ["休士頓"],
+      "type": "cross_strait",
+      "context": "@geo city (城市)",
+      "english": "Houston"
     },
     {
       "from": "伯利茲",
       "to": ["貝里斯"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Belize"
+    },
+    {
+      "from": "佈局",
+      "to": ["版面配置"],
+      "type": "cross_strait",
+      "context": "@domain IT。cn「佈局」(UI)；tw 用「版面配置」(layout)",
+      "english": "layout",
+      "context_clues": ["CSS", "UI", "介面", "排版", "設計"]
     },
     {
       "from": "位圖",
       "to": ["點陣圖", "位元映射", "位元圖"],
       "type": "cross_strait",
+      "context": "@domain 資料結構。限圖形/程式設計語境",
       "english": "bitmap"
     },
     {
@@ -440,46 +548,56 @@
       "from": "位址空間",
       "to": ["定址空間"],
       "type": "cross_strait",
-      "context": "限 IT 語境",
+      "context": "@domain 作業系統。限 IT 語境",
       "english": "address space"
     },
     {
       "from": "位域",
       "to": ["位元欄"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "bit field"
     },
     {
       "from": "位拷貝",
       "to": ["逐位元複製"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "bitwise copy"
     },
     {
       "from": "位操作",
       "to": ["逐位元操作", "逐位元運算"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "bitwise operation/bit-wise operation"
     },
     {
       "from": "低級",
       "to": ["低階"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "low-level"
     },
     {
       "from": "佛得角",
       "to": ["維德角"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Cape Verde"
+    },
+    {
+      "from": "佛羅倫薩",
+      "to": ["佛羅倫斯"],
+      "type": "cross_strait",
+      "context": "@geo city (城市)",
+      "english": "Florence"
     },
     {
       "from": "作業",
       "to": ["工作"],
       "type": "cross_strait",
-      "context": "限作業系統 job 語境。「作業系統」「家庭作業」等用法不替換",
+      "context": "@domain 作業系統。限作業系統 job 語境。「作業系統」「家庭作業」等用法不替換",
       "english": "job",
       "context_clues": ["Job", "job", "批次", "排程", "佇列", "queue"],
       "exceptions": ["作業系統", "家庭作業"]
@@ -510,37 +628,73 @@
       "from": "例程",
       "to": ["常式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "routine"
+    },
+    {
+      "from": "依賴",
+      "to": ["相依性"],
+      "type": "cross_strait",
+      "context": "@domain IT。cn「依賴」(軟體)；tw 用「相依性」(dependency)",
+      "english": "dependency",
+      "context_clues": ["套件", "模組", "npm", "pip", "安裝", "版本"]
+    },
+    {
+      "from": "依賴項",
+      "to": ["相依套件"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "dependency",
+      "context_clues": ["安裝", "套件", "版本", "管理"]
     },
     {
       "from": "便攜式",
       "to": ["行動式", "攜帶型"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "portable"
+    },
+    {
+      "from": "保修",
+      "to": ["保固"],
+      "type": "cross_strait",
+      "context": "@domain 電商",
+      "english": "warranty",
+      "context_clues": ["期限", "維修", "產品", "售後"]
+    },
+    {
+      "from": "保修期",
+      "to": ["保固期"],
+      "type": "cross_strait",
+      "context": "@domain 電商",
+      "english": "warranty period"
     },
     {
       "from": "保存",
       "to": ["儲存"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "save"
     },
     {
       "from": "保質期",
       "to": ["保存期限"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "expiration date"
     },
     {
       "from": "信噪比",
       "to": ["訊雜比"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "signal-to-noise ratio (SNR)"
     },
     {
       "from": "信息",
       "to": ["資訊"],
       "type": "cross_strait",
-      "context": "tw 「信息」通常指 message (訊息) 或生物學名詞，限 IT 語境",
+      "context": "@domain IT。tw 「信息」通常指 message (訊息) 或生物學名詞，限 IT 語境",
       "english": "information",
       "exceptions": ["信息素"]
     },
@@ -548,50 +702,56 @@
       "from": "信息安全",
       "to": ["資訊安全"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "information security"
     },
     {
       "from": "信息技術",
       "to": ["資訊科技"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "information technology (IT)"
     },
     {
       "from": "信息素",
       "to": ["費洛蒙"],
       "type": "cross_strait",
-      "context": "tw 生物學用語以外來語「費洛蒙」為主流",
+      "context": "@domain 生物學。tw 生物學用語以外來語「費洛蒙」為主流",
       "english": "pheromone"
     },
     {
       "from": "信息論",
       "to": ["資訊理論"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "information theory"
     },
     {
       "from": "信號",
       "to": ["訊號"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "signal"
     },
     {
       "from": "信道",
       "to": ["通道"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "channel"
     },
     {
       "from": "修飾符",
       "to": ["修飾子", "修飾詞", "飾詞"],
       "type": "cross_strait",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "modifier"
     },
     {
       "from": "倉庫",
       "to": ["儲存庫"],
       "type": "cross_strait",
-      "context": "限版本控制語境 (Git repository)。一般語境「倉庫」(warehouse) 為正確 tw 用法",
+      "context": "@domain 版本控制。限版本控制語境 (Git repository)。一般語境「倉庫」(warehouse) 為正確 tw 用法",
       "english": "repository",
       "context_clues": ["git", "Git", "GitHub", "clone", "commit", "push", "pull", "版本", "分支", "branch"]
     },
@@ -599,6 +759,7 @@
       "from": "個性化",
       "to": ["個人化"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "personalize"
     },
     {
@@ -613,12 +774,14 @@
       "from": "候選函數",
       "to": ["候選函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "candidate function"
     },
     {
       "from": "借記卡",
       "to": ["簽帳金融卡"],
       "type": "cross_strait",
+      "context": "@domain 金融",
       "english": "debit card"
     },
     {
@@ -658,57 +821,74 @@
       "context": "AI filler phrase with zero information content; delete"
     },
     {
+      "from": "假肢",
+      "to": ["義肢"],
+      "type": "cross_strait",
+      "context": "@domain 醫學",
+      "english": "prosthesis",
+      "context_clues": ["截肢", "復健", "裝置", "肢體"]
+    },
+    {
       "from": "健壯",
       "to": ["強固", "穩健"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "robust"
     },
     {
       "from": "健壯性",
       "to": ["強固性", "穩健性"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "robustness"
     },
     {
       "from": "偽代碼",
       "to": ["虛擬碼"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "pseudocode"
     },
     {
       "from": "偽碼",
       "to": ["虛擬碼"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "pseudo code"
     },
     {
       "from": "傅里葉",
       "to": ["傅立葉"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "Fourier"
     },
     {
       "from": "備份文件",
       "to": ["備份檔案"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "backup file"
     },
     {
       "from": "傳感",
       "to": ["感測"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "sensing"
     },
     {
       "from": "傳感器",
       "to": ["感測器"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "sensor"
     },
     {
       "from": "像素",
       "to": ["畫素"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "pixel"
     },
     {
@@ -721,6 +901,7 @@
       "from": "儀表盤",
       "to": ["儀表板"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "dashboard"
     },
     {
@@ -739,12 +920,14 @@
       "from": "優先級",
       "to": ["優先順序"],
       "type": "cross_strait",
+      "context": "@domain 金融",
       "english": "priority"
     },
     {
       "from": "優先級反轉",
       "to": ["優先權反轉"],
       "type": "cross_strait",
+      "context": "@domain 金融",
       "english": "priority inversion"
     },
     {
@@ -758,7 +941,7 @@
       "from": "優先順序反轉",
       "to": ["優先權反轉"],
       "type": "cross_strait",
-      "context": "priority inversion 中的 priority 譯為「優先權」而非「優先順序」，因反轉的是權利而非順序",
+      "context": "@domain 作業系統。priority inversion 中的 priority 譯為「優先權」而非「優先順序」，因反轉的是權利而非順序",
       "english": "priority inversion"
     },
     {
@@ -772,26 +955,57 @@
       "from": "優化",
       "to": ["最佳化"],
       "type": "cross_strait",
-      "context": "著重於經過反覆調整在不同方案間挑選出最適宜、最佳且符合需求的一項。若譯為「優化」則與 improve (改善/提升) 混淆，喪失「挑選比較」的暗喻",
+      "context": "@domain IT。著重於經過反覆調整在不同方案間挑選出最適宜、最佳且符合需求的一項。若譯為「優化」則與 improve (改善/提升) 混淆，喪失「挑選比較」的暗喻",
       "english": "optimize"
+    },
+    {
+      "from": "優步",
+      "to": ["Uber"],
+      "type": "cross_strait",
+      "context": "@domain 日常",
+      "english": "Uber"
+    },
+    {
+      "from": "優盤",
+      "to": ["隨身碟"],
+      "type": "cross_strait",
+      "context": "@domain 硬體",
+      "english": "USB flash drive"
+    },
+    {
+      "from": "優衣庫",
+      "to": ["UNIQLO"],
+      "type": "cross_strait",
+      "context": "@domain 日常",
+      "english": "UNIQLO"
+    },
+    {
+      "from": "儲蓄卡",
+      "to": ["金融卡"],
+      "type": "cross_strait",
+      "context": "@domain 金融",
+      "english": "debit card",
+      "context_clues": ["銀行", "提款", "帳戶", "刷卡"]
     },
     {
       "from": "元數據",
       "to": [],
       "type": "cross_strait",
-      "context": "源自希臘文 meta- (關於) + data (資料)，原意為「描述資料的資料」",
+      "context": "@domain 資料。源自希臘文 meta- (關於) + data (資料)，原意為「描述資料的資料」",
       "english": "metadata"
     },
     {
       "from": "元編程",
       "to": ["超程式設計"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "metaprogramming/meta-programming"
     },
     {
       "from": "元音",
       "to": ["母音"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "vowel"
     },
     {
@@ -805,70 +1019,86 @@
       "from": "兄弟節點",
       "to": ["平輩節點"],
       "type": "cross_strait",
-      "context": "避免父權語彙。sibling 為中性詞，「平輩」明確表達同一層級的血緣關係而不指定性別",
+      "context": "@domain 資料結構。避免父權語彙。sibling 為中性詞，「平輩」明確表達同一層級的血緣關係而不指定性別",
       "english": "sibling node"
     },
     {
       "from": "充值",
       "to": ["加值", "儲值"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "top-up/recharge"
     },
     {
       "from": "充電寶",
       "to": ["行動電源"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "power bank"
     },
     {
       "from": "光伏",
       "to": ["太陽能板"],
       "type": "cross_strait",
+      "context": "@domain 能源",
       "english": "photovoltaic/solar panel"
     },
     {
       "from": "光刻機",
       "to": ["曝光機"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "lithography machine"
     },
     {
       "from": "光標",
       "to": ["游標"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "cursor"
     },
     {
       "from": "光盤",
       "to": ["光碟"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "optical disc"
     },
     {
       "from": "光驅",
       "to": ["光碟機"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "optical drive"
     },
     {
       "from": "克羅地亞",
       "to": ["克羅埃西亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Croatia"
     },
     {
       "from": "克隆",
       "to": ["複製"],
       "type": "cross_strait",
-      "context": "git 或類似命令的語境可保留英文",
+      "context": "@domain IT。git 或類似命令的語境可保留英文",
       "english": "clone"
     },
     {
       "from": "免提",
       "to": ["擴音"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "hands-free/speakerphone"
+    },
+    {
+      "from": "免賠額",
+      "to": ["自負額"],
+      "type": "cross_strait",
+      "context": "@domain 金融",
+      "english": "deductible",
+      "context_clues": ["保險", "理賠", "保單", "醫療"]
     },
     {
       "from": "內地",
@@ -881,7 +1111,7 @@
       "from": "內存",
       "to": ["記憶體"],
       "type": "cross_strait",
-      "context": "區分 RAM (記憶體) 與 ROM/Flash (儲存空間)",
+      "context": "@domain IT。區分 RAM (記憶體) 與 ROM/Flash (儲存空間)",
       "english": "memory (RAM)",
       "exceptions": ["海內存知己"]
     },
@@ -896,13 +1126,14 @@
       "from": "內嵌類",
       "to": ["內部類別"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "inner class"
     },
     {
       "from": "內核",
       "to": ["核心"],
       "type": "cross_strait",
-      "context": "限 IT 語境。天文領域也有「內核」，但指 inner core",
+      "context": "@domain 作業系統。限 IT 語境。天文領域也有「內核」，但指 inner core",
       "english": "kernel",
       "context_clues": ["Linux", "Windows", "Android", "作業系統", "驅動", "系統呼叫", "核心模組", "OS"],
       "exceptions": ["地球內核", "行星內核"]
@@ -911,68 +1142,92 @@
       "from": "內核映象",
       "to": ["核心映像檔"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "kernel image"
     },
     {
       "from": "內核棧",
       "to": ["核心堆疊"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "kernel stack"
     },
     {
       "from": "內核轉儲",
       "to": ["記憶體傾印"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "core dump"
     },
     {
       "from": "內核鏡像",
       "to": ["核心映像檔"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "kernel image"
+    },
+    {
+      "from": "內窺鏡",
+      "to": ["內視鏡"],
+      "type": "cross_strait",
+      "context": "@domain 醫學",
+      "english": "endoscope",
+      "context_clues": ["檢查", "手術", "胃", "腸"]
     },
     {
       "from": "內置",
       "to": ["內建"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "built-in"
+    },
+    {
+      "from": "內羅畢",
+      "to": ["奈洛比"],
+      "type": "cross_strait",
+      "context": "@geo city (城市)",
+      "english": "Nairobi"
     },
     {
       "from": "內聯",
       "to": ["行內", "內嵌"],
       "type": "cross_strait",
-      "context": "CSS 語境 vs function 語境",
+      "context": "@domain 程式設計。CSS 語境 vs function 語境",
       "english": "inline"
     },
     {
       "from": "內聯函數",
       "to": ["行內函數"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "inline function"
     },
     {
       "from": "內聯展開",
       "to": ["行內展開"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "inline expansion"
     },
     {
       "from": "全局",
       "to": ["全域"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "global"
     },
     {
       "from": "全局對象",
       "to": ["全域物件"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "global object"
     },
     {
       "from": "全局的",
       "to": ["全域的"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "global",
       "context_clues": ["變數", "變量", "函式", "函數", "作用域", "生存空間"]
     },
@@ -980,25 +1235,28 @@
       "from": "全局範圍解析操作符",
       "to": ["全域生存空間運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "global scope resolution operator"
     },
     {
       "from": "全屏",
       "to": ["全螢幕"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "fullscreen"
     },
     {
       "from": "全棧",
       "to": ["全端"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "full-stack"
     },
     {
       "from": "全角",
       "to": ["全形"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "full-width"
     },
     {
@@ -1012,55 +1270,70 @@
       "from": "公交",
       "to": ["公車"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "public bus"
     },
     {
       "from": "公交車",
       "to": ["公車"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "public bus"
     },
     {
       "from": "共享庫",
       "to": ["共享函式庫"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "shared library"
     },
     {
       "from": "兼容",
       "to": ["相容"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "compatible"
     },
     {
       "from": "冒泡排序",
       "to": ["泡沫排序", "氣泡排序"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "bubble sort"
     },
     {
       "from": "冪次",
       "to": ["冪"],
       "type": "cross_strait",
-      "context": "cn 用「冪次」表示 power，tw 數學標準用「冪」（如「2 的 3 次冪」）或「乘冪」",
+      "context": "@domain 數學。cn 用「冪次」表示 power，tw 數學標準用「冪」（如「2 的 3 次冪」）或「乘冪」",
       "english": "power (mathematics)"
     },
     {
       "from": "冰棍",
       "to": ["冰棒"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "popsicle"
+    },
+    {
+      "from": "冰激凌",
+      "to": ["冰淇淋"],
+      "type": "cross_strait",
+      "context": "@domain 日常",
+      "english": "ice cream"
     },
     {
       "from": "出租車",
       "to": ["計程車"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "taxi"
     },
     {
       "from": "函子",
       "to": ["仿函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "functor"
     },
     {
@@ -1085,30 +1358,35 @@
       "from": "函數對象",
       "to": ["函式物件"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "function object"
     },
     {
       "from": "函數庫",
       "to": ["函式庫", "程式庫"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "library"
     },
     {
       "from": "函數式編程",
       "to": ["函數語言程式設計"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "functional programming"
     },
     {
       "from": "函數式語言",
       "to": ["函數式程式語言"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "functional language"
     },
     {
       "from": "函數模板",
       "to": ["函式模板", "函式範本"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "function template"
     },
     {
@@ -1122,69 +1400,85 @@
       "from": "函數重載解決",
       "to": ["函式多載決議"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "function overloaded resolution"
     },
     {
       "from": "刀片服務器",
       "to": ["刀鋒伺服器"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "blade server"
     },
     {
       "from": "分佈式",
       "to": ["分散式"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "distributed"
     },
     {
       "from": "分佈式計算",
       "to": ["分散式計算"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "distributed computing"
     },
     {
       "from": "分割槽",
       "to": ["分割區"],
       "type": "cross_strait",
-      "context": "OpenCC 可能將「分区」轉為「分割槽」，tw 正確用語為「分割區」",
+      "context": "@domain 作業系統。OpenCC 可能將「分区」轉為「分割槽」，tw 正確用語為「分割區」",
       "english": "partition"
+    },
+    {
+      "from": "分割線",
+      "to": ["分隔線"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "divider",
+      "context_clues": ["UI", "介面", "排版", "分隔"]
     },
     {
       "from": "分區",
       "to": ["分割區"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "partition"
     },
     {
       "from": "分形",
       "to": ["碎形"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "fractal"
     },
     {
       "from": "分派",
       "to": ["發派"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "dispatch"
     },
     {
       "from": "分組框",
       "to": ["群組方塊"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "group box"
     },
     {
       "from": "分辨率",
       "to": ["解析度"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "resolution"
     },
     {
       "from": "分配",
       "to": ["配置"],
       "type": "cross_strait",
-      "context": "限記憶體配置語境。「分配工作」(assign/distribute) 為正確 tw 用法",
+      "context": "@domain 系統程式。限記憶體配置語境。「分配工作」(assign/distribute) 為正確 tw 用法",
       "english": "allocate",
       "context_clues": ["記憶體", "內存", "malloc", "heap", "堆疊", "指標", "指針", "位元組"]
     },
@@ -1192,26 +1486,28 @@
       "from": "分配器",
       "to": ["配置器"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "allocator"
     },
     {
       "from": "切分窗口",
       "to": ["分裂視窗"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "splitter"
     },
     {
       "from": "列支敦士登",
       "to": ["列支敦斯登"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Liechtenstein"
     },
     {
       "from": "列表",
       "to": ["串列"],
       "type": "cross_strait",
-      "context": "限資料結構語境。UI 語境中「列表」通常應譯為「清單」",
+      "context": "@domain UI。限資料結構語境。UI 語境中「列表」通常應譯為「清單」",
       "english": "list",
       "context_clues": ["資料結構", "數組", "陣列", "鏈結", "鏈表", "遍歷", "走訪"]
     },
@@ -1219,20 +1515,36 @@
       "from": "列集",
       "to": ["編列"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "marshal"
+    },
+    {
+      "from": "利比裡亞",
+      "to": ["賴比瑞亞"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Liberia"
     },
     {
       "from": "利比里亞",
       "to": ["賴比瑞亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Liberia"
+    },
+    {
+      "from": "利潤表",
+      "to": ["損益表"],
+      "type": "cross_strait",
+      "context": "@domain 金融",
+      "english": "income statement / P&L",
+      "context_clues": ["財報", "會計", "營收", "損益"]
     },
     {
       "from": "刷新",
       "to": ["重新整理"],
       "type": "cross_strait",
-      "context": "限 UI 語境。「刷新紀錄」(break a record) 為正確用法，不應替換",
+      "context": "@domain UI。限 UI 語境。「刷新紀錄」(break a record) 為正確用法，不應替換",
       "english": "refresh",
       "context_clues": ["頁面", "瀏覽器", "網頁", "載入", "加載", "快取", "緩存", "按鈕"]
     },
@@ -1240,86 +1552,113 @@
       "from": "刷新率",
       "to": ["更新率"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "refresh rate"
     },
     {
       "from": "刻錄",
       "to": ["燒錄"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "burn (disc)"
+    },
+    {
+      "from": "剃鬚刀",
+      "to": ["刮鬍刀"],
+      "type": "cross_strait",
+      "context": "@domain 日常",
+      "english": "razor"
     },
     {
       "from": "前列腺",
       "to": ["攝護腺"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "prostate"
     },
     {
       "from": "前沿",
       "to": ["尖端", "前瞻", "先進"],
       "type": "cross_strait",
+      "context": "@domain UI。視語境選用：「尖端」(技術)、「前瞻」(研究)、「先進」(一般)",
       "english": "cutting-edge/frontier"
     },
     {
       "from": "前綴",
       "to": ["字首"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "prefix"
     },
     {
       "from": "前置聲明",
       "to": ["前置宣告"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "forward declaration"
     },
     {
       "from": "剪切",
       "to": ["剪下", "裁切"],
       "type": "cross_strait",
+      "context": "@domain UI。UI 操作 cut = 剪下；圖片裁剪 crop = 裁切",
       "english": "cut"
     },
     {
       "from": "剪貼板",
       "to": ["剪貼簿"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "clipboard"
     },
     {
       "from": "創口貼",
       "to": ["OK繃"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "adhesive bandage"
     },
     {
       "from": "創建",
       "to": ["建立"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "create"
     },
     {
       "from": "功放",
       "to": ["功率擴大機"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "power amplifier"
+    },
+    {
+      "from": "加息",
+      "to": ["升息"],
+      "type": "cross_strait",
+      "context": "@domain 金融",
+      "english": "interest rate hike",
+      "context_clues": ["利率", "央行", "貨幣", "聯準會"]
     },
     {
       "from": "加納",
       "to": ["迦納"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Ghana"
     },
     {
       "from": "加蓬",
       "to": ["加彭"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Gabon"
     },
     {
       "from": "加載",
       "to": ["載入"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "load"
     },
     {
@@ -1333,62 +1672,92 @@
       "from": "動態庫",
       "to": ["動態函式庫"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "dynamic library"
     },
     {
       "from": "動態綁定",
       "to": ["動態繫結"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "dynamic binding"
+    },
+    {
+      "from": "包管理器",
+      "to": ["套件管理員"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "package manager",
+      "context_clues": ["npm", "pip", "apt", "安裝", "套件"]
     },
     {
       "from": "包郵",
       "to": ["含運"],
       "type": "cross_strait",
+      "context": "@domain 金融",
       "english": "free shipping"
     },
     {
       "from": "匯編",
       "to": ["組譯"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "assembly"
     },
     {
       "from": "匯編語言",
       "to": ["組合語言"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "assembly language"
     },
     {
       "from": "千兆",
       "to": ["十億"],
       "type": "cross_strait",
-      "context": "cn「兆」= 10^6 (百萬)，tw「兆」= 10^12，量級定義不同",
+      "context": "@domain IT。cn「兆」= 10^6 (百萬)，tw「兆」= 10^12，量級定義不同",
       "english": "giga"
+    },
+    {
+      "from": "千克",
+      "to": ["公斤"],
+      "type": "cross_strait",
+      "context": "@domain 日常",
+      "english": "kilogram"
+    },
+    {
+      "from": "千米",
+      "to": ["公里"],
+      "type": "cross_strait",
+      "context": "@domain 日常",
+      "english": "kilometer"
     },
     {
       "from": "半角",
       "to": ["半形"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "half-width"
     },
     {
       "from": "協議",
       "to": ["協定"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "protocol"
     },
     {
       "from": "博主",
       "to": ["部落客"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "blogger"
     },
     {
       "from": "博客",
       "to": ["部落格", "網誌"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "blog",
       "exceptions": ["博客來"]
     },
@@ -1396,28 +1765,28 @@
       "from": "博茨瓦納",
       "to": ["波札那"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Botswana"
     },
     {
       "from": "卡內基梅隆大學",
       "to": ["卡內基·美隆大學"],
       "type": "cross_strait",
-      "context": "Carnegie Mellon University (CMU)；tw 慣用間隔號「·」分隔音譯複合姓名",
+      "context": "@geo university (大學)",
       "english": "Carnegie Mellon University"
     },
     {
       "from": "卡塔爾",
       "to": ["卡達"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Qatar"
     },
     {
       "from": "危地馬拉",
       "to": ["瓜地馬拉"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Guatemala"
     },
     {
@@ -1432,7 +1801,7 @@
       "from": "卸載",
       "to": ["解除安裝", "移除"],
       "type": "cross_strait",
-      "context": "完整移除軟體 (uninstall) vs 移除某個元件/項目 (remove)",
+      "context": "@domain IT。完整移除軟體 (uninstall) vs 移除某個元件/項目 (remove)",
       "english": "uninstall",
       "negative_context_clues": ["掛載", "mount", "umount", "unmount", "檔案系統", "分割區"]
     },
@@ -1440,34 +1809,42 @@
       "from": "厄瓜多爾",
       "to": ["厄瓜多"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Ecuador"
     },
     {
       "from": "厄立特里亞",
       "to": ["厄利垂亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Eritrea"
+    },
+    {
+      "from": "厘米",
+      "to": ["公分"],
+      "type": "cross_strait",
+      "context": "@domain 日常",
+      "english": "centimeter"
     },
     {
       "from": "原代碼",
       "to": ["原始程式碼"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "source code"
     },
     {
       "from": "原始碼",
       "to": ["原始程式碼"],
       "type": "cross_strait",
-      "context": "tw 標準用語為「原始程式碼」(source code)",
+      "context": "@domain IT。tw 標準用語為「原始程式碼」(source code)",
       "exceptions": ["開放原始碼"]
     },
     {
       "from": "原子操作",
       "to": ["不可分割操作", "最小操作"],
       "type": "cross_strait",
-      "context": "此處「原子」為 indivisible 語意，非物理學的 atom",
+      "context": "@domain 程式設計。此處「原子」為 indivisible 語意，非物理學的 atom",
       "english": "atomic operation"
     },
     {
@@ -1475,70 +1852,77 @@
       "to": ["引數"],
       "type": "cross_strait",
       "disabled": true,
-      "context": "tw: 參數=parameter (correct tw), 引數=argument. Rule disabled: flagging 參數 is a false positive.",
+      "context": "@domain 程式設計。tw: 參數=parameter (correct tw), 引數=argument. Rule disabled: flagging 參數 is a false positive.",
       "english": "parameter"
     },
     {
       "from": "參數列表",
       "to": ["參數列"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "parameter list"
     },
     {
       "from": "參數表",
       "to": ["參數列"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "parameter list"
     },
     {
       "from": "反安裝",
       "to": ["解除安裝"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "uninstall"
     },
     {
       "from": "反碼",
       "to": ["一補數"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "ones' complement"
     },
     {
       "from": "反饋",
       "to": ["回饋"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "feedback"
     },
     {
       "from": "叔伯節點",
       "to": ["親代的平輩節點"],
       "type": "cross_strait",
-      "context": "避免父權語彙。parent's sibling 應譯為中性用語",
+      "context": "@domain 資料結構。避免父權語彙。parent's sibling 應譯為中性用語",
       "english": "uncle node/parent's sibling node"
     },
     {
       "from": "取地址操作符",
       "to": ["取址運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "address-of operator"
     },
     {
       "from": "句柄",
       "to": ["代號", "控制代碼", "控制代號"],
       "type": "cross_strait",
-      "context": "限程式設計語境，作為名詞時使用",
+      "context": "@domain 程式設計。限程式設計語境，作為名詞時使用",
       "english": "handle"
     },
     {
       "from": "另存為",
       "to": ["另存新檔"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "save as"
     },
     {
       "from": "只讀",
       "to": ["唯讀"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "read-only"
     },
     {
@@ -1552,12 +1936,14 @@
       "from": "可行函數",
       "to": ["可行函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "viable function"
     },
     {
       "from": "可視化",
       "to": ["視覺化"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "visualization"
     },
     {
@@ -1588,6 +1974,7 @@
       "from": "台式電腦",
       "to": ["桌上型電腦"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "desktop computer"
     },
     {
@@ -1606,83 +1993,115 @@
       "from": "台球",
       "to": ["撞球"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "billiards"
+    },
+    {
+      "from": "合同",
+      "to": ["合約"],
+      "type": "cross_strait",
+      "context": "@domain 商業",
+      "english": "contract",
+      "context_clues": ["簽訂", "條款", "甲方", "乙方", "履行"]
     },
     {
       "from": "吉布提",
       "to": ["吉布地"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Djibouti"
+    },
+    {
+      "from": "吉爾吉斯斯坦",
+      "to": ["吉爾吉斯"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Kyrgyzstan"
     },
     {
       "from": "向下兼容",
       "to": ["回溯相容"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "backward compatible"
     },
     {
       "from": "呼出",
       "to": ["撥出"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "dial out"
     },
     {
       "from": "呼叫轉移",
       "to": ["來電轉接"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "call forwarding"
     },
     {
       "from": "命令式編程",
       "to": ["命令式程式設計"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "imperative programming"
     },
     {
       "from": "命令行",
       "to": ["命令列"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "command line"
     },
     {
       "from": "命名空間",
       "to": ["名稱空間", "名字空間"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "namespace"
     },
     {
       "from": "咖喱",
       "to": ["咖哩"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "curry"
     },
     {
       "from": "哈希",
       "to": ["雜湊"],
       "type": "cross_strait",
-      "context": "意指將資料打散混雜再映射，採意譯「雜湊」描述其機制，非音譯",
+      "context": "@domain IT。意指將資料打散混雜再映射，採意譯「雜湊」描述其機制，非音譯",
       "english": "hash"
     },
     {
       "from": "哈希表",
       "to": ["雜湊表"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "hash table"
     },
     {
       "from": "哈薩克斯坦",
       "to": ["哈薩克"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Kazakhstan"
     },
     {
       "from": "哥斯達黎加",
       "to": ["哥斯大黎加"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Costa Rica"
+    },
+    {
+      "from": "哮喘",
+      "to": ["氣喘"],
+      "type": "cross_strait",
+      "context": "@domain 醫學",
+      "english": "asthma",
+      "context_clues": ["呼吸", "過敏", "症狀", "治療"]
     },
     {
       "from": "啓",
@@ -1700,12 +2119,14 @@
       "from": "單參函數",
       "to": ["一元函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "unary function"
     },
     {
       "from": "單擊",
       "to": ["點選", "按一下"],
       "type": "cross_strait",
+      "context": "@domain UI。UI 操作 click",
       "english": "click"
     },
     {
@@ -1719,19 +2140,29 @@
       "from": "單片機",
       "to": ["微控制器"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "microcontroller (MCU)"
     },
     {
       "from": "單選按鈕",
       "to": ["選項按鈕", "圓鈕"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "radio button"
+    },
+    {
+      "from": "單選框",
+      "to": ["選項按鈕"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "radio button",
+      "context_clues": ["表單", "UI", "選擇", "勾選", "介面"]
     },
     {
       "from": "嚮導",
       "to": ["精靈"],
       "type": "cross_strait",
-      "context": "限 UI 語境。非 UI 語境中「嚮導」仍正確 (如旅遊嚮導)",
+      "context": "@domain UI。限 UI 語境。非 UI 語境中「嚮導」仍正確 (如旅遊嚮導)",
       "english": "wizard (UI)",
       "context_clues": ["安裝", "設定", "配置", "視窗", "窗口", "步驟", "下一步"]
     },
@@ -1743,28 +2174,39 @@
       "english": "quad-core"
     },
     {
+      "from": "回收站",
+      "to": ["資源回收桶"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "recycle bin",
+      "context_clues": ["刪除", "檔案", "桌面", "清空", "還原"]
+    },
+    {
       "from": "回放",
       "to": ["重播"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "playback"
     },
     {
       "from": "回滾",
       "to": ["回溯", "還原"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "rollback"
     },
     {
       "from": "回調",
       "to": ["回呼"],
       "type": "cross_strait",
-      "context": "有時翻譯為「回呼」",
+      "context": "@domain 程式設計。有時翻譯為「回呼」",
       "english": "callback"
     },
     {
       "from": "回車",
       "to": ["Enter"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "Enter key/carriage return"
     },
     {
@@ -1777,87 +2219,98 @@
       "from": "固件",
       "to": ["韌體"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "firmware"
     },
     {
       "from": "固態硬盤",
       "to": ["固態硬碟"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "SSD (solid-state drive)"
     },
     {
       "from": "圓括弧",
       "to": ["小括弧", "小括號"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "parentheses"
     },
     {
       "from": "圓括號",
       "to": ["小括弧", "小括號"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "parentheses"
     },
     {
       "from": "圓珠筆",
       "to": ["原子筆"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "ballpoint pen"
     },
     {
       "from": "圖像",
       "to": ["影像", "圖片"],
       "type": "cross_strait",
+      "context": "@domain IT。照片/圖檔 = 圖片 (image file)；電腦視覺/處理 = 影像 (visual image)",
       "english": "image"
     },
     {
       "from": "圖元",
       "to": ["畫素"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "pixel"
     },
     {
       "from": "圖庫",
       "to": ["相簿"],
       "type": "cross_strait",
+      "context": "@domain 社群",
       "english": "photo gallery"
     },
     {
       "from": "圖形界面",
       "to": ["圖形介面"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "GUI"
     },
     {
       "from": "圖標",
       "to": ["圖示"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "icon"
     },
     {
       "from": "圖瓦盧",
       "to": ["吐瓦魯"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Tuvalu"
     },
     {
       "from": "圖象",
       "to": ["影像"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "image"
     },
     {
       "from": "土庫曼斯坦",
       "to": ["土庫曼"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Turkmenistan"
     },
     {
       "from": "土豆",
       "to": ["馬鈴薯"],
       "type": "cross_strait",
-      "context": "tw 「土豆」指花生 (peanuts)，語意完全不同",
+      "context": "@domain 日常。tw 「土豆」指花生 (peanuts)，語意完全不同",
       "english": "potato"
     },
     {
@@ -1870,6 +2323,7 @@
       "from": "在線",
       "to": ["線上"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "online"
     },
     {
@@ -1900,7 +2354,7 @@
       "from": "圭亞那",
       "to": ["蓋亞那"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Guyana"
     },
     {
@@ -1915,89 +2369,120 @@
       "from": "地址欄",
       "to": ["位址列"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "address bar"
     },
     {
       "from": "地址空間",
       "to": ["定址空間"],
       "type": "cross_strait",
-      "context": "限 IT 語境",
+      "context": "@domain 作業系統。限 IT 語境",
       "english": "address space"
     },
     {
       "from": "坦桑尼亞",
       "to": ["坦尚尼亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Tanzania"
     },
     {
       "from": "埃塞俄比亞",
       "to": ["衣索比亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Ethiopia"
+    },
+    {
+      "from": "埃菲爾鐵塔",
+      "to": ["艾菲爾鐵塔"],
+      "type": "cross_strait",
+      "context": "@geo landmark (地標)",
+      "english": "Eiffel Tower"
     },
     {
       "from": "城域網",
       "to": ["都會網路"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "metropolitan area network (MAN)"
+    },
+    {
+      "from": "域名",
+      "to": ["網域"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "domain name",
+      "context_clues": ["DNS", "網址", "註冊", "伺服器", "網站"]
     },
     {
       "from": "埠口",
       "to": ["通訊埠", "連接埠"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "port"
     },
     {
       "from": "培訓",
       "to": ["教育訓練"],
       "type": "cross_strait",
+      "context": "@domain 教育",
       "english": "training"
     },
     {
       "from": "基帶",
       "to": ["基頻"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "baseband"
     },
     {
       "from": "基於對象的",
       "to": ["以物件為基礎的"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "object based"
     },
     {
       "from": "基於消息的",
       "to": ["以訊息為基礎的"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "message based"
     },
     {
       "from": "基站",
       "to": ["基地台"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "base station"
+    },
+    {
+      "from": "基裡巴斯",
+      "to": ["吉里巴斯"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Kiribati"
     },
     {
       "from": "基里巴斯",
       "to": ["吉里巴斯"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Kiribati"
     },
     {
       "from": "基類",
       "to": ["基底類別", "基礎類別"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "base class"
     },
     {
       "from": "堆",
       "to": ["堆積"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "heap",
       "exceptions": ["堆疊", "垃圾堆", "土堆", "障堆", "堆積"]
     },
@@ -2005,19 +2490,21 @@
       "from": "堆棧",
       "to": ["堆疊"],
       "type": "cross_strait",
-      "context": "cn 常用「堆棧」表示 stack; 若無此規則，個別規則 堆→堆積 + 棧→堆疊 會產生錯誤的「堆積堆疊」",
+      "context": "@domain IT。cn 常用「堆棧」表示 stack; 若無此規則，個別規則 堆→堆積 + 棧→堆疊 會產生錯誤的「堆積堆疊」",
       "english": "stack"
     },
     {
       "from": "報道",
       "to": ["報導"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "news report"
     },
     {
       "from": "場效應管",
       "to": ["場效電晶體"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "field-effect transistor (FET)"
     },
     {
@@ -2032,59 +2519,63 @@
       "from": "塑料",
       "to": ["塑膠"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "plastic"
     },
     {
       "from": "塔吉克斯坦",
       "to": ["塔吉克"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Tajikistan"
     },
     {
       "from": "塞拉利昂",
       "to": ["獅子山"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Sierra Leone"
     },
     {
       "from": "塞浦路斯",
       "to": ["塞普勒斯"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Cyprus"
     },
     {
       "from": "塞舌爾",
       "to": ["塞席爾"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Seychelles"
     },
     {
       "from": "增加操作符",
       "to": ["累加運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "increment operator"
     },
     {
       "from": "墻紙",
       "to": ["桌布"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "wallpaper"
     },
     {
       "from": "壁紙",
       "to": ["桌布"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "wallpaper"
     },
     {
       "from": "外圍類",
       "to": ["外圍類別"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "enclosing class",
       "exceptions": ["外圍類別"]
     },
@@ -2092,30 +2583,35 @@
       "from": "外置",
       "to": ["外接"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "external"
     },
     {
       "from": "外設",
       "to": ["硬體周邊"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "peripheral"
     },
     {
       "from": "外鍵",
       "to": ["外部索引鍵"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "foreign key"
     },
     {
       "from": "多任務",
       "to": ["多工"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "multitasking/multi-tasking"
     },
     {
       "from": "多態",
       "to": ["多型"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "polymorphism"
     },
     {
@@ -2129,25 +2625,28 @@
       "from": "多米尼加",
       "to": ["多明尼加"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Dominican Republic"
     },
     {
       "from": "多線程",
       "to": ["多執行緒"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "multithreading/multi-threading"
     },
     {
       "from": "多線程安全",
       "to": ["多執行緒安全"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "thread safe"
     },
     {
       "from": "大文件",
       "to": ["大檔案"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "large file"
     },
     {
@@ -2160,24 +2659,28 @@
       "from": "奔馳",
       "to": ["賓士"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "Mercedes-Benz"
     },
     {
       "from": "套接字",
-      "to": [],
+      "to": ["Socket"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "socket"
     },
     {
       "from": "奶酪",
       "to": ["乳酪"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "cheese"
     },
     {
       "from": "委託",
       "to": ["委派"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "delegate"
     },
     {
@@ -2191,6 +2694,14 @@
       "to": ["媯"],
       "type": "variant",
       "context": "MoE 標準字體 (姓氏)"
+    },
+    {
+      "from": "子域名",
+      "to": ["子網域"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "subdomain",
+      "context_clues": ["DNS", "網域", "網址", "伺服器"]
     },
     {
       "from": "子常式",
@@ -2212,6 +2723,7 @@
       "from": "子網掩碼",
       "to": ["子網路遮罩"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "subnet mask"
     },
     {
@@ -2225,6 +2737,7 @@
       "from": "子類",
       "to": ["子類別"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "child class",
       "exceptions": ["子類別"]
     },
@@ -2232,55 +2745,71 @@
       "from": "子類型",
       "to": ["子型別"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "subtype"
     },
     {
       "from": "字庫",
       "to": ["字型檔"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "font library"
     },
     {
       "from": "字段",
       "to": ["欄位"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "field"
     },
     {
       "from": "字符",
       "to": ["字元"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "character"
     },
     {
       "from": "字符串",
       "to": ["字串"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "string"
     },
     {
       "from": "字符集",
       "to": ["字元集"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "character set"
     },
     {
       "from": "字節",
       "to": ["位元組"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "byte"
     },
     {
       "from": "字處理器",
       "to": ["文書處理器"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "word processor"
+    },
+    {
+      "from": "字號",
+      "to": ["字級"],
+      "type": "cross_strait",
+      "context": "@domain UI。限 GUI/HCI 語境。指號碼與代號時，仍可用，如「公文字號」和「身分證字號」",
+      "english": "font size",
+      "context_clues": ["字型", "文字", "大小", "pt", "CSS"]
     },
     {
       "from": "字面量",
       "to": ["字面值", "原詞"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "literal"
     },
     {
@@ -2288,25 +2817,44 @@
       "to": ["字型"],
       "type": "confusable",
       "context": "區分特定組合 (字型) 與整套設計風格 (字體)",
-      "english": "font"
+      "english": "font",
+      "context_clues": ["設計", "風格", "家族", "font", "family"]
     },
     {
       "from": "存儲",
       "to": ["儲存"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "storage"
     },
     {
       "from": "存儲卡",
       "to": ["記憶卡"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "memory card"
+    },
+    {
+      "from": "存儲過程",
+      "to": ["預存程序"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "stored procedure",
+      "context_clues": ["SQL", "資料庫", "呼叫", "參數"]
     },
     {
       "from": "存盤",
       "to": ["存檔"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "save to disk"
+    },
+    {
+      "from": "孟加拉國",
+      "to": ["孟加拉"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Bangladesh"
     },
     {
       "from": "孤兒程序",
@@ -2319,33 +2867,58 @@
       "from": "宇航員",
       "to": ["太空人"],
       "type": "cross_strait",
+      "context": "@domain 航太",
       "english": "astronaut"
     },
     {
       "from": "守護進程",
       "to": ["系統守護行程"],
       "type": "cross_strait",
-      "context": "限 Unix 風格之作業系統語境",
+      "context": "@domain 作業系統。限 Unix 風格之作業系統語境",
       "english": "daemon"
     },
     {
       "from": "安保",
       "to": ["保全"],
       "type": "cross_strait",
-      "context": "tw: 保全 (security guard/security); cn: 安保",
+      "context": "@domain 資安。tw: 保全 (security guard/security); cn: 安保",
       "english": "security"
+    },
+    {
+      "from": "安全審計",
+      "to": ["資安稽核"],
+      "type": "cross_strait",
+      "context": "@domain 資安",
+      "english": "security audit",
+      "context_clues": ["安全", "漏洞", "稽核", "合規"]
+    },
+    {
+      "from": "安卓",
+      "to": ["Android"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "Android"
     },
     {
       "from": "安提瓜和巴布達",
       "to": ["安地卡及巴布達"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Antigua and Barbuda"
+    },
+    {
+      "from": "安裝包",
+      "to": ["安裝檔"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "installer/package",
+      "context_clues": ["下載", "安裝", "軟體", "APP"]
     },
     {
       "from": "宏",
       "to": ["巨集"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "macro",
       "exceptions": ["宏觀", "宏大", "宏偉", "宏亮", "宏願", "宏圖", "宏旨", "宏遠", "恢宏", "寬宏", "宏碁", "宏達電", "宏核心", "宏內核"]
     },
@@ -2353,32 +2926,35 @@
       "from": "宏內核",
       "to": ["單體式核心"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "monolithic kernel"
     },
     {
       "from": "宏核心",
       "to": ["單體式核心"],
       "type": "cross_strait",
-      "context": "monolithic kernel 的 cn 用法；tw 用「單體式核心」以區分 kernel (核心)",
+      "context": "@domain 作業系統。monolithic kernel 的 cn 用法；tw 用「單體式核心」以區分 kernel (核心)",
       "english": "monolithic kernel"
     },
     {
       "from": "客戶/服務器",
       "to": ["主從架構"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "client-server"
     },
     {
       "from": "客戶端",
       "to": ["用戶端"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "client"
     },
     {
       "from": "寄存器",
       "to": ["暫存器"],
       "type": "cross_strait",
-      "context": "限 CPU/硬體語境。cash register 翻譯為「收銀機」，不適用本規則",
+      "context": "@domain 程式設計。限 CPU/硬體語境。cash register 翻譯為「收銀機」，不適用本規則",
       "english": "register",
       "context_clues": ["CPU", "處理器", "指令", "記憶體", "架構", "組合語言", "assembly", "ALU", "暫存"]
     },
@@ -2386,13 +2962,14 @@
       "from": "密鑰",
       "to": ["金鑰"],
       "type": "cross_strait",
+      "context": "@domain 資安",
       "english": "key (cryptographic)"
     },
     {
       "from": "實例",
       "to": ["實體", "例項", "具現體", "具現化實體"],
       "type": "cross_strait",
-      "context": "依 MoE 辭典，「實例」僅有 example (實際例子) 之意。程式設計中 instance 應譯「實體」或「具現體」，不可借用「實例」",
+      "context": "@domain 程式設計。依 MoE 辭典，「實例」僅有 example (實際例子) 之意。程式設計中 instance 應譯「實體」或「具現體」，不可借用「實例」",
       "english": "instance",
       "context_clues": ["物件", "對象", "類別", "class", "new", "建構", "方法", "OOP", "繼承", "多型", "介面", "實體化", "具現化"]
     },
@@ -2400,25 +2977,28 @@
       "from": "實例化",
       "to": ["具現化", "實體化"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "instantiated"
     },
     {
       "from": "實參",
       "to": ["引數"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "argument"
     },
     {
       "from": "實時",
       "to": ["即時"],
       "type": "cross_strait",
-      "context": "即時 = 在指定或預期的時間範圍內務必達成。just in time = 及時 (略晚但在可容許的範圍內)，二者語意不同",
+      "context": "@domain IT。即時 = 在指定或預期的時間範圍內務必達成。just in time = 及時 (略晚但在可容許的範圍內)，二者語意不同",
       "english": "real-time"
     },
     {
       "from": "實模式",
       "to": ["真實模式"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "real mode",
       "exceptions": ["真實模式"]
     },
@@ -2426,7 +3006,7 @@
       "from": "實現",
       "to": ["實作"],
       "type": "cross_strait",
-      "context": "限程式設計語境 (implement)。非 IT 語境可表示 realize，為正確 tw 用法",
+      "context": "@domain 程式設計。限程式設計語境 (implement)。非 IT 語境可表示 realize，為正確 tw 用法",
       "english": "implement",
       "context_clues": ["函式", "函數", "介面", "接口", "程式碼", "代碼", "類別", "方法", "演算法", "算法", "模組", "編譯", "核心", "驅動", "系統呼叫", "API", "IPC"]
     },
@@ -2441,12 +3021,14 @@
       "from": "審覈",
       "to": ["稽核"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "audit/review"
     },
     {
       "from": "寫保護",
       "to": ["防寫"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "write protection"
     },
     {
@@ -2460,32 +3042,35 @@
       "from": "寬帶",
       "to": ["寬頻"],
       "type": "cross_strait",
-      "context": "tw 用語採取「頻」而非「帶」",
+      "context": "@domain 網路。tw 用語採取「頻」而非「帶」",
       "english": "broadband"
     },
     {
       "from": "封禁",
       "to": ["封鎖"],
       "type": "cross_strait",
+      "context": "@domain 社群",
       "english": "ban"
     },
     {
       "from": "尋址",
       "to": ["定址"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "address (verb)"
     },
     {
       "from": "對話框",
       "to": ["對話方塊", "對話窗", "對話盒"],
       "type": "cross_strait",
+      "context": "@domain UI。tw「對話方塊」為 Microsoft 用語；「對話窗」「對話盒」亦常見",
       "english": "dialog box"
     },
     {
       "from": "對象",
       "to": ["物件"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "object",
       "context_clues": ["類別", "屬性", "方法", "繼承", "封裝", "多型", "實例", "程式碼", "代碼", "介面", "函式"],
       "negative_context_clues": ["批評"],
@@ -2495,25 +3080,45 @@
       "from": "對象模型",
       "to": ["物件模型"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "object model"
     },
     {
       "from": "導入",
       "to": ["匯入"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "import"
     },
     {
       "from": "導出",
       "to": ["匯出"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "export"
+    },
+    {
+      "from": "導師",
+      "to": ["指導教授"],
+      "type": "cross_strait",
+      "context": "@domain 教育。限學術語境。cn「導師」；tw 用「指導教授」(advisor/supervisor)",
+      "english": "advisor/supervisor",
+      "context_clues": ["論文", "研究", "碩士", "博士", "指導"]
     },
     {
       "from": "導航",
       "to": ["導覽"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "navigate"
+    },
+    {
+      "from": "導航欄",
+      "to": ["導覽列"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "navigation bar",
+      "context_clues": ["網頁", "瀏覽器", "選單", "UI", "介面", "導覽"]
     },
     {
       "from": "就緒進程",
@@ -2526,27 +3131,28 @@
       "from": "尼日利亞",
       "to": ["奈及利亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Nigeria"
     },
     {
       "from": "尼日爾",
       "to": ["尼日"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Niger"
     },
     {
       "from": "局域網",
       "to": ["區域網路"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "LAN (local area network)"
     },
     {
       "from": "局部",
       "to": ["區域性"],
       "type": "cross_strait",
-      "context": "限程式設計語境 (local variable/scope)。「局部」(partial/local area) 為標準 tw 用法",
+      "context": "@domain 程式設計。限程式設計語境 (local variable/scope)。「局部」(partial/local area) 為標準 tw 用法",
       "english": "local",
       "context_clues": ["變數", "變量", "函式", "函數", "local", "區域", "全域"],
       "negative_context_clues": ["局部細節", "局部最", "局部地區", "局部區域"]
@@ -2555,19 +3161,21 @@
       "from": "局部對象",
       "to": ["區域物件"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "local object"
     },
     {
       "from": "局部特化",
       "to": ["偏特化"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "partial specialization"
     },
     {
       "from": "局部的",
       "to": ["區域的"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "local",
       "context_clues": ["變數", "變量", "函式", "函數", "作用域", "生存空間"]
     },
@@ -2575,44 +3183,49 @@
       "from": "局部變量",
       "to": ["區域變數"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "local variable"
     },
     {
       "from": "屏保",
       "to": ["螢幕保護程式"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "screensaver"
     },
     {
       "from": "屏幕",
       "to": ["螢幕"],
       "type": "cross_strait",
-      "context": "projection screen (電影院) = 銀幕，與電子顯示裝置用途不同",
+      "context": "@domain 硬體。projection screen (電影院) = 銀幕，與電子顯示裝置用途不同",
       "english": "screen"
     },
     {
       "from": "屏幕截圖",
       "to": ["螢幕截圖", "螢幕快照"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "snapshot"
     },
     {
       "from": "屏蔽",
       "to": ["封鎖"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "block"
     },
     {
       "from": "層次結構",
       "to": ["階層結構", "階層", "階層體系"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "hierarchy"
     },
     {
       "from": "岡比亞",
       "to": ["甘比亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Gambia"
     },
     {
@@ -2625,19 +3238,29 @@
       "from": "嵌套",
       "to": ["巢狀"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "nested"
     },
     {
       "from": "嵌套類",
       "to": ["巢狀類別"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "nested class"
+    },
+    {
+      "from": "工具欄",
+      "to": ["工具列"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "toolbar",
+      "context_clues": ["瀏覽器", "選單", "按鈕", "視窗", "介面", "UI"]
     },
     {
       "from": "工程",
       "to": ["專案"],
       "type": "cross_strait",
-      "context": "限 project 語境。「軟體工程」(software engineering) 為正確 tw 用法",
+      "context": "@domain IT。限 project 語境。「軟體工程」(software engineering) 為正確 tw 用法",
       "english": "project",
       "context_clues": ["專案", "項目", "管理", "IDE", "開發"],
       "exceptions": ["工程師", "軟體工程", "軟件工程", "逆向工程", "工程學"]
@@ -2646,78 +3269,115 @@
       "from": "巨集核心",
       "to": ["單體式核心"],
       "type": "cross_strait",
-      "context": "OpenCC artifact: 宏→巨集 (macro) 誤轉；monolithic kernel 應為「單體式核心」",
+      "context": "@domain 作業系統。OpenCC artifact: 宏→巨集 (macro) 誤轉；monolithic kernel 應為「單體式核心」",
       "english": "monolithic kernel"
+    },
+    {
+      "from": "巴塞羅那",
+      "to": ["巴塞隆納"],
+      "type": "cross_strait",
+      "context": "@geo city (城市)",
+      "english": "Barcelona"
     },
     {
       "from": "巴巴多斯",
       "to": ["巴貝多"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Barbados"
     },
     {
       "from": "巴布亞新幾內亞",
       "to": ["巴布亞紐幾內亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Papua New Guinea"
+    },
+    {
+      "from": "市淨率",
+      "to": ["股價淨值比"],
+      "type": "cross_strait",
+      "context": "@domain 金融",
+      "english": "price-to-book ratio / P/B ratio",
+      "context_clues": ["股票", "估值", "投資", "淨值"]
+    },
+    {
+      "from": "市盈率",
+      "to": ["本益比"],
+      "type": "cross_strait",
+      "context": "@domain 金融",
+      "english": "price-to-earnings ratio / P/E ratio",
+      "context_clues": ["股票", "估值", "投資", "財報"]
     },
     {
       "from": "布基納法索",
       "to": ["布吉納法索"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Burkina Faso"
     },
     {
       "from": "布爾",
       "to": ["布林"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "Boolean"
     },
     {
       "from": "布爾值",
       "to": ["布林值"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "boolean"
     },
     {
       "from": "布隆迪",
       "to": ["蒲隆地"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Burundi"
     },
     {
       "from": "帕勞",
       "to": ["帛琉"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Palau"
+    },
+    {
+      "from": "帕金森",
+      "to": ["帕金森氏症"],
+      "type": "cross_strait",
+      "context": "@domain 醫學",
+      "english": "Parkinson's disease",
+      "context_clues": ["疾病", "神經", "症狀", "治療"]
     },
     {
       "from": "帖子",
       "to": ["貼文"],
       "type": "cross_strait",
+      "context": "@domain 社群",
       "english": "post"
     },
     {
       "from": "帶寬",
       "to": ["頻寬"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "bandwidth"
     },
     {
       "from": "常量",
       "to": ["常數"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "constant"
     },
     {
       "from": "幀率",
       "to": ["影格率"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "frame rate"
     },
     {
@@ -2730,13 +3390,14 @@
       "from": "幾內亞比紹",
       "to": ["幾內亞比索"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Guinea-Bissau"
     },
     {
       "from": "幾率",
       "to": ["機率"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "probability"
     },
     {
@@ -2751,13 +3412,14 @@
       "from": "庫函數",
       "to": ["程式庫函式"],
       "type": "cross_strait",
-      "context": "cn 語序「庫函數」= library function；tw 語序「程式庫函式」避免「函式庫函式」的詞彙重複",
+      "context": "@domain 程式設計。cn 語序「庫函數」= library function；tw 語序「程式庫函式」避免「函式庫函式」的詞彙重複",
       "english": "library function"
     },
     {
       "from": "廣域網",
       "to": ["廣域網路"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "WAN (wide area network)",
       "exceptions": ["廣域網路"]
     },
@@ -2765,44 +3427,58 @@
       "from": "引出",
       "to": ["匯出"],
       "type": "cross_strait",
-      "context": "僅限資料匯出語境；引出用於「帶出、引起」時為正確用法",
+      "context": "@domain 通訊。僅限資料匯出語境；引出用於「帶出、引起」時為正確用法",
       "english": "export",
       "context_clues": ["匯入", "export", "import", "CSV", "JSON", "PDF", "報表"]
     },
     {
       "from": "引導程序",
-      "to": [""],
+      "to": ["開機程式"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "bootloader"
+    },
+    {
+      "from": "彈窗",
+      "to": ["彈出視窗"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "popup",
+      "context_clues": ["廣告", "視窗", "阻擋", "瀏覽器", "通知"]
     },
     {
       "from": "彙編",
       "to": ["組譯"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "assembly"
     },
     {
       "from": "彙編器",
       "to": ["組譯器"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "assembler"
     },
     {
       "from": "彙編語言",
       "to": ["組合語言"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "assembly language"
     },
     {
       "from": "後台進程",
       "to": ["背景程式", "背景行程"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "background process"
     },
     {
       "from": "後綴",
       "to": ["字尾"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "suffix"
     },
     {
@@ -2810,6 +3486,14 @@
       "to": [],
       "type": "ai_filler",
       "context": "AI hedging phrase (從某種角度來看); flag but do not auto-delete — it is a semantic hedge that may carry intended meaning"
+    },
+    {
+      "from": "從節點",
+      "to": ["從屬節點"],
+      "type": "cross_strait",
+      "context": "@domain IT。限 IT 語境",
+      "english": "secondary node",
+      "context_clues": ["主節點", "叢集", "複製", "節點"]
     },
     {
       "from": "循環",
@@ -2823,130 +3507,192 @@
       "from": "微交易",
       "to": ["小額支付", "小額付款"],
       "type": "cross_strait",
+      "context": "@domain 資料",
       "english": "microtransaction"
     },
     {
       "from": "忙等待",
       "to": ["忙碌等待"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "busy waiting"
+    },
+    {
+      "from": "快捷方式",
+      "to": ["捷徑"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "shortcut",
+      "context_clues": ["桌面", "檔案", "建立", "捷徑", "鍵盤"]
     },
     {
       "from": "快捷鍵",
       "to": ["快速鍵"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "shortcut key"
     },
     {
       "from": "快排",
       "to": ["快速排序"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "quick sort"
     },
     {
       "from": "快退",
       "to": ["倒帶"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "rewind"
     },
     {
       "from": "快進",
       "to": ["快轉"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "fast forward"
     },
     {
       "from": "性價比",
       "to": ["價效比"],
       "type": "cross_strait",
+      "context": "@domain 商業",
       "english": "cost-performance ratio"
     },
     {
       "from": "性能",
       "to": ["效能"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "performance"
+    },
+    {
+      "from": "恢復",
+      "to": ["還原", "復原"],
+      "type": "cross_strait",
+      "context": "@domain UI。限 UI 語境。cn「恢復」；tw 用「還原」或「復原」(restore/recover)",
+      "english": "restore/recover",
+      "context_clues": ["系統", "備份", "預設", "設定", "出廠", "資料"]
+    },
+    {
+      "from": "悉尼",
+      "to": ["雪梨"],
+      "type": "cross_strait",
+      "context": "@geo city (城市)",
+      "english": "Sydney"
+    },
+    {
+      "from": "悉尼歌劇院",
+      "to": ["雪梨歌劇院"],
+      "type": "cross_strait",
+      "context": "@geo landmark (地標)",
+      "english": "Sydney Opera House"
     },
     {
       "from": "意大利",
       "to": ["義大利"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Italy"
     },
     {
       "from": "應用程序",
       "to": ["應用程式"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "application"
     },
     {
       "from": "應用程序框架",
       "to": ["應用程式框架", "應用框架"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "application framework"
     },
     {
       "from": "懶加載",
       "to": ["惰性載入", "延遲載入"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "lazy loading"
     },
     {
       "from": "懸停",
       "to": ["暫留"],
       "type": "cross_strait",
-      "context": "指將滑鼠指標暫時停留於畫面某處上",
+      "context": "@domain UI。指將滑鼠指標暫時停留於畫面某處上",
       "english": "hover"
     },
     {
       "from": "成員函數",
       "to": ["成員函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "member function"
     },
     {
       "from": "成員存取操作符",
       "to": ["成員取用運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "member access operator"
     },
     {
       "from": "成員變量",
       "to": ["成員變數", "資料成員"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "data member"
     },
     {
       "from": "截取",
       "to": ["擷取"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "capture/extract"
     },
     {
       "from": "截屏",
       "to": ["螢幕截圖"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "screenshot"
+    },
+    {
+      "from": "戰略",
+      "to": ["策略"],
+      "type": "cross_strait",
+      "context": "@domain 商業。cn「戰略」(商業)；tw 用「策略」(strategy)",
+      "english": "strategy",
+      "context_clues": ["企業", "商業", "規劃", "佈局", "長期"]
     },
     {
       "from": "所羅門羣島",
       "to": ["索羅門群島"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
+      "english": "Solomon Islands"
+    },
+    {
+      "from": "所羅門群島",
+      "to": ["索羅門群島"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
       "english": "Solomon Islands"
     },
     {
       "from": "手動檔",
       "to": ["手排"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "manual transmission"
     },
     {
       "from": "手電",
       "to": ["手電筒"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "flashlight",
       "exceptions": ["手電筒"]
     },
@@ -2954,32 +3700,35 @@
       "from": "打印",
       "to": ["列印"],
       "type": "cross_strait",
-      "context": "紙本輸出 vs 螢幕/主控台顯示",
+      "context": "@domain IT。紙本輸出 vs 螢幕/主控台顯示",
       "english": "print"
     },
     {
       "from": "打印機",
       "to": ["印表機"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "printer"
     },
     {
       "from": "打開",
       "to": ["開啟"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "open"
     },
     {
       "from": "批處理",
       "to": ["批次處理"],
       "type": "cross_strait",
-      "context": "tw: 批次處理, cn: 批處理",
+      "context": "@domain 作業系統。tw: 批次處理, cn: 批處理",
       "english": "batch processing"
     },
     {
       "from": "批量",
       "to": ["批次"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "batch"
     },
     {
@@ -2993,75 +3742,100 @@
       "from": "抑鬱症",
       "to": ["憂鬱症"],
       "type": "cross_strait",
+      "context": "@domain 醫學",
       "english": "depression"
     },
     {
       "from": "抖色",
       "to": ["遞色"],
       "type": "cross_strait",
+      "context": "@domain 圖形",
       "english": "dithering"
     },
     {
       "from": "拉黑",
       "to": ["封鎖"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "block (social media)"
     },
     {
       "from": "拋出",
       "to": ["丟出"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "throw (exception)"
+    },
+    {
+      "from": "拒絕服務",
+      "to": ["阻斷服務"],
+      "type": "cross_strait",
+      "context": "@domain 資安",
+      "english": "denial-of-service / DoS",
+      "context_clues": ["攻擊", "DDoS", "DoS", "安全"]
     },
     {
       "from": "拖拽",
       "to": ["拖曳"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "drag"
+    },
+    {
+      "from": "招聘",
+      "to": ["招募"],
+      "type": "cross_strait",
+      "context": "@domain 商業",
+      "english": "recruitment",
+      "context_clues": ["求職", "職缺", "應徵", "人才"]
     },
     {
       "from": "拷貝",
       "to": ["複製"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "copy"
     },
     {
       "from": "持久性",
       "to": ["永續性"],
       "type": "cross_strait",
+      "context": "@domain 資料庫",
       "english": "persistence"
     },
     {
       "from": "持續集成",
       "to": ["持續整合"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "continuous integration (CI)"
     },
     {
       "from": "指針",
       "to": ["指標"],
       "type": "cross_strait",
-      "context": "限程式設計語境，不同於 index",
+      "context": "@domain 程式設計。限程式設計語境，不同於 index",
       "english": "pointer"
     },
     {
       "from": "按值傳遞",
       "to": ["傳值"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "pass by value"
     },
     {
       "from": "按引用傳遞",
       "to": ["傳址"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "pass by reference"
     },
     {
       "from": "捕獲",
       "to": ["抓取"],
       "type": "cross_strait",
-      "context": "依 MoE 辭典，「捕獲」指捉拿人犯或動物。程式設計中 catch (exception) 應譯「抓取」，避免濫用",
+      "context": "@domain 程式設計。依 MoE 辭典，「捕獲」指捉拿人犯或動物。程式設計中 catch (exception) 應譯「抓取」，避免濫用",
       "english": "catch (exception)",
       "context_clues": ["例外", "異常", "exception", "try", "catch", "throw", "錯誤處理", "error", "拋出", "丟出"]
     },
@@ -3069,114 +3843,152 @@
       "from": "捲積",
       "to": ["摺積"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "convolution"
     },
     {
       "from": "掃描儀",
       "to": ["掃描器"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "scanner"
     },
     {
       "from": "掛斷",
       "to": ["結束通話"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "hang up"
     },
     {
       "from": "採樣",
       "to": ["取樣"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "sampling"
     },
     {
       "from": "採樣率",
       "to": ["取樣率"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "sampling rate"
     },
     {
       "from": "接口",
       "to": ["介面"],
       "type": "cross_strait",
-      "context": "限程式設計語境。硬體 connector/port = 接頭/連接埠",
+      "context": "@domain 程式設計。限程式設計語境。硬體 connector/port = 接頭/連接埠",
       "english": "interface",
       "context_clues": ["API", "函數", "函式", "類別", "定義", "實現", "實作", "調用", "呼叫", "軟件", "軟體"]
     },
     {
       "from": "控件",
-      "to": ["控制項"],
+      "to": ["控制項", "控制元件"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "control (UI)"
     },
     {
       "from": "控制台",
       "to": ["主控台"],
       "type": "cross_strait",
-      "context": "限程式設計/IT 語境",
+      "context": "@domain 程式設計。限程式設計/IT 語境",
       "english": "console",
       "context_clues": ["程式", "程序", "終端", "命令", "console", "terminal"]
+    },
+    {
+      "from": "控制面板",
+      "to": ["控制台"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "control panel",
+      "context_clues": ["Windows", "設定", "系統", "管理"]
     },
     {
       "from": "推遲",
       "to": ["延緩"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "defer"
     },
     {
       "from": "插件",
       "to": ["外掛程式"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "plugin"
     },
     {
       "from": "握手",
       "to": ["交握"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "handshake"
     },
     {
       "from": "搜索",
       "to": ["搜尋"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "search"
     },
     {
       "from": "搜索引擎",
       "to": ["搜尋引擎"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "search engine"
+    },
+    {
+      "from": "搜索框",
+      "to": ["搜尋框"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "search box",
+      "context_clues": ["輸入", "查詢", "搜尋", "UI", "介面"]
     },
     {
       "from": "摳圖",
       "to": ["去背"],
       "type": "cross_strait",
+      "context": "@domain 圖形",
       "english": "background removal"
+    },
+    {
+      "from": "撤銷",
+      "to": ["復原"],
+      "type": "cross_strait",
+      "context": "@domain UI。限 UI 語境。cn「撤銷」；tw 用「復原」(undo)",
+      "english": "undo",
+      "context_clues": ["復原", "操作", "Ctrl", "上一步", "編輯"]
     },
     {
       "from": "播客",
       "to": [],
       "type": "cross_strait",
+      "context": "@domain 社群",
       "english": "podcast"
     },
     {
       "from": "操作數",
       "to": ["運算元"],
       "type": "cross_strait",
-      "context": "「元」意指「基本的/元素」(參考《遠流中文活用大辭典》)，即「用來進行運算的基本單元」",
+      "context": "@domain IT。「元」意指「基本的/元素」(參考《遠流中文活用大辭典》)，即「用來進行運算的基本單元」",
       "english": "operand"
     },
     {
       "from": "操作符",
       "to": ["運算子"],
       "type": "cross_strait",
-      "context": "「子」(非語尾綴詞) 意指「從事某種職業的人」(如學子、舟子)，故「運算子」即「進行運算者」",
+      "context": "@domain IT。「子」(非語尾綴詞) 意指「從事某種職業的人」(如學子、舟子)，故「運算子」即「進行運算者」",
       "english": "operator"
     },
     {
       "from": "操作系統",
       "to": ["作業系統"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "operating system"
     },
     {
@@ -3189,31 +4001,35 @@
       "from": "擴展",
       "to": ["擴充"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "extension"
     },
     {
       "from": "擴展名",
       "to": ["副檔名"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "file extension"
     },
     {
       "from": "擴展塢",
       "to": ["擴充埠", "擴充集線器"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "docking station"
     },
     {
       "from": "攝像頭",
       "to": ["攝影機"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "camera"
     },
     {
       "from": "支持",
       "to": ["支援"],
       "type": "cross_strait",
-      "context": "限 IT 語境。「支持」偏指「贊成/背書」(endorse)；技術語境中 support = 支援 (如「瀏覽器支援此功能」)。政治/日常語境的「支持」為正確 tw 用法",
+      "context": "@domain IT。限 IT 語境。「支持」偏指「贊成/背書」(endorse)；技術語境中 support = 支援 (如「瀏覽器支援此功能」)。政治/日常語境的「支持」為正確 tw 用法",
       "english": "support",
       "context_clues": ["軟體", "軟件", "瀏覽器", "裝置", "設備", "協定", "協議", "格式", "驅動", "硬體", "硬件", "函式", "函數", "API"]
     },
@@ -3221,37 +4037,42 @@
       "from": "教程",
       "to": ["教學"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "tutorial"
     },
     {
       "from": "散列",
       "to": ["雜湊"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "hash"
     },
     {
       "from": "散列表",
       "to": ["雜湊表"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "hash table"
     },
     {
       "from": "散集",
       "to": ["反編列"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "demarshal"
     },
     {
       "from": "整型",
       "to": ["整數型"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "integer (integral)"
     },
     {
       "from": "數字",
       "to": ["數位"],
       "type": "cross_strait",
-      "context": "「數字化/數字技術」(digital) tw 用「數位」；「數字」作為 number/figure 為正確 tw 用法",
+      "context": "@domain IT。「數字化/數字技術」(digital) tw 用「數位」；「數字」作為 number/figure 為正確 tw 用法",
       "english": "digital",
       "context_clues": ["技術", "轉型", "電視", "廣播", "影像", "音訊", "媒體"]
     },
@@ -3259,49 +4080,56 @@
       "from": "數字印刷",
       "to": ["數位印刷"],
       "type": "cross_strait",
+      "context": "@domain 電子",
       "english": "digital printing"
     },
     {
       "from": "數字簽名",
       "to": ["數位簽章"],
       "type": "cross_strait",
+      "context": "@domain 電子",
       "english": "digital signature"
     },
     {
       "from": "數字電子",
       "to": ["數位電子"],
       "type": "cross_strait",
+      "context": "@domain 電子",
       "english": "digital electronics"
     },
     {
       "from": "數字電路",
       "to": ["數位電路"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "digital circuit"
     },
     {
       "from": "數據",
       "to": ["資料"],
       "type": "cross_strait",
-      "context": "資料涵蓋文字、聲音、影像等所有形式的紀錄。「數據」僅指純數值資料，不應一律代替 data。「data and number」應譯為「資料與數據」",
+      "context": "@domain 資料。資料涵蓋文字、聲音、影像等所有形式的紀錄。「數據」僅指純數值資料，不應一律代替 data。「data and number」應譯為「資料與數據」",
       "english": "data"
     },
     {
       "from": "數據倉庫",
       "to": ["資料倉儲"],
       "type": "cross_strait",
+      "context": "@domain 資料",
       "english": "data warehouse"
     },
     {
       "from": "數據包",
       "to": ["封包"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "packet"
     },
     {
       "from": "數據報",
       "to": ["資料包"],
       "type": "cross_strait",
+      "context": "@domain 資料",
       "english": "datagram"
     },
     {
@@ -3315,55 +4143,63 @@
       "from": "數據庫結構綱目",
       "to": ["資料庫結構綱目"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "database schema"
     },
     {
       "from": "數據成員",
       "to": ["資料成員", "成員變數"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "data member"
     },
     {
       "from": "數據挖掘",
       "to": ["資料探勘"],
       "type": "cross_strait",
+      "context": "@domain 資料",
       "english": "data mining"
     },
     {
       "from": "數據流",
       "to": ["資料流", "串流"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "stream"
     },
     {
       "from": "數據源",
       "to": ["資料來源"],
       "type": "cross_strait",
+      "context": "@domain 資料",
       "english": "data source"
     },
     {
       "from": "數據結構",
       "to": ["資料結構"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "data structure"
     },
     {
       "from": "數據類型",
       "to": ["資料型別"],
       "type": "cross_strait",
-      "context": "程式設計語境中慣用「型別」",
+      "context": "@domain 程式設計。程式設計語境中慣用「型別」",
       "english": "data type"
     },
     {
       "from": "數碼",
       "to": ["數位"],
       "type": "cross_strait",
+      "context": "@domain 電子",
       "english": "digital"
     },
     {
       "from": "數組",
       "to": ["陣列"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "array"
     },
     {
@@ -3378,7 +4214,7 @@
       "from": "文件內容",
       "to": ["檔案內容"],
       "type": "cross_strait",
-      "context": "限檔案 I/O 語境。「文件內容」(document content) 為標準 tw 用法",
+      "context": "@domain IT。限檔案 I/O 語境。「文件內容」(document content) 為標準 tw 用法",
       "english": "file content",
       "context_clues": ["檔案", "路徑", "I/O", "磁碟", "目錄", "open", "read", "write", "讀取", "寫入"]
     },
@@ -3386,6 +4222,7 @@
       "from": "文件名",
       "to": ["檔名"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "filename"
     },
     {
@@ -3399,45 +4236,58 @@
       "from": "文件描述符",
       "to": ["檔案描述子"],
       "type": "cross_strait",
-      "context": "「符」在繁體中文有宗教暗示；「描述子」與「運算子」(operator) 命名邏輯一致",
+      "context": "@domain IT。「符」在繁體中文有宗教暗示；「描述子」與「運算子」(operator) 命名邏輯一致",
       "english": "file descriptor"
     },
     {
       "from": "文件操作",
       "to": ["檔案操作"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "file operation"
     },
     {
       "from": "文件擴展名",
       "to": ["副檔名"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "file extension"
     },
     {
       "from": "文件系統",
       "to": ["檔案系統"],
       "type": "cross_strait",
-      "context": "限作業系統語境",
+      "context": "@domain 作業系統。限作業系統語境",
       "english": "filesystem/file system"
     },
     {
       "from": "文字處理",
       "to": ["文書處理"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "word processing"
     },
     {
       "from": "文本",
       "to": ["文字"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "text"
     },
     {
       "from": "文本文件",
       "to": ["文字檔"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "text file"
+    },
+    {
+      "from": "文本框",
+      "to": ["文字方塊"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "text box",
+      "context_clues": ["表單", "輸入", "UI", "介面", "欄位"]
     },
     {
       "from": "文檔",
@@ -3450,47 +4300,56 @@
       "from": "文萊",
       "to": ["汶萊"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Brunei"
     },
     {
       "from": "斯坦福",
       "to": ["史丹福"],
       "type": "cross_strait",
-      "context": "地名 (@in California)",
+      "context": "@geo university (大學)",
       "english": "Stanford"
     },
     {
       "from": "斯威士蘭",
       "to": ["史瓦濟蘭"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Eswatini/Swaziland"
     },
     {
       "from": "斯洛文尼亞",
       "to": ["斯洛維尼亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Slovenia"
+    },
+    {
+      "from": "斯裡蘭卡",
+      "to": ["斯里蘭卡"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Sri Lanka"
     },
     {
       "from": "新建",
       "to": ["新增", "建立"],
       "type": "cross_strait",
+      "context": "@domain IT。UI create/new",
       "english": "new/create"
     },
     {
       "from": "新西蘭",
       "to": ["紐西蘭"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "New Zealand"
     },
     {
       "from": "斷點",
       "to": ["中斷點"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "breakpoint",
       "exceptions": ["中斷點"]
     },
@@ -3498,18 +4357,21 @@
       "from": "方便麪",
       "to": ["泡麵", "速食麵"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "instant noodles"
     },
     {
       "from": "方括弧",
       "to": ["中括弧", "中括號"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "bracket (square bracket)"
     },
     {
       "from": "方括號",
       "to": ["中括弧", "中括號"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "bracket (square bracket)"
     },
     {
@@ -3524,31 +4386,35 @@
       "from": "映射",
       "to": ["對映"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "mapping"
     },
     {
       "from": "時分多址",
       "to": ["分時多重進接"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "time-division multiple access (TDMA)"
     },
     {
       "from": "時分複用",
       "to": ["分時多工"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "time-division multiplexing (TDM)"
     },
     {
       "from": "時鐘頻率",
       "to": ["時脈頻率"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "clock frequency"
     },
     {
       "from": "時間片",
       "to": ["時間片段"],
       "type": "cross_strait",
-      "context": "tw: 時間片段, cn: 時間片",
+      "context": "@domain 作業系統。tw: 時間片段, cn: 時間片",
       "english": "timeslice",
       "exceptions": ["時間片段"]
     },
@@ -3556,24 +4422,28 @@
       "from": "晶閘管",
       "to": ["閘流體"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "thyristor"
     },
     {
       "from": "晶體管",
       "to": ["電晶體"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "transistor"
     },
     {
       "from": "智能",
       "to": ["智慧"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "smart/intelligent"
     },
     {
       "from": "智能手機",
       "to": ["智慧型手機"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "smartphone"
     },
     {
@@ -3592,6 +4462,7 @@
       "from": "最底層派生類",
       "to": ["最末層衍生類別"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "most derived class"
     },
     {
@@ -3605,18 +4476,21 @@
       "from": "最終用戶",
       "to": ["終端使用者"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "end user"
     },
     {
       "from": "有損壓縮",
       "to": ["有失真壓縮"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "lossy compression"
     },
     {
       "from": "服務器",
       "to": ["伺服器"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "server"
     },
     {
@@ -3630,20 +4504,45 @@
       "from": "服務端",
       "to": ["伺服端", "伺服器"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "server"
+    },
+    {
+      "from": "木馬",
+      "to": ["木馬程式"],
+      "type": "cross_strait",
+      "context": "@domain 資安。cn「木馬」(資安)；tw 用「木馬程式」(trojan)",
+      "english": "trojan",
+      "context_clues": ["病毒", "惡意", "安全", "感染"]
     },
     {
       "from": "本地代碼",
       "to": ["原生碼"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "native code"
     },
     {
       "from": "本地化",
       "to": ["在地化"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "localization (L10N)"
+    },
+    {
+      "from": "本科",
+      "to": ["大學部"],
+      "type": "cross_strait",
+      "context": "@domain 教育",
+      "english": "undergraduate",
+      "context_clues": ["學位", "研究所", "大學", "學士"]
+    },
+    {
+      "from": "本科生",
+      "to": ["大學生"],
+      "type": "cross_strait",
+      "context": "@domain 教育",
+      "english": "undergraduate student"
     },
     {
       "from": "東盟",
@@ -3656,36 +4555,42 @@
       "from": "析構函數",
       "to": ["解構函式", "解構式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "destructor"
     },
     {
       "from": "枚舉",
       "to": ["列舉"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "enumeration"
     },
     {
       "from": "查找",
       "to": ["尋找", "搜尋"],
       "type": "cross_strait",
+      "context": "@domain UI。UI find/search",
       "english": "find"
     },
     {
       "from": "查看",
       "to": ["檢視"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "view/inspect"
     },
     {
       "from": "标准 C 库",
       "to": ["標準 C 語言函式庫"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "C standard library"
     },
     {
       "from": "校驗和",
       "to": ["總和檢查碼"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "checksum"
     },
     {
@@ -3707,13 +4612,14 @@
       "from": "核心映象",
       "to": ["核心映像檔"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "kernel image"
     },
     {
       "from": "核心服務",
       "to": ["主體服務"],
       "type": "cross_strait",
-      "context": "避免混用 kernel (核心) 和 core; tw 用「主體服務」表示 core service",
+      "context": "@domain IT。避免混用 kernel (核心) 和 core; tw 用「主體服務」表示 core service",
       "english": "core service",
       "context_clues": ["Core", "core", "服務層", "PID"]
     },
@@ -3721,14 +4627,14 @@
       "from": "核心棧",
       "to": ["核心堆疊"],
       "type": "cross_strait",
-      "context": "OpenCC 可能將內核棧轉為核心棧，仍需轉為核心堆疊",
+      "context": "@domain 作業系統。OpenCC 可能將內核棧轉為核心棧，仍需轉為核心堆疊",
       "english": "kernel stack"
     },
     {
       "from": "核心概念",
       "to": ["主體概念"],
       "type": "cross_strait",
-      "context": "避免混用 kernel (核心) 和 core; 當「核心」不指 OS kernel 時用「主體」",
+      "context": "@domain IT。避免混用 kernel (核心) 和 core; 當「核心」不指 OS kernel 時用「主體」",
       "english": "core concept",
       "context_clues": ["作業系統", "OS", "kernel", "核心", "微核心", "程序", "行程"]
     },
@@ -3736,7 +4642,7 @@
       "from": "核心洞察",
       "to": ["關鍵洞察"],
       "type": "cross_strait",
-      "context": "避免濫用「核心」; 當不指 OS kernel 時改用「關鍵」",
+      "context": "@domain IT。避免濫用「核心」; 當不指 OS kernel 時改用「關鍵」",
       "english": "core insight / key insight"
     },
     {
@@ -3750,39 +4656,42 @@
       "from": "格林納達",
       "to": ["格瑞那達"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Grenada"
     },
     {
       "from": "格魯吉亞",
       "to": ["喬治亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Georgia"
     },
     {
       "from": "桌面型",
       "to": ["桌上型"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "desktop"
     },
     {
       "from": "條指令",
       "to": ["道指令"],
       "type": "cross_strait",
-      "context": "「指令」(instruction) 的量詞是「道」而非「條」",
+      "context": "@domain 程式設計。「指令」(instruction) 的量詞是「道」而非「條」",
       "english": "instruction (classifier)"
     },
     {
       "from": "棧",
       "to": ["堆疊"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "stack"
     },
     {
       "from": "棧輾轉開解",
       "to": ["堆疊輾轉開解"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "stack unwinding"
     },
     {
@@ -3795,57 +4704,71 @@
       "from": "極客",
       "to": ["科技發燒友"],
       "type": "cross_strait",
+      "context": "@domain 社群",
       "english": "geek"
     },
     {
       "from": "概率",
       "to": ["機率"],
       "type": "cross_strait",
-      "context": "數學/統計領域用詞",
+      "context": "@domain 語言學。數學/統計領域用詞",
       "english": "probability"
     },
     {
       "from": "構建",
       "to": ["建構"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "build"
     },
     {
       "from": "構造函數",
       "to": ["建構函式", "建構式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "constructor"
     },
     {
       "from": "標清",
       "to": ["標準畫質"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "standard definition (SD)"
     },
     {
       "from": "標準 C 庫",
       "to": ["標準 C 語言函式庫"],
       "type": "cross_strait",
-      "context": "避免孤立的「C」造成突兀感，完整表述為「C 語言函式庫」",
+      "context": "@domain 程式設計。避免孤立的「C」造成突兀感，完整表述為「C 語言函式庫」",
       "english": "C standard library"
     },
     {
       "from": "標準庫",
       "to": ["標準函式庫", "標準程式庫"],
       "type": "cross_strait",
-      "context": "cn 用「庫」作 library 後綴；tw 用「函式庫」或「程式庫」",
+      "context": "@domain 程式設計。cn 用「庫」作 library 後綴；tw 用「函式庫」或「程式庫」",
       "english": "standard library"
+    },
+    {
+      "from": "標籤頁",
+      "to": ["分頁標籤", "分頁"],
+      "type": "cross_strait",
+      "context": "@domain UI。cn「標籤頁」；tw 用「分頁標籤」或「分頁」(tab page)",
+      "english": "tab",
+      "context_clues": ["瀏覽器", "視窗", "開啟", "關閉", "切換"]
     },
     {
       "from": "標識符",
       "to": ["識別子"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "identifier"
     },
     {
       "from": "標量",
       "to": ["純量"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "scalar"
     },
     {
@@ -3858,13 +4781,22 @@
       "from": "模塊",
       "to": ["模組"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "module"
+    },
+    {
+      "from": "模態框",
+      "to": ["模態對話框"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "modal dialog",
+      "context_clues": ["UI", "視窗", "對話", "介面", "彈出"]
     },
     {
       "from": "模擬",
       "to": ["類比"],
       "type": "cross_strait",
-      "context": "「模擬電路/訊號」(analog) tw 用「類比」；「模擬器/模擬執行」(simulate) 為正確 tw 用法",
+      "context": "@domain 電子。「模擬電路/訊號」(analog) tw 用「類比」；「模擬器/模擬執行」(simulate) 為正確 tw 用法",
       "english": "analog",
       "context_clues": ["電路", "訊號", "類比", "器件", "ADC", "DAC"]
     },
@@ -3872,25 +4804,37 @@
       "from": "模擬電子",
       "to": ["類比電子"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "analog electronics"
     },
     {
       "from": "模擬電路",
       "to": ["類比電路"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "analog circuit"
     },
     {
       "from": "模板",
       "to": ["範本"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "template"
     },
     {
       "from": "模板參數推導",
       "to": ["模板引數推導"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "template argument deduction"
+    },
+    {
+      "from": "機械硬盤",
+      "to": ["機械硬碟"],
+      "type": "cross_strait",
+      "context": "@domain 硬體",
+      "english": "HDD",
+      "context_clues": ["硬碟", "SSD", "儲存", "硬體"]
     },
     {
       "from": "檐",
@@ -3902,49 +4846,56 @@
       "from": "檔次",
       "to": ["等級"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "grade/tier"
     },
     {
       "from": "檢測",
       "to": ["偵測"],
       "type": "cross_strait",
-      "context": "「檢測」偏指 inspect/test，語意不同",
+      "context": "@domain IT。「檢測」偏指 inspect/test，語意不同",
       "english": "detect"
     },
     {
       "from": "權限",
       "to": ["許可權"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "permission"
     },
     {
       "from": "歐拉",
       "to": ["尤拉"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "Euler"
     },
     {
       "from": "正則表達式",
       "to": ["正規表示式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "regular expression (regex)"
     },
     {
       "from": "歸併排序",
       "to": ["合併排序"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "merge sort"
     },
     {
       "from": "死機",
       "to": ["當機"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "crash"
     },
     {
       "from": "死鎖",
       "to": ["死結"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "deadlock"
     },
     {
@@ -3958,46 +4909,63 @@
       "from": "殺毒",
       "to": ["防毒"],
       "type": "cross_strait",
+      "context": "@domain 資安",
       "english": "antivirus"
     },
     {
       "from": "殺毒軟體",
       "to": ["防毒軟體"],
       "type": "cross_strait",
+      "context": "@domain 資安",
       "english": "antivirus"
     },
     {
       "from": "母節點",
       "to": ["親代節點"],
       "type": "cross_strait",
-      "context": "避免父權語彙。parent 的本意為「親代」，不隱含性別",
+      "context": "@domain 資料結構。避免父權語彙。parent 的本意為「親代」，不隱含性別",
       "english": "parent node"
     },
     {
       "from": "比特",
       "to": ["位元"],
       "type": "cross_strait",
-      "context": "cn 「位」兼作量詞，造成歧義：「三十二位整数」中 bit 乍看成量詞。tw 「位元」明確為計量單位，無歧義。例外: bitcoin 已約定成俗，寫作「比特幣」",
+      "context": "@domain IT。cn 「位」兼作量詞，造成歧義：「三十二位整数」中 bit 乍看成量詞。tw 「位元」明確為計量單位，無歧義。例外: bitcoin 已約定成俗，寫作「比特幣」",
       "english": "bit"
     },
     {
       "from": "比特率",
       "to": ["位元率"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "bitrate"
+    },
+    {
+      "from": "毛裡塔尼亞",
+      "to": ["茅利塔尼亞"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Mauritania"
+    },
+    {
+      "from": "毛裡求斯",
+      "to": ["模里西斯"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Mauritius"
     },
     {
       "from": "毛里塔尼亞",
       "to": ["茅利塔尼亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Mauritania"
     },
     {
       "from": "毛里求斯",
       "to": ["模里西斯"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Mauritius"
     },
     {
@@ -4010,15 +4978,23 @@
       "from": "沙特",
       "to": ["沙烏地"],
       "type": "cross_strait",
-      "context": "國名 簡稱 (@seealso 沙特阿拉伯)",
+      "context": "@geo country (國名)",
       "english": "Saudi Arabia"
     },
     {
       "from": "沙特阿拉伯",
       "to": ["沙烏地阿拉伯"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Saudi Arabia"
+    },
+    {
+      "from": "沙箱",
+      "to": ["沙盒"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "sandbox",
+      "context_clues": ["隔離", "安全", "環境", "測試"]
     },
     {
       "from": "泄",
@@ -4030,51 +5006,56 @@
       "from": "泛型算法",
       "to": ["泛型演算法"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "generic algorithm"
     },
     {
       "from": "波分複用",
       "to": ["波長分波多工"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "wavelength-division multiplexing (WDM)"
     },
     {
       "from": "波斯尼亞黑塞哥維那",
       "to": ["波士尼亞與赫塞哥維納"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Bosnia and Herzegovina"
     },
     {
       "from": "洗髮水",
       "to": ["洗髮精"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "shampoo"
     },
     {
       "from": "津巴布韋",
       "to": ["辛巴威"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Zimbabwe"
     },
     {
       "from": "洪都拉斯",
       "to": ["宏都拉斯"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Honduras"
     },
     {
       "from": "派生類",
       "to": ["衍生類別"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "derived class"
     },
     {
       "from": "流媒體",
       "to": ["串流媒體"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "streaming media",
       "exceptions": ["串流媒體"]
     },
@@ -4082,25 +5063,44 @@
       "from": "流水線",
       "to": ["生產線", "管線"],
       "type": "cross_strait",
-      "context": "工廠語境 vs CPU/軟體語境",
+      "context": "@domain 程式設計。工廠語境 vs CPU/軟體語境",
       "english": "production line/pipeline"
+    },
+    {
+      "from": "流處理",
+      "to": ["串流處理"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "stream processing",
+      "context_clues": ["即時", "Kafka", "資料", "管線"]
     },
     {
       "from": "消息",
       "to": ["訊息"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "message"
     },
     {
       "from": "消息環",
       "to": ["訊息迴圈"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "message loop"
+    },
+    {
+      "from": "消息隊列",
+      "to": ["訊息佇列"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "message queue",
+      "context_clues": ["MQ", "Kafka", "RabbitMQ", "非同步", "佇列"]
     },
     {
       "from": "涼菜",
       "to": ["冷盤"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "cold dish/appetizer"
     },
     {
@@ -4113,19 +5113,21 @@
       "from": "添加",
       "to": ["新增"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "add"
     },
     {
       "from": "渠道",
       "to": ["管道", "通路"],
       "type": "cross_strait",
+      "context": "@domain 商業",
       "english": "channel"
     },
     {
       "from": "渲染",
       "to": ["算繪"],
       "type": "cross_strait",
-      "context": "依 MoE 辭典，「渲染」本義為國畫用水墨暈染技法或文字誇大手法，語意與 rendering (計算+繪製) 相反。CG 語境應譯「算繪」，建築裝潢語境譯「粉刷」",
+      "context": "@domain 程式設計。依 MoE 辭典，「渲染」本義為國畫用水墨暈染技法或文字誇大手法，語意與 rendering (計算+繪製) 相反。CG 語境應譯「算繪」，建築裝潢語境譯「粉刷」",
       "english": "render",
       "context_clues": ["圖學", "圖形", "3D", "GPU", "畫面", "幀", "frame", "shader", "貼圖", "光線", "場景", "引擎", "OpenGL", "Vulkan", "DirectX", "管線", "pipeline"]
     },
@@ -4133,67 +5135,84 @@
       "from": "渲染管線",
       "to": ["算繪管線"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "rendering pipeline"
+    },
+    {
+      "from": "湯加",
+      "to": ["東加"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Tonga"
     },
     {
       "from": "源代碼",
       "to": ["原始程式碼"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "source code"
     },
     {
       "from": "源文件",
       "to": ["原始檔"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "source file"
     },
     {
       "from": "源碼",
       "to": ["原始程式碼"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "source code"
     },
     {
       "from": "溢出",
       "to": ["溢位", "上限溢位"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "overflow"
     },
     {
       "from": "滑塊",
       "to": ["滑桿"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "slider"
     },
     {
       "from": "滾動條",
       "to": ["捲軸"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "scroll bar"
     },
     {
       "from": "滾回",
       "to": ["還原"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "rollback"
     },
     {
       "from": "滿屏",
       "to": ["佔滿螢幕"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "screen-filling/full-screen"
     },
     {
       "from": "演示",
       "to": ["示範", "展示"],
       "type": "cross_strait",
-      "context": "實際操作示範 (demo) vs 展覽呈現 (showcase)",
+      "context": "@domain IT。實際操作示範 (demo) vs 展覽呈現 (showcase)",
       "english": "demo/demonstrate"
     },
     {
       "from": "演示文稿",
       "to": ["簡報"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "presentation"
     },
     {
@@ -4212,50 +5231,64 @@
       "from": "激光",
       "to": ["雷射"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "laser"
     },
     {
       "from": "激活",
       "to": ["啟用", "活化"],
       "type": "cross_strait",
-      "context": "軟體/帳號語境用「啟用」，化學/生物語境用「活化」",
+      "context": "@domain IT。軟體/帳號語境用「啟用」，化學/生物語境用「活化」",
       "english": "activate"
     },
     {
       "from": "激活碼",
       "to": ["啟動碼", "啟用碼"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "activation code"
     },
     {
       "from": "烏茲別克斯坦",
       "to": ["烏茲別克"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Uzbekistan"
     },
     {
       "from": "無損壓縮",
       "to": ["無失真壓縮"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "lossless compression"
     },
     {
       "from": "無限循環",
       "to": ["無窮迴圈"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "infinite loop"
+    },
+    {
+      "from": "無限滾動",
+      "to": ["無限捲動"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "infinite scroll",
+      "context_clues": ["UI", "載入", "頁面", "捲動", "滾動"]
     },
     {
       "from": "無限遞歸",
       "to": ["無窮遞迴"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "infinite recursive"
     },
     {
       "from": "營銷",
       "to": ["行銷"],
       "type": "cross_strait",
+      "context": "@domain 商業",
       "english": "marketing"
     },
     {
@@ -4268,7 +5301,7 @@
       "from": "父子常式",
       "to": ["親代和子代行程"],
       "type": "cross_strait",
-      "context": "中性用語 (tw: 親代和子代行程, cn: 父子進程); OpenCC 可能誤植子進程→子常式",
+      "context": "@domain 作業系統。中性用語 (tw: 親代和子代行程, cn: 父子進程); OpenCC 可能誤植子進程→子常式",
       "english": "parent and child processes"
     },
     {
@@ -4298,14 +5331,14 @@
       "from": "父節點",
       "to": ["親代節點"],
       "type": "cross_strait",
-      "context": "避免父權語彙。parent 的本意為「親代」，不隱含性別。二元樹中 parent node 無成對性別關連",
+      "context": "@domain 資料結構。避免父權語彙。parent 的本意為「親代」，不隱含性別。二元樹中 parent node 無成對性別關連",
       "english": "parent node"
     },
     {
       "from": "父行程",
       "to": ["親代行程"],
       "type": "cross_strait",
-      "context": "中性用語，避免父權主義遺毒 (tw: 親代行程, cn: 父進程)",
+      "context": "@domain 作業系統。中性用語，避免父權主義遺毒 (tw: 親代行程, cn: 父進程)",
       "english": "parent process"
     },
     {
@@ -4319,7 +5352,7 @@
       "from": "父類",
       "to": ["親代類別"],
       "type": "cross_strait",
-      "context": "避免父權語彙。parent 的本意為「親代」，不隱含性別",
+      "context": "@domain IT。避免父權語彙。parent 的本意為「親代」，不隱含性別",
       "english": "parent class"
     },
     {
@@ -4332,6 +5365,7 @@
       "from": "版本號",
       "to": ["版本號碼"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "version number",
       "exceptions": ["版本號碼"]
     },
@@ -4346,14 +5380,14 @@
       "from": "物理內存",
       "to": ["實體記憶體"],
       "type": "cross_strait",
-      "context": "限 IT 語境",
+      "context": "@domain 程式設計。限 IT 語境",
       "english": "physical memory"
     },
     {
       "from": "物理地址",
       "to": ["實體位址"],
       "type": "cross_strait",
-      "context": "限 IT 語境",
+      "context": "@domain 程式設計。限 IT 語境",
       "english": "physical address"
     },
     {
@@ -4395,7 +5429,7 @@
       "from": "物理記憶體",
       "to": ["實體記憶體"],
       "type": "cross_strait",
-      "context": "僅在學科名稱時用「物理」，否則用「實體」(tw: 實體記憶體, cn: 物理內存)",
+      "context": "@domain 程式設計。僅在學科名稱時用「物理」，否則用「實體」(tw: 實體記憶體, cn: 物理內存)",
       "english": "physical memory",
       "negative_context_clues": ["物理學", "物理系", "物理課"]
     },
@@ -4410,7 +5444,7 @@
       "from": "特化",
       "to": ["特殊化", "特殊化定義", "特殊化宣告"],
       "type": "cross_strait",
-      "context": "限 C++ 模板語境",
+      "context": "@domain 程式設計。限 C++ 模板語境",
       "english": "specialization",
       "context_clues": ["模板", "範本", "template", "C++", "泛型"]
     },
@@ -4418,47 +5452,57 @@
       "from": "特立尼達和多巴哥",
       "to": ["千里達及托巴哥"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Trinidad and Tobago"
     },
     {
       "from": "狀態欄",
       "to": ["狀態列"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "status bar"
+    },
+    {
+      "from": "班主任",
+      "to": ["導師"],
+      "type": "cross_strait",
+      "context": "@domain 教育",
+      "english": "homeroom teacher",
+      "context_clues": ["班級", "學生", "學校", "老師"]
     },
     {
       "from": "瑙魯",
       "to": ["諾魯"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Nauru"
     },
     {
       "from": "瓦努阿圖",
       "to": ["萬那杜"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Vanuatu"
     },
     {
       "from": "生存空間操作符",
       "to": ["生存空間運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "scope operator"
     },
     {
       "from": "生存空間解析操作符",
       "to": ["生存空間決議運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "scope resolution operator"
     },
     {
       "from": "用戶",
       "to": ["使用者"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "user",
       "exceptions": ["用戶端", "用戶端作業系統"]
     },
@@ -4466,46 +5510,49 @@
       "from": "用戶名",
       "to": ["使用者名稱"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "username"
     },
     {
       "from": "用戶堆",
       "to": ["使用者端堆積"],
       "type": "cross_strait",
-      "context": "tw: 使用者端堆積 (heap→堆積), cn: 用戶堆",
+      "context": "@domain IT。tw: 使用者端堆積 (heap→堆積), cn: 用戶堆",
       "english": "user heap"
     },
     {
       "from": "用戶棧",
       "to": ["使用者端堆疊"],
       "type": "cross_strait",
-      "context": "tw: 使用者端堆疊 (stack→堆疊), cn: 用戶棧",
+      "context": "@domain IT。tw: 使用者端堆疊 (stack→堆疊), cn: 用戶棧",
       "english": "user stack"
     },
     {
       "from": "用戶界面",
       "to": ["使用者介面", "用戶介面", "人機介面"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "user interface"
     },
     {
       "from": "用戶級線程",
       "to": ["使用者層級執行緒"],
       "type": "cross_strait",
-      "context": "tw: 使用者層級執行緒, cn: 用戶級線程",
+      "context": "@domain IT。tw: 使用者層級執行緒, cn: 用戶級線程",
       "english": "user-level thread"
     },
     {
       "from": "界面",
       "to": ["介面"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "interface"
     },
     {
       "from": "異常",
       "to": ["例外", "異常情況"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "exception",
       "context_clues": ["拋出", "捕獲", "處理", "程式碼", "代碼", "函式", "函數", "方法", "類別", "除錯", "偵錯"],
       "negative_context_clues": ["偵測", "檢測", "異常值", "統計", "分佈"],
@@ -4515,7 +5562,7 @@
       "from": "異常聲明",
       "to": ["異常宣告"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "exception declaration",
       "context_clues": ["C++", "Java", "函式", "函數", "編譯", "throw"]
     },
@@ -4523,7 +5570,7 @@
       "from": "異常規範",
       "to": ["異常規格"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "exception specification",
       "context_clues": ["C++", "Java", "函式", "函數", "編譯", "throw"]
     },
@@ -4531,27 +5578,28 @@
       "from": "異構運算",
       "to": ["異質運算", "異質多核運算"],
       "type": "cross_strait",
-      "context": "tw 以「異質」對應 heterogeneous (不同質的元件協作)；「異構」多見於 cn。「異質多核運算」特指 CPU+GPU 整合架構 (如 AMD APU)",
+      "context": "@domain IT。tw 以「異質」對應 heterogeneous (不同質的元件協作)；「異構」多見於 cn。「異質多核運算」特指 CPU+GPU 整合架構 (如 AMD APU)",
       "english": "heterogeneous computing"
     },
     {
       "from": "異步",
       "to": ["非同步"],
       "type": "cross_strait",
-      "context": "「非」明確表達「不」，而「異」指「不同/特別/不尋常」(如《史記》:「皆異能之士也」的「異」是「特別」)，用「異」會造成歧義並與其他科學術語 (如立體異構物 stereoisomers) 衝突",
+      "context": "@domain 程式設計。「非」明確表達「不」，而「異」指「不同/特別/不尋常」(如《史記》:「皆異能之士也」的「異」是「特別」)，用「異」會造成歧義並與其他科學術語 (如立體異構物 stereoisomers) 衝突",
       "english": "asynchronous"
     },
     {
       "from": "當且僅當",
       "to": ["若且唯若"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "if and only if"
     },
     {
       "from": "當前",
       "to": ["目前"],
       "type": "cross_strait",
-      "context": "避免文言表述「當前」，改用「目前」消除歧異 (tw: 目前, cn: 當前)",
+      "context": "@domain IT。避免文言表述「當前」，改用「目前」消除歧異 (tw: 目前, cn: 當前)",
       "english": "current/currently",
       "context_clues": ["行程", "系統", "狀態", "執行", "核心", "記憶體", "CPU", "排程"]
     },
@@ -4559,13 +5607,14 @@
       "from": "疊代",
       "to": ["迭代"],
       "type": "cross_strait",
-      "context": "「疊」(堆聚、累積) 強調反覆堆疊的過程；「迭」(輪流、更替) 則指交替，「迭」在 1964–1986 年間曾是「疊」的 cn 簡化字。教育部《國家教育研究院雙語詞彙》收錄「疊代」",
+      "context": "@domain IT。「疊」(堆聚、累積) 強調反覆堆疊的過程；「迭」(輪流、更替) 則指交替，「迭」在 1964–1986 年間曾是「疊」的 cn 簡化字。教育部《國家教育研究院雙語詞彙》收錄「疊代」",
       "english": "iterate"
     },
     {
       "from": "疊代器",
       "to": ["迭代器"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "iterator"
     },
     {
@@ -4584,31 +5633,44 @@
       "from": "登錄",
       "to": ["登入"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "login"
     },
     {
       "from": "發佈",
       "to": ["釋出"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "release/publish"
     },
     {
       "from": "發光二極管",
       "to": ["發光二極體"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "LED"
     },
     {
       "from": "發動機",
       "to": ["引擎"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "engine"
     },
     {
       "from": "發送",
       "to": ["傳送"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "send"
+    },
+    {
+      "from": "白帽",
+      "to": ["白帽駭客"],
+      "type": "cross_strait",
+      "context": "@domain 資安",
+      "english": "white hat",
+      "context_clues": ["駭客", "安全", "滲透", "漏洞"]
     },
     {
       "from": "皁",
@@ -4620,56 +5682,70 @@
       "from": "的士",
       "to": ["計程車"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "taxi"
     },
     {
       "from": "盤片",
       "to": ["碟片"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "disk platter"
     },
     {
       "from": "盤符",
       "to": ["磁碟機代號"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "drive letter"
     },
     {
       "from": "盧旺達",
       "to": ["盧安達"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Rwanda"
+    },
+    {
+      "from": "盧浮宮",
+      "to": ["羅浮宮"],
+      "type": "cross_strait",
+      "context": "@geo landmark (地標)",
+      "english": "Louvre"
     },
     {
       "from": "目標代碼",
       "to": ["目的碼"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "object code"
     },
     {
       "from": "目標文件",
       "to": ["目的檔"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "object file"
     },
     {
       "from": "直接下層派生類",
       "to": ["直接下層衍生類"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "immediate derived"
     },
     {
       "from": "直接記憶體訪問",
       "to": ["直接記憶體存取"],
       "type": "cross_strait",
-      "context": "DMA (Direct Memory Access)；「訪問」僅指 visit，access 應譯為「存取」",
+      "context": "@domain IT。DMA (Direct Memory Access)；「訪問」僅指 visit，access 應譯為「存取」",
       "english": "Direct Memory Access / DMA"
     },
     {
       "from": "相冊",
       "to": ["相簿"],
       "type": "cross_strait",
+      "context": "@domain 社群",
       "english": "photo album"
     },
     {
@@ -4688,80 +5764,91 @@
       "from": "矢量",
       "to": ["向量"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "vector"
     },
     {
       "from": "知識產權",
       "to": ["智慧財產權"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "intellectual property (IP)"
     },
     {
       "from": "短信",
       "to": ["簡訊"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "SMS"
     },
     {
       "from": "硅",
       "to": ["矽"],
       "type": "cross_strait",
-      "context": "tw 依 1933 年 MoE 標準譯名。cn 於 1957 年改用現名，偏離音譯系統",
+      "context": "@domain 材料。tw 依 1933 年 MoE 標準譯名。cn 於 1957 年改用現名，偏離音譯系統",
       "english": "silicon"
     },
     {
       "from": "硬件",
       "to": ["硬體"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "hardware"
     },
     {
       "from": "硬盤",
       "to": ["硬碟"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "hard disk"
     },
     {
       "from": "硬編碼的",
       "to": ["編死的"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "hard-coded"
     },
     {
       "from": "碼分多址",
       "to": ["分碼多重進接"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "code-division multiple access (CDMA)"
     },
     {
       "from": "碼率",
       "to": ["位元率"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "bitrate"
     },
     {
       "from": "磁盤",
       "to": ["磁碟"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "disk"
     },
     {
       "from": "磁碟文件",
       "to": ["磁碟檔案"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "disk file"
     },
     {
       "from": "磁道",
       "to": ["磁軌"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "track (disk)"
     },
     {
       "from": "社交",
       "to": ["社群"],
       "type": "cross_strait",
-      "context": "限 social network 語境。「社交能力」為正確 tw 用法",
+      "context": "@domain 通訊。限 social network 語境。「社交能力」為正確 tw 用法",
       "english": "social (network)",
       "context_clues": ["媒體", "網路", "網絡", "平台", "帳號", "賬號", "貼文"]
     },
@@ -4769,7 +5856,7 @@
       "from": "社區",
       "to": ["社群"],
       "type": "cross_strait",
-      "context": "「社區」指實體住宅區，online/tech community 語意不同",
+      "context": "@domain 社群。「社區」指實體住宅區，online/tech community 語意不同",
       "english": "community"
     },
     {
@@ -4789,63 +5876,86 @@
       "from": "禁用",
       "to": ["停用"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "disable"
+    },
+    {
+      "from": "私信",
+      "to": ["私訊"],
+      "type": "cross_strait",
+      "context": "@domain 社群",
+      "english": "direct message / DM",
+      "context_clues": ["訊息", "發送", "聊天", "好友"]
     },
     {
       "from": "科摩羅",
       "to": ["葛摩"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Comoros"
     },
     {
       "from": "科特迪瓦",
       "to": ["象牙海岸"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Ivory Coast (Cote d'Ivoire)"
     },
     {
       "from": "移動硬盤",
       "to": ["行動硬碟"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "portable hard drive"
+    },
+    {
+      "from": "移動端",
+      "to": ["行動裝置"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "mobile",
+      "context_clues": ["手機", "APP", "響應式", "行動"]
     },
     {
       "from": "移動網絡",
       "to": ["行動網路"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "mobile network"
     },
     {
       "from": "移動設備",
       "to": ["行動裝置"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "mobile device"
     },
     {
       "from": "移動資料",
       "to": ["行動資料"],
       "type": "cross_strait",
+      "context": "@domain 資料",
       "english": "mobile data"
     },
     {
       "from": "移動通信",
       "to": ["行動通訊"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "mobile communication"
     },
     {
       "from": "移動電話",
       "to": ["行動電話"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "mobile phone"
     },
     {
       "from": "程序",
       "to": ["程式"],
       "type": "cross_strait",
-      "context": "限 IT 語境。不應與「程序」(procedure/步驟) 混淆",
+      "context": "@domain IT。限 IT 語境。不應與「程序」(procedure/步驟) 混淆",
       "english": "program",
       "context_clues": ["編寫", "代碼", "程式碼", "執行", "開發", "編譯", "軟件", "軟體", "調試", "除錯", "偵錯", "CPU", "排程", "行程", "核心", "記憶體", "I/O", "作業系統", "狀態", "IPC", "Process"],
       "exceptions": ["標準程序", "行政程序", "法律程序", "司法程序", "議事程序", "審核程序", "審查程序"]
@@ -4854,7 +5964,7 @@
       "from": "程序 (Process)",
       "to": ["行程 (Process)"],
       "type": "cross_strait",
-      "context": "OpenCC s2twp 將進程 (Process) 轉為程序 (Process)；明確標註 Process 即為行程",
+      "context": "@domain 作業系統。OpenCC s2twp 將進程 (Process) 轉為程序 (Process)；明確標註 Process 即為行程",
       "english": "process"
     },
     {
@@ -4868,13 +5978,14 @@
       "from": "程序員",
       "to": ["程式設計師", "程式開發者"],
       "type": "cross_strait",
+      "context": "@domain IT。programmer; tw 用「程式設計師」或「程式開發者」",
       "english": "programmer"
     },
     {
       "from": "程序抽象",
       "to": ["行程抽象"],
       "type": "cross_strait",
-      "context": "限作業系統語境。此處「程序」指 process (行程)，非 program (程式)",
+      "context": "@domain 程式設計。限作業系統語境。此處「程序」指 process (行程)，非 program (程式)",
       "english": "process abstraction",
       "context_clues": ["作業系統", "OS", "kernel", "核心", "排程", "fork", "exec", "CPU", "記憶體", "行程", "執行緒", "IPC"]
     },
@@ -4934,14 +6045,14 @@
       "from": "程序（Process）",
       "to": ["行程（Process）"],
       "type": "cross_strait",
-      "context": "OpenCC s2twp 將進程（Process）轉為程序（Process）；全形括弧版本",
+      "context": "@domain 作業系統。OpenCC s2twp 將進程（Process）轉為程序（Process）；全形括弧版本",
       "english": "process"
     },
     {
       "from": "積分",
       "to": ["點數", "分數", "紅利"],
       "type": "cross_strait",
-      "context": "限商業語境 (loyalty points)。數學「積分」(integral) 為標準 tw 用語",
+      "context": "@domain 數學。限商業語境 (loyalty points)。數學「積分」(integral) 為標準 tw 用語",
       "english": "points/credits",
       "context_clues": ["會員", "紅利", "兌換", "獎勵", "消費", "回饋"]
     },
@@ -4949,18 +6060,21 @@
       "from": "空分多址",
       "to": ["分空間多重進接"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "space-division multiple access (SDMA)"
     },
     {
       "from": "空分複用",
       "to": ["空間多工"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "space-division multiplexing (SDM)"
     },
     {
       "from": "空氣淨化器",
       "to": ["空氣清淨機"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "air purifier"
     },
     {
@@ -4998,20 +6112,21 @@
       "from": "空間站",
       "to": ["太空站"],
       "type": "cross_strait",
+      "context": "@domain 航太",
       "english": "space station"
     },
     {
       "from": "突尼斯",
       "to": ["突尼西亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Tunisia"
     },
     {
       "from": "窗口",
       "to": ["視窗"],
       "type": "cross_strait",
-      "context": "限 GUI/HCI 語境。依 MoE 辭典，「窗口」指實體窗戶或服務櫃檯。GUI window 應譯「視窗」",
+      "context": "@domain UI。限 GUI/HCI 語境。依 MoE 辭典，「窗口」指實體窗戶或服務櫃檯。GUI window 應譯「視窗」",
       "english": "window",
       "context_clues": ["GUI", "UI", "介面", "桌面", "對話框", "彈出", "最小化", "最大化", "關閉", "視窗", "拖曳", "操作", "應用程式", "瀏覽器", "工具列", "切換", "分割", "標題列", "全螢幕", "面板", "選單"]
     },
@@ -5019,13 +6134,14 @@
       "from": "窗口函數",
       "to": ["視窗函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "window function"
     },
     {
       "from": "窗體",
       "to": ["表單"],
       "type": "cross_strait",
-      "context": "限 UI 語境",
+      "context": "@domain UI。限 UI 語境",
       "english": "form",
       "context_clues": ["UI", "介面", "接口", "控件", "按鈕", "HTML"]
     },
@@ -5036,9 +6152,18 @@
       "context": "MoE 標準字體 (@example 灶台、灶神)"
     },
     {
+      "from": "端到端測試",
+      "to": ["端對端測試"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "end-to-end test / E2E test",
+      "context_clues": ["測試", "自動化", "瀏覽器", "E2E"]
+    },
+    {
       "from": "端口",
       "to": ["連接埠", "埠"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "port"
     },
     {
@@ -5049,28 +6174,39 @@
       "english": "port number"
     },
     {
+      "from": "競態條件",
+      "to": ["競爭條件"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "race condition",
+      "context_clues": ["執行緒", "並行", "同步", "鎖", "race"]
+    },
+    {
       "from": "筆記本電腦",
       "to": ["筆記型電腦"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "laptop/notebook"
     },
     {
       "from": "等號操作符",
       "to": ["equality 運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "equality operator"
     },
     {
       "from": "等離子",
       "to": ["電漿"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "plasma"
     },
     {
       "from": "算子",
       "to": ["運算子"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "operator",
       "exceptions": ["運算子"]
     },
@@ -5078,6 +6214,7 @@
       "from": "算法",
       "to": ["演算法"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "algorithm",
       "exceptions": ["演算法"]
     },
@@ -5085,26 +6222,28 @@
       "from": "箭頭操作符",
       "to": ["arrow 運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "arrow operator"
     },
     {
       "from": "範式",
       "to": ["正規化"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "normal form/paradigm"
     },
     {
       "from": "範式轉移",
       "to": ["典範轉移"],
       "type": "cross_strait",
-      "context": "tw 學術界標準譯法；「典範」源自孔恩 (Thomas Kuhn)《科學革命的結構》中文譯本用語",
+      "context": "@domain 程式設計。tw 學術界標準譯法；「典範」源自孔恩 (Thomas Kuhn)《科學革命的結構》中文譯本用語",
       "english": "paradigm shift"
     },
     {
       "from": "粘貼",
       "to": ["貼上"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "paste"
     },
     {
@@ -5117,38 +6256,56 @@
       "from": "系統托盤",
       "to": ["系統匣"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "system tray"
+    },
+    {
+      "from": "約翰內斯堡",
+      "to": ["約翰尼斯堡"],
+      "type": "cross_strait",
+      "context": "@geo city (城市)",
+      "english": "Johannesburg"
     },
     {
       "from": "紅心大戰",
       "to": ["傷心小棧"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "Hearts (card game)"
     },
     {
       "from": "納米",
       "to": ["奈米"],
       "type": "cross_strait",
-      "context": "SI 長度單位 (10^-9 m)；製程技術語境最常見 (如 90奈米、7奈米製程)",
+      "context": "@domain 硬體。SI 長度單位 (10^-9 m)；製程技術語境最常見 (如 90奈米、7奈米製程)",
       "english": "nanometer/nm"
     },
     {
       "from": "素數",
       "to": ["質數"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "prime"
+    },
+    {
+      "from": "索馬裡",
+      "to": ["索馬利亞"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Somalia"
     },
     {
       "from": "索馬里",
       "to": ["索馬利亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Somalia"
     },
     {
       "from": "終端",
       "to": ["終端機"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "terminal",
       "exceptions": ["終端機"]
     },
@@ -5156,117 +6313,133 @@
       "from": "終端用戶",
       "to": ["終端使用者"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "end user"
     },
     {
       "from": "組件",
       "to": ["元件"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "component"
     },
     {
       "from": "組合框",
       "to": ["組合方塊", "複合方塊", "複合框"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "combo box"
     },
     {
       "from": "綁定",
       "to": ["繫結"],
       "type": "cross_strait",
-      "context": "限程式設計語境。data binding = 資料繫結；event binding = 事件繫結。依語境自行斟酌",
+      "context": "@domain 程式設計。限程式設計語境。data binding = 資料繫結；event binding = 事件繫結。依語境自行斟酌",
       "english": "bind"
     },
     {
       "from": "綑綁",
       "to": ["組合"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "bundle"
     },
     {
       "from": "網上鄰居",
       "to": ["網路芳鄰"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "Network Neighborhood"
     },
     {
       "from": "網卡",
       "to": ["網路卡"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "network card (NIC)"
     },
     {
       "from": "網吧",
       "to": ["網咖"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "internet cafe"
     },
     {
       "from": "網民",
       "to": ["網友"],
       "type": "cross_strait",
+      "context": "@domain 社群",
       "english": "netizen"
     },
     {
       "from": "網絡",
       "to": ["網路"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "network"
     },
     {
       "from": "網絡棧",
       "to": ["網路堆疊"],
       "type": "cross_strait",
-      "context": "tw: 網路堆疊, cn: 網絡棧/網路棧",
+      "context": "@domain IT。tw: 網路堆疊, cn: 網絡棧/網路棧",
       "english": "network stack"
     },
     {
       "from": "網絡適配器",
       "to": ["網路介面卡"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "network adapter"
     },
     {
       "from": "網路棧",
       "to": ["網路堆疊"],
       "type": "cross_strait",
-      "context": "tw: 網路堆疊, cn: 網絡棧/網路棧 (OpenCC 可能保留「棧」)",
+      "context": "@domain IT。tw: 網路堆疊, cn: 網絡棧/網路棧 (OpenCC 可能保留「棧」)",
       "english": "network stack"
     },
     {
       "from": "網關",
       "to": ["閘道器"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "gateway"
     },
     {
       "from": "線程",
       "to": ["執行緒"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "thread"
     },
     {
       "from": "線程池",
       "to": ["執行緒池"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "thread pool"
     },
     {
       "from": "編程",
       "to": ["程式設計"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "programming"
     },
     {
       "from": "編程語言",
       "to": ["程式語言"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "programming language"
     },
     {
       "from": "編譯時",
       "to": ["編譯時期"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "compile time",
       "exceptions": ["編譯時期"]
     },
@@ -5274,13 +6447,14 @@
       "from": "編譯期",
       "to": ["編譯時期"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "compile time"
     },
     {
       "from": "緩存",
       "to": ["快取"],
       "type": "cross_strait",
-      "context": "快取有「快速存取」的意涵。詞源是法裔北美獵人的俚語「儲存物品的秘密場所」。簡體「緩存」(高速緩衝存儲器的簡稱) 混淆 cache 與 buffer 的概念，「高速」和「緩存」更是語意衝突",
+      "context": "@domain IT。快取有「快速存取」的意涵。詞源是法裔北美獵人的俚語「儲存物品的秘密場所」。簡體「緩存」(高速緩衝存儲器的簡稱) 混淆 cache 與 buffer 的概念，「高速」和「緩存」更是語意衝突",
       "english": "cache"
     },
     {
@@ -5294,12 +6468,14 @@
       "from": "縮略圖",
       "to": ["縮圖"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "thumbnail"
     },
     {
       "from": "縮進",
       "to": ["縮排"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "indent"
     },
     {
@@ -5318,6 +6494,7 @@
       "from": "總線",
       "to": ["匯流排"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "bus"
     },
     {
@@ -5343,6 +6520,7 @@
       "from": "缺省",
       "to": ["預設"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "default"
     },
     {
@@ -5356,14 +6534,14 @@
       "from": "缺頁異常",
       "to": ["分頁錯誤"],
       "type": "cross_strait",
-      "context": "page fault 的標準 tw 譯法為「分頁錯誤」。「缺頁」為 cn 用語，「異常」在此指 fault 而非 exception",
+      "context": "@domain 程式設計。page fault 的標準 tw 譯法為「分頁錯誤」。「缺頁」為 cn 用語，「異常」在此指 fault 而非 exception",
       "english": "page fault"
     },
     {
       "from": "美聯儲",
       "to": ["美國聯準會"],
       "type": "cross_strait",
-      "context": "全名為「美國聯邦準備理事會」(Federal Reserve System)；cn 音譯/縮略「聯儲」，tw 慣用「聯準會」",
+      "context": "@domain 金融。全名為「美國聯邦準備理事會」(Federal Reserve System)；cn 音譯/縮略「聯儲」，tw 慣用「聯準會」",
       "english": "Federal Reserve System (Fed)"
     },
     {
@@ -5373,70 +6551,87 @@
       "context": "MoE 標準字體 (@example 群組、群眾)"
     },
     {
+      "from": "群聊",
+      "to": ["群組聊天"],
+      "type": "cross_strait",
+      "context": "@domain 社群",
+      "english": "group chat"
+    },
+    {
       "from": "翻譯器",
       "to": ["轉譯器"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "translator"
     },
     {
       "from": "老撾",
       "to": ["寮國"],
       "type": "cross_strait",
-      "context": "國名 cn 取 Lao 音譯，tw 依法語 Laos 音譯",
+      "context": "@geo country (國名)",
       "english": "Laos"
+    },
+    {
+      "from": "聖地亞哥",
+      "to": ["聖地牙哥"],
+      "type": "cross_strait",
+      "context": "@geo city (城市)",
+      "english": "Santiago/San Diego"
     },
     {
       "from": "聖基茨和尼維斯",
       "to": ["聖克里斯多福及尼維斯"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Saint Kitts and Nevis"
     },
     {
       "from": "聖文森特和格林納丁斯",
       "to": ["聖文森及格瑞那丁"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Saint Vincent and the Grenadines"
     },
     {
       "from": "聖盧西亞",
       "to": ["聖露西亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Saint Lucia"
     },
     {
       "from": "聖馬力諾",
       "to": ["聖馬利諾"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "San Marino"
     },
     {
       "from": "聯繫",
       "to": ["聯絡"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "contact"
     },
     {
       "from": "聯繫歷史",
       "to": ["通話記錄"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "call history"
     },
     {
       "from": "聲卡",
       "to": ["音效卡"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "sound card"
     },
     {
       "from": "聲明",
       "to": ["宣告"],
       "type": "cross_strait",
-      "context": "限程式設計語境 (variable/type declaration)。日常語境「發表聲明」(public statement) 為正確 tw 用法",
+      "context": "@domain 程式設計。限程式設計語境 (variable/type declaration)。日常語境「發表聲明」(public statement) 為正確 tw 用法",
       "english": "declaration",
       "context_clues": ["變數", "變量", "函式", "函數", "型別", "類別", "類型", "屬性", "方法", "介面", "接口", "模組"]
     },
@@ -5444,13 +6639,14 @@
       "from": "肯尼亞",
       "to": ["肯亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Kenya"
     },
     {
       "from": "胰腺",
       "to": ["胰臟"],
       "type": "cross_strait",
+      "context": "@domain 醫學",
       "english": "pancreas"
     },
     {
@@ -5463,102 +6659,119 @@
       "from": "脫機",
       "to": ["離線"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "offline"
     },
     {
       "from": "腳本",
       "to": ["指令碼"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "script"
     },
     {
       "from": "臨時對象",
       "to": ["暫時物件"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "temporary object"
     },
     {
       "from": "自動檔",
       "to": ["自排"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "automatic transmission"
     },
     {
       "from": "自動轉屏",
       "to": ["自動旋轉螢幕"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "auto-rotate"
     },
     {
       "from": "自定義",
       "to": ["自訂"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "customize"
     },
     {
       "from": "自行車",
       "to": ["腳踏車"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "bicycle"
     },
     {
       "from": "自適應",
       "to": ["適應性"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "adaptive"
     },
     {
       "from": "臺式機",
       "to": ["桌上型電腦"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "desktop computer"
     },
     {
       "from": "舉報",
       "to": ["檢舉"],
       "type": "cross_strait",
+      "context": "@domain 社群",
       "english": "report (complaint)"
     },
     {
       "from": "航天",
       "to": ["航空太空"],
       "type": "cross_strait",
+      "context": "@domain 航太",
       "english": "spaceflight"
     },
     {
       "from": "航天飛機",
       "to": ["太空梭"],
       "type": "cross_strait",
+      "context": "@domain 航太",
       "english": "space shuttle"
     },
     {
       "from": "芯片",
       "to": ["晶片"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "chip"
     },
     {
       "from": "花屏",
       "to": ["破圖"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "screen glitch/garbled display"
     },
     {
       "from": "花括弧",
       "to": ["大括弧", "大括號"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "brace (curly brace)"
     },
     {
       "from": "花括號",
       "to": ["大括弧", "大括號"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "brace (curly brace)"
     },
     {
       "from": "英偉達",
       "to": ["輝達"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "NVIDIA"
     },
     {
@@ -5571,7 +6784,7 @@
       "from": "莫桑比克",
       "to": ["莫三比克"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Mozambique"
     },
     {
@@ -5586,28 +6799,43 @@
       "from": "萊索托",
       "to": ["賴索托"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
+      "english": "Lesotho"
+    },
+    {
+      "from": "萊索託",
+      "to": ["賴索托"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
       "english": "Lesotho"
     },
     {
       "from": "萬億",
       "to": ["兆"],
       "type": "cross_strait",
-      "context": "兆 = 10^12",
+      "context": "@domain 金融。兆 = 10^12",
       "english": "trillion"
     },
     {
       "from": "萬維網",
       "to": ["全球資訊網"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "World Wide Web (WWW)"
     },
     {
       "from": "萬象",
       "to": ["永珍"],
       "type": "cross_strait",
-      "context": "地名 (@in Laos)",
+      "context": "@geo city (城市)",
       "english": "Vientiane"
+    },
+    {
+      "from": "蒙特利爾",
+      "to": ["蒙特婁"],
+      "type": "cross_strait",
+      "context": "@geo city (城市)",
+      "english": "Montreal"
     },
     {
       "from": "蔘",
@@ -5625,37 +6853,49 @@
       "from": "藍屏",
       "to": ["藍色當機畫面"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "blue screen (BSOD)"
+    },
+    {
+      "from": "蘇裡南",
+      "to": ["蘇利南"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Suriname"
     },
     {
       "from": "蘇里南",
       "to": ["蘇利南"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Suriname"
     },
     {
       "from": "處理函數",
       "to": ["處理常式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "handler"
     },
     {
       "from": "虛內存",
       "to": ["虛擬記憶體"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "virtual memory"
     },
     {
       "from": "虛函數",
       "to": ["虛擬函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "virtual function"
     },
     {
       "from": "虛存",
       "to": ["虛擬記憶體"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "virtual memory"
     },
     {
@@ -5683,19 +6923,29 @@
       "from": "行業",
       "to": ["產業"],
       "type": "cross_strait",
+      "context": "@domain 商業",
       "english": "industry"
+    },
+    {
+      "from": "表情包",
+      "to": ["貼圖包"],
+      "type": "cross_strait",
+      "context": "@domain 社群",
+      "english": "sticker pack",
+      "context_clues": ["聊天", "下載", "傳送", "LINE"]
     },
     {
       "from": "表達式",
       "to": ["表示式", "運算式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "expression"
     },
     {
       "from": "被重載的操作符",
       "to": ["多載化運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "overloaded operator"
     },
     {
@@ -5708,19 +6958,21 @@
       "from": "補丁",
       "to": ["修補程式", "更新檔"],
       "type": "cross_strait",
-      "context": "修正程式碼缺陷 (patch) vs 軟體版本更新 (update)",
+      "context": "@domain IT。修正程式碼缺陷 (patch) vs 軟體版本更新 (update)",
       "english": "patch"
     },
     {
       "from": "補碼",
       "to": ["二補數"],
       "type": "cross_strait",
+      "context": "@domain 數學",
       "english": "two's complement"
     },
     {
       "from": "裝置號",
       "to": ["裝置號碼"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "device number",
       "exceptions": ["裝置號碼"]
     },
@@ -5728,7 +6980,7 @@
       "from": "裝置驅動",
       "to": ["裝置驅動程式"],
       "type": "cross_strait",
-      "context": "tw 慣用「裝置驅動程式」，省略「程式」二字易與動詞混淆",
+      "context": "@domain IT。tw 慣用「裝置驅動程式」，省略「程式」二字易與動詞混淆",
       "english": "device driver",
       "exceptions": ["裝置驅動程式"]
     },
@@ -5736,18 +6988,21 @@
       "from": "複印",
       "to": ["影印"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "photocopy"
     },
     {
       "from": "複選按鈕",
       "to": ["核取按鈕", "方鈕"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "checkbox"
     },
     {
       "from": "複選框",
       "to": ["核取方塊"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "checkbox"
     },
     {
@@ -5760,6 +7015,7 @@
       "from": "視圖",
       "to": ["檢視"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "view"
     },
     {
@@ -5787,57 +7043,86 @@
       "from": "視頻電話",
       "to": ["視訊電話"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "video phone"
+    },
+    {
+      "from": "解壓",
+      "to": ["解壓縮"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "decompress/unzip",
+      "context_clues": ["檔案", "壓縮", "zip", "rar"]
     },
     {
       "from": "解釋器",
       "to": ["直譯器", "解譯器"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "interpreter"
     },
     {
       "from": "觸摸",
       "to": ["觸控"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "touch"
     },
     {
       "from": "觸摸屏",
       "to": ["觸控螢幕"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "touch screen"
+    },
+    {
+      "from": "計劃",
+      "to": ["計畫"],
+      "type": "cross_strait",
+      "context": "@domain 商業",
+      "english": "plan"
     },
     {
       "from": "計算機",
       "to": ["電腦"],
       "type": "cross_strait",
-      "context": "限非專業語境。針對專業場景，諸如電腦科學的科目名稱，仍允許使用「計算機」，如「計算機結構」(computer architecture)",
+      "context": "@domain IT。限非專業語境。針對專業場景，諸如電腦科學的科目名稱，仍允許使用「計算機」，如「計算機結構」(computer architecture)",
       "english": "computer"
     },
     {
       "from": "計算機安全",
       "to": ["電腦保安"],
       "type": "cross_strait",
+      "context": "@domain 資安",
       "english": "computer security"
     },
     {
       "from": "計算機科學",
       "to": ["電腦科學"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "computer science"
     },
     {
       "from": "計算機體系結構",
       "to": ["計算機結構"],
       "type": "cross_strait",
-      "context": "電腦科學的科目名稱",
+      "context": "@domain 程式設計。電腦科學的科目名稱",
       "english": "computer architecture"
+    },
+    {
+      "from": "託盤",
+      "to": ["系統匣"],
+      "type": "cross_strait",
+      "context": "@domain 硬體。cn「託盤」(系統)；tw 用「系統匣」(system tray)",
+      "english": "system tray",
+      "context_clues": ["通知", "圖示", "工作列", "系統"]
     },
     {
       "from": "記憶棒",
       "to": ["MS 記憶卡", "記憶卡"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "Memory Stick"
     },
     {
@@ -5851,7 +7136,7 @@
       "from": "訪問",
       "to": ["存取"],
       "type": "cross_strait",
-      "context": "「訪問」僅指 visit/interview，computing 語境語意不同",
+      "context": "@domain 程式設計。「訪問」僅指 visit/interview，computing 語境語意不同",
       "english": "access",
       "context_clues": ["記憶體", "指標", "陣列", "資料", "位址", "磁碟", "檔案", "權限", "核心", "使用者空間", "CPU", "暫存器", "快取"]
     },
@@ -5859,25 +7144,28 @@
       "from": "訪問函數",
       "to": ["存取函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "access function"
     },
     {
       "from": "訪問級別",
       "to": ["存取級別"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "access level"
     },
     {
       "from": "設備",
       "to": ["裝置"],
       "type": "cross_strait",
-      "context": "大型設施仍可用「設備」",
+      "context": "@domain 硬體。大型設施仍可用「設備」",
       "english": "device"
     },
     {
       "from": "設備號",
       "to": ["裝置號碼"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "device number"
     },
     {
@@ -5892,47 +7180,58 @@
       "from": "設置",
       "to": ["設定"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "settings"
     },
     {
       "from": "設計模式",
       "to": ["設計樣式", "設計範式"],
       "type": "cross_strait",
-      "context": "限軟體設計語境。「設計模式」在 tw 也常用，此規則僅在明確軟體設計語境提示",
+      "context": "@domain 程式設計。限軟體設計語境。「設計模式」在 tw 也常用，此規則僅在明確軟體設計語境提示",
       "english": "design pattern",
       "context_clues": ["GoF", "pattern", "物件導向", "面向對象", "軟體", "軟件"]
+    },
+    {
+      "from": "許可證",
+      "to": ["授權條款"],
+      "type": "cross_strait",
+      "context": "@domain 軟體授權。cn「許可證」(軟體)；tw 用「授權條款」(license)",
+      "english": "license",
+      "context_clues": ["MIT", "GPL", "Apache", "開源", "授權"]
     },
     {
       "from": "註冊機",
       "to": ["序號產生器"],
       "type": "cross_strait",
+      "context": "@domain 資安",
       "english": "keygen"
     },
     {
       "from": "註冊表",
       "to": ["登錄檔"],
       "type": "cross_strait",
-      "context": "限 Windows 語境",
+      "context": "@domain IT。限 Windows 語境",
       "english": "registry"
     },
     {
       "from": "註銷",
       "to": ["登出"],
       "type": "cross_strait",
-      "context": "「註銷」指永久刪除帳號，與 logout/sign out 語意不同",
+      "context": "@domain UI。「註銷」指永久刪除帳號，與 logout/sign out 語意不同",
       "english": "logout/sign out"
     },
     {
       "from": "詞組",
       "to": ["片語"],
       "type": "cross_strait",
+      "context": "@domain 語言學",
       "english": "phrase"
     },
     {
       "from": "語句",
       "to": ["敘述", "陳述式", "述句"],
       "type": "cross_strait",
-      "context": "限程式設計語境。語言學的「語句」為正確 tw 用法",
+      "context": "@domain 程式設計。限程式設計語境。語言學的「語句」為正確 tw 用法",
       "english": "statement",
       "context_clues": ["代碼", "程式碼", "編譯", "執行", "迴圈", "循環", "條件"]
     },
@@ -5940,75 +7239,84 @@
       "from": "語句塊",
       "to": ["區塊", "區段"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "block"
     },
     {
       "from": "調制解調器",
       "to": ["數據機"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "modem"
     },
     {
       "from": "調度",
       "to": ["排程"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "schedule"
     },
     {
       "from": "調度程序",
       "to": ["排程器"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "scheduler"
     },
     {
       "from": "調用",
       "to": ["呼叫", "喚起"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "call/invoke"
     },
     {
       "from": "調用操作符",
       "to": ["call 運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "call operator"
     },
     {
       "from": "調用棧",
       "to": ["呼叫堆疊"],
       "type": "cross_strait",
-      "context": "tw: 呼叫堆疊, cn: 調用棧",
+      "context": "@domain IT。tw: 呼叫堆疊, cn: 調用棧",
       "english": "call stack"
     },
     {
       "from": "調色板",
       "to": ["調色盤"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "palette"
     },
     {
       "from": "調製",
       "to": ["調變"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "modulation"
     },
     {
       "from": "調製解調器",
       "to": ["數據機"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "modem"
     },
     {
       "from": "調試",
       "to": ["除錯"],
       "type": "cross_strait",
-      "context": "tw 標準用語為除錯；偵錯偏重找出錯誤，除錯涵蓋找出與修正，為 debug 的慣用翻譯",
+      "context": "@domain 程式設計。tw 標準用語為除錯；偵錯偏重找出錯誤，除錯涵蓋找出與修正，為 debug 的慣用翻譯",
       "english": "debug"
     },
     {
       "from": "調試器",
       "to": ["除錯器"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "debugger"
     },
     {
@@ -6023,6 +7331,7 @@
       "from": "警告信息",
       "to": ["警告訊息"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "warning message"
     },
     {
@@ -6036,7 +7345,7 @@
       "from": "讀文件",
       "to": ["讀取檔案"],
       "type": "cross_strait",
-      "context": "限檔案 I/O 語境。「閱讀文件」(read documentation) 不適用",
+      "context": "@domain IT。限檔案 I/O 語境。「閱讀文件」(read documentation) 不適用",
       "english": "read file",
       "context_clues": ["檔案", "路徑", "I/O", "磁碟", "目錄", "open", "read", "write"]
     },
@@ -6044,32 +7353,43 @@
       "from": "變量",
       "to": ["變數"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "variable"
     },
     {
       "from": "许可证",
       "to": ["授權條款"],
       "type": "cross_strait",
-      "context": "限 IT 語境。軟體授權 (software license) 應譯「授權條款」，法律語境可用「許可證」",
+      "context": "@domain 軟體授權。限 IT 語境。軟體授權 (software license) 應譯「授權條款」，法律語境可用「許可證」",
       "english": "license"
     },
     {
       "from": "貝寧",
       "to": ["貝南"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Benin"
     },
     {
       "from": "負一屏",
       "to": ["資訊主頁"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "Today view/widget screen"
+    },
+    {
+      "from": "負載均衡",
+      "to": ["負載平衡"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "load balancing",
+      "context_clues": ["伺服器", "流量", "叢集", "分散"]
     },
     {
       "from": "資料綁定",
       "to": ["資料繫結"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "data binding"
     },
     {
@@ -6084,27 +7404,28 @@
       "from": "資源管理器",
       "to": ["檔案總管"],
       "type": "cross_strait",
-      "context": "限 Windows 語境",
+      "context": "@domain IT。限 Windows 語境",
       "english": "file explorer"
     },
     {
       "from": "賦值",
       "to": ["指派"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "assign"
     },
     {
       "from": "賦值操作符",
       "to": ["指派運算子"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "assignment operator"
     },
     {
       "from": "質量",
       "to": ["品質"],
       "type": "cross_strait",
-      "context": "「質量」在 tw 僅指 mass (物理量)，與 quality 語意不同",
+      "context": "@domain IT。「質量」在 tw 僅指 mass (物理量)，與 quality 語意不同",
       "english": "quality",
       "context_clues": ["保證", "管理", "控制", "提升", "改善", "軟件", "軟體", "產品", "服務", "測試"]
     },
@@ -6112,38 +7433,50 @@
       "from": "賬單",
       "to": ["帳單"],
       "type": "cross_strait",
+      "context": "@domain 商業",
       "english": "bill"
     },
     {
       "from": "賬戶",
       "to": ["帳戶"],
       "type": "cross_strait",
-      "context": "cn 用「賬」，tw 用「帳」",
+      "context": "@domain 商業。cn 用「賬」，tw 用「帳」",
       "english": "account"
     },
     {
       "from": "賬號",
       "to": ["帳號"],
       "type": "cross_strait",
+      "context": "@domain 商業",
       "english": "account"
     },
     {
       "from": "贊比亞",
       "to": ["尚比亞"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Zambia"
+    },
+    {
+      "from": "超時",
+      "to": ["逾時"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "timeout",
+      "context_clues": ["連線", "請求", "伺服器", "回應", "秒"]
     },
     {
       "from": "超清",
       "to": ["超高畫質"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "ultra high definition (UHD)"
     },
     {
       "from": "跟隨",
       "to": ["追蹤"],
       "type": "cross_strait",
+      "context": "@domain 社群",
       "english": "follow"
     },
     {
@@ -6156,55 +7489,63 @@
       "from": "蹦極",
       "to": ["高空彈跳"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "bungee jumping"
     },
     {
       "from": "軟件",
       "to": ["軟體"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "software"
     },
     {
       "from": "軟件包",
       "to": ["套裝軟體"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "software package"
     },
     {
       "from": "軟驅",
       "to": ["軟碟機"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "floppy drive"
     },
     {
       "from": "輔音",
       "to": ["子音"],
       "type": "cross_strait",
+      "context": "@domain 語言學",
       "english": "consonant"
     },
     {
       "from": "轉發",
       "to": ["轉寄"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "forward"
     },
     {
       "from": "轉發函數",
       "to": ["轉發函式", "轉呼叫函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "forwarding function"
     },
     {
       "from": "轉義字符",
       "to": ["跳脫字元"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "escape character"
     },
     {
       "from": "返回",
-      "to": ["傳回", "回返"],
+      "to": ["傳回", "回返", "回傳"],
       "type": "cross_strait",
-      "context": "限程式設計語境。一般用法「返回」(go back) 為正確 tw 用法",
+      "context": "@domain 程式設計。限程式設計語境。一般用法「返回」(go back) 為正確 tw 用法",
       "english": "return",
       "context_clues": ["函式", "函數", "程式碼", "代碼", "變數", "變量", "回傳"]
     },
@@ -6212,55 +7553,70 @@
       "from": "返回值",
       "to": ["回傳值", "回返值"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "return value"
     },
     {
       "from": "返回類型",
       "to": ["回傳型別", "回返型別"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "return type"
     },
     {
       "from": "返現",
       "to": ["回饋", "現金回饋"],
       "type": "cross_strait",
+      "context": "@domain 商業",
       "english": "cashback"
+    },
+    {
+      "from": "迪拜",
+      "to": ["杜拜"],
+      "type": "cross_strait",
+      "context": "@geo city (城市)",
+      "english": "Dubai"
     },
     {
       "from": "通信",
       "to": ["通訊"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "communication"
     },
     {
       "from": "通用算法",
       "to": ["泛型演算法"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "generic algorithm"
     },
     {
       "from": "通訊卡",
       "to": ["通話卡"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "communication card"
     },
     {
       "from": "通過",
       "to": ["透過"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "through/via"
     },
     {
       "from": "通配符",
       "to": ["萬用字元"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "wildcard"
     },
     {
       "from": "連接",
       "to": ["連線"],
       "type": "cross_strait",
-      "context": "連接埠（port）為正確台灣慣用語；連接點（articulation/junction point）為圖論術語，均不替換",
+      "context": "@domain IT。連接埠（port）為正確台灣慣用語；連接點（articulation/junction point）為圖論術語，均不替換",
       "english": "connect",
       "exceptions": ["連接埠", "連接點"]
     },
@@ -6268,57 +7624,63 @@
       "from": "連接器",
       "to": ["聯結器"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "connector"
     },
     {
       "from": "進制",
       "to": ["進位制"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "radix/numeral system"
     },
     {
       "from": "進程",
       "to": ["行程"],
       "type": "cross_strait",
-      "context": "行程強調已在執行中的程式實體。「進程」實為 progress (進度/進展)，不宜指 OS process。半導體語境 = 製程。program 是靜態，process 是動態",
+      "context": "@domain 作業系統。行程強調已在執行中的程式實體。「進程」實為 progress (進度/進展)，不宜指 OS process。半導體語境 = 製程。program 是靜態，process 是動態",
       "english": "process"
     },
     {
       "from": "進程抽象",
       "to": ["行程抽象"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "process abstraction"
     },
     {
       "from": "進程管理",
       "to": ["行程管理"],
       "type": "cross_strait",
-      "context": "作業系統術語；cn: 進程管理, tw: 行程管理",
+      "context": "@domain 作業系統。作業系統術語；cn: 進程管理, tw: 行程管理",
       "english": "process management"
     },
     {
       "from": "運營",
       "to": ["營運"],
       "type": "cross_strait",
+      "context": "@domain 商業",
       "english": "operate"
     },
     {
       "from": "運算符",
       "to": ["運算子"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "operator"
     },
     {
       "from": "運維",
       "to": ["維運"],
       "type": "cross_strait",
+      "context": "@domain 雲端",
       "english": "DevOps/operations"
     },
     {
       "from": "運行",
       "to": ["執行"],
       "type": "cross_strait",
-      "context": "英語的 run 和 execute 有時可互換，前者著重應用程式層級，後者則用於 CPU 和作業系統層級。tw 沒有明確區分",
+      "context": "@domain UI。英語的 run 和 execute 有時可互換，前者著重應用程式層級，後者則用於 CPU 和作業系統層級。tw 沒有明確區分",
       "english": "run/execute"
     },
     {
@@ -6340,62 +7702,70 @@
       "from": "遍歷",
       "to": ["走訪"],
       "type": "cross_strait",
-      "context": "「遍」含「到處/全面」之意，但 traverse 原意僅為 to pass or move over，不隱含「全部」。另「遍歷」已用於 Ergodic theory (遍歷理論)，不宜混用",
+      "context": "@domain 程式設計。「遍」含「到處/全面」之意，但 traverse 原意僅為 to pass or move over，不隱含「全部」。另「遍歷」已用於 Ergodic theory (遍歷理論)，不宜混用",
       "english": "traverse"
     },
     {
       "from": "過濾器",
       "to": ["篩選器"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "filter"
     },
     {
       "from": "過程式編程",
       "to": ["程序式程式設計"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "procedural programming"
     },
     {
       "from": "遞歸",
       "to": ["遞迴"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "recursion"
     },
     {
       "from": "遠程",
       "to": ["遠端"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "remote"
     },
     {
       "from": "適配",
       "to": ["配接", "轉接"],
       "type": "cross_strait",
-      "context": "軟體/介面 vs 硬體轉接頭",
+      "context": "@domain IT。軟體/介面 vs 硬體轉接頭",
       "english": "adapt"
     },
     {
       "from": "適配卡",
       "to": ["介面卡", "配接卡"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "adapter card"
     },
     {
       "from": "適配器",
       "to": ["配接器", "介面卡"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "adapter"
     },
     {
       "from": "選中",
       "to": ["選取"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "select"
     },
     {
       "from": "選項卡",
       "to": ["頁籤"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "tab"
     },
     {
@@ -6409,83 +7779,109 @@
       "from": "邏輯門",
       "to": ["邏輯閘"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "logic gate"
     },
     {
       "from": "郵箱",
       "to": ["電子信箱", "電子郵件"],
       "type": "cross_strait",
-      "context": "「郵箱」指實體郵筒，與電子信箱語意不同",
+      "context": "@domain 網路。「郵箱」指實體郵筒，與電子信箱語意不同",
       "english": "email/mailbox"
     },
     {
       "from": "配置",
       "to": ["設定", "組態"],
       "type": "cross_strait",
-      "context": "「硬體/網路配置」tw 用「組態」；「記憶體配置」(allocation) 為正確 tw 用法",
+      "context": "@domain IT。「硬體/網路配置」tw 用「組態」；「記憶體配置」(allocation) 為正確 tw 用法",
       "english": "configuration",
       "context_clues": ["硬體", "韌體", "BIOS", "路由器", "防火牆", "網路", "交換器", "機箱", "主機板", "插槽", "插卡", "NIC", "PCIe", "PCI"],
       "negative_context_clues": ["記憶體", "回收", "配置器", "malloc", "allocat"]
     },
     {
+      "from": "配置文件",
+      "to": ["組態檔"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "configuration file",
+      "context_clues": ["設定", "系統", "伺服器", "修改"]
+    },
+    {
       "from": "配置檔",
       "to": ["設定檔"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "configuration file"
     },
     {
       "from": "酸奶",
       "to": ["優格", "發酵乳", "優酪乳"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "yogurt"
     },
     {
       "from": "重命名",
       "to": ["重新命名"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "rename"
+    },
+    {
+      "from": "重啟",
+      "to": ["重新啟動"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "restart/reboot",
+      "context_clues": ["系統", "電腦", "伺服器", "服務"]
     },
     {
       "from": "重定向",
       "to": ["重新導向"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "redirect"
     },
     {
       "from": "重裝",
       "to": ["重灌"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "reinstall"
     },
     {
       "from": "重載",
       "to": ["多載化"],
       "type": "cross_strait",
-      "context": "限程式設計語境",
+      "context": "@domain 程式設計。限程式設計語境",
       "english": "overload"
     },
     {
       "from": "重載的函數",
       "to": ["多載化函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "overloaded function"
     },
     {
       "from": "重載集合",
       "to": ["多載集合"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "overloaded set"
     },
     {
       "from": "金屬氧化物半導體",
       "to": ["金氧半導體"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "metal-oxide-semiconductor (MOS)"
     },
     {
       "from": "金槍魚",
       "to": ["鮪魚"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "tuna"
     },
     {
@@ -6498,6 +7894,7 @@
       "from": "鉤子",
       "to": ["掛鉤"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "hook"
     },
     {
@@ -6510,12 +7907,14 @@
       "from": "錄像",
       "to": ["錄影"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "record (video)"
     },
     {
       "from": "錯誤信息",
       "to": ["錯誤訊息"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "error message"
     },
     {
@@ -6528,12 +7927,14 @@
       "from": "鏈接",
       "to": ["連結"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "link"
     },
     {
       "from": "鏈接庫",
       "to": ["連結函式庫"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "link library"
     },
     {
@@ -6552,22 +7953,41 @@
       "english": "linked list"
     },
     {
+      "from": "鏡像",
+      "to": ["映像檔"],
+      "type": "cross_strait",
+      "context": "@domain 硬體。cn「鏡像」(軟體)；tw 用「映像檔」(image file)",
+      "english": "image",
+      "context_clues": ["ISO", "Docker", "安裝", "燒錄", "容器"]
+    },
+    {
       "from": "門戶網站",
       "to": ["入口網站"],
       "type": "cross_strait",
+      "context": "@domain 網路",
       "english": "web portal"
     },
     {
       "from": "門電路",
       "to": ["閘電路"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "gate circuit"
     },
     {
       "from": "閃存",
       "to": ["快閃記憶體"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "flash memory"
+    },
+    {
+      "from": "開始菜單",
+      "to": ["開始功能表"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "start menu",
+      "context_clues": ["Windows", "桌面", "工作列", "程式"]
     },
     {
       "from": "開源",
@@ -6589,20 +8009,21 @@
       "from": "閾值",
       "to": ["門檻值", "臨界值"],
       "type": "cross_strait",
-      "context": "「閾」為罕用字，tw 多用「門檻值」",
+      "context": "@domain 數學。「閾」為罕用字，tw 多用「門檻值」",
       "english": "threshold"
     },
     {
       "from": "關係數據庫",
       "to": ["關聯式資料庫"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "relational database"
     },
     {
       "from": "關注",
       "to": ["追蹤"],
       "type": "cross_strait",
-      "context": "「關注」偏指 pay attention to，社群媒體語境語意不同",
+      "context": "@domain 社群。「關注」偏指 pay attention to，社群媒體語境語意不同",
       "english": "follow/subscribe",
       "context_clues": ["訂閱", "帳號", "貼文", "社群", "粉絲", "推特", "臉書", "Twitter", "Facebook", "Instagram", "YouTube", "追蹤者"]
     },
@@ -6610,38 +8031,50 @@
       "from": "阿塞拜疆",
       "to": ["亞塞拜然"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Azerbaijan"
     },
     {
       "from": "阿拉伯聯合酋長國",
       "to": ["阿拉伯聯合大公國"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "United Arab Emirates (UAE)"
+    },
+    {
+      "from": "阿爾茨海默",
+      "to": ["阿茲海默症"],
+      "type": "cross_strait",
+      "context": "@domain 醫學",
+      "english": "Alzheimer's disease",
+      "context_clues": ["失智", "疾病", "記憶", "老年"]
     },
     {
       "from": "附加組件",
       "to": ["附加元件"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "addon"
     },
     {
       "from": "限定修飾詞",
       "to": ["資格修飾詞", "飾詞"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "qualifier"
     },
     {
       "from": "隊列",
       "to": ["佇列"],
       "type": "cross_strait",
+      "context": "@domain 資料結構",
       "english": "queue"
     },
     {
       "from": "隨機存取存儲器",
       "to": ["隨機存取記憶體"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "RAM"
     },
     {
@@ -6656,18 +8089,29 @@
       "from": "集成",
       "to": ["整合"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "integrate"
     },
     {
       "from": "集成圖形",
       "to": ["整合圖形"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "integrated graphics"
+    },
+    {
+      "from": "集成測試",
+      "to": ["整合測試"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "integration test",
+      "context_clues": ["測試", "單元", "CI", "自動化"]
     },
     {
       "from": "集成開發環境",
       "to": ["整合式開發環境", "整合開發環境"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "IDE"
     },
     {
@@ -6681,12 +8125,22 @@
       "from": "集羣",
       "to": ["叢集"],
       "type": "cross_strait",
+      "context": "@domain 雲端",
       "english": "cluster"
+    },
+    {
+      "from": "集群",
+      "to": ["叢集"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "cluster",
+      "context_clues": ["伺服器", "節點", "分散", "部署", "K8s"]
     },
     {
       "from": "雙參函數",
       "to": ["二元函式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "binary function"
     },
     {
@@ -6700,36 +8154,42 @@
       "from": "雲存儲",
       "to": ["雲端儲存"],
       "type": "cross_strait",
+      "context": "@domain 雲端",
       "english": "cloud storage"
     },
     {
       "from": "雲服務",
       "to": ["雲端服務"],
       "type": "cross_strait",
+      "context": "@domain 雲端",
       "english": "cloud service"
     },
     {
       "from": "雲計算",
       "to": ["雲端運算"],
       "type": "cross_strait",
+      "context": "@domain 雲端",
       "english": "cloud computing"
     },
     {
       "from": "零部件",
       "to": ["零組件"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "components/parts"
     },
     {
       "from": "電源適配器",
       "to": ["電源供應器"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "power adapter"
     },
     {
       "from": "電芯",
       "to": ["電池芯"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "battery cell"
     },
     {
@@ -6754,6 +8214,7 @@
       "from": "靈活性",
       "to": ["彈性"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "flexibility"
     },
     {
@@ -6767,56 +8228,63 @@
       "from": "靜態庫",
       "to": ["靜態函式庫"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "static library"
     },
     {
       "from": "面向對象",
       "to": ["物件導向"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "object-oriented"
     },
     {
       "from": "面向對象的",
       "to": ["物件導向的"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "object oriented"
     },
     {
       "from": "面向過程",
       "to": ["程序導向"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "procedural"
     },
     {
       "from": "音箱",
-      "to": ["喇叭", "揚聲器"],
+      "to": ["喇叭", "揚聲器", "音響"],
       "type": "cross_strait",
-      "context": "口語/日常 vs 技術文件/規格",
+      "context": "@domain 硬體。口語/日常 vs 技術文件/規格",
       "english": "speaker"
     },
     {
       "from": "音頻",
       "to": ["音訊"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "audio"
     },
     {
       "from": "響應",
       "to": ["回應"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "response"
     },
     {
       "from": "頁眉",
       "to": ["頁首"],
       "type": "cross_strait",
-      "context": "限出版語境",
+      "context": "@domain 文書。限出版語境",
       "english": "header (page)"
     },
     {
       "from": "頁腳",
       "to": ["頁尾"],
       "type": "cross_strait",
+      "context": "@domain 文書",
       "english": "footer (page)"
     },
     {
@@ -6830,61 +8298,82 @@
       "from": "項目",
       "to": ["專案"],
       "type": "cross_strait",
-      "context": "限軟體開發語境。cn 以「項目」表示 project，tw 用「專案」；「項目」作為 item/品項時為正確 tw 用法",
+      "context": "@domain IT。限軟體開發語境。cn 以「項目」表示 project，tw 用「專案」；「項目」作為 item/品項時為正確 tw 用法",
       "english": "project",
       "context_clues": ["開發", "部署", "版本", "軟體", "軟件", "程式碼", "代碼", "工程", "建置", "維護"]
+    },
+    {
+      "from": "項目管理",
+      "to": ["專案管理"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "project management",
+      "context_clues": ["排程", "任務", "進度", "敏捷"]
     },
     {
       "from": "順序式容器",
       "to": ["序列式容器"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "sequential container"
     },
     {
       "from": "預分配",
       "to": ["預先配置"],
       "type": "cross_strait",
-      "context": "限記憶體/資源配置語境",
+      "context": "@domain 系統程式。限記憶體/資源配置語境",
       "english": "pre-allocate"
     },
     {
       "from": "預處理器",
       "to": ["前置處理器"],
       "type": "cross_strait",
+      "context": "@domain 作業系統",
       "english": "preprocessor"
     },
     {
       "from": "頭",
       "to": ["標頭"],
       "type": "cross_strait",
-      "context": "限程式設計語境 (C/C++ header file)。「開頭」「剃頭」「橋頭」等日常語境不在此範圍",
+      "context": "@domain 程式設計。限程式設計語境 (C/C++ header file)。「開頭」「剃頭」「橋頭」等日常語境不在此範圍",
       "english": "header (programming)",
       "context_clues": ["標頭", "宣告", "定義", "編譯", "函式", "函數", "程式碼", "代碼", "原始碼"],
       "exceptions": ["開頭", "裡頭", "回頭", "前頭", "後頭", "起頭", "盡頭", "剃頭", "橋頭", "碼頭", "源頭", "骨頭", "標頭"]
     },
     {
+      "from": "頭像",
+      "to": ["大頭貼"],
+      "type": "cross_strait",
+      "context": "@domain 社群。cn「頭像」；tw 用「大頭貼」或「頭像」(avatar/profile picture)",
+      "english": "avatar",
+      "context_clues": ["帳號", "個人", "設定", "上傳"]
+    },
+    {
       "from": "頭文件",
       "to": ["標頭檔"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "header file"
     },
     {
       "from": "頻分多址",
       "to": ["分頻多重進接"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "frequency-division multiple access (FDMA)"
     },
     {
       "from": "頻分複用",
       "to": ["分頻多工"],
       "type": "cross_strait",
+      "context": "@domain 通訊",
       "english": "frequency-division multiplexing (FDM)"
     },
     {
       "from": "類",
       "to": ["類別"],
       "type": "cross_strait",
-      "context": "依 MoE 辭典，「類」為分類/種類之意。程式設計中 class 應譯「類別」，限程式設計語境",
+      "context": "@domain 程式設計。依 MoE 辭典，「類」為分類/種類之意。程式設計中 class 應譯「類別」，限程式設計語境",
       "english": "class",
       "context_clues": ["class", "物件", "對象", "繼承", "多型", "介面", "OOP", "建構", "方法", "抽象", "封裝", "實體", "子類別", "基底", "衍生", "overrid", "虛擬函式"],
       "exceptions": ["分類", "人類", "種類", "類似", "歸類", "各類", "同類", "大類", "小類", "這類", "那類", "此類", "何類", "一類", "之類", "其類", "同類之", "以及類似", "類比", "類推", "類別"]
@@ -6893,7 +8382,7 @@
       "from": "類型",
       "to": ["型態", "型別"],
       "type": "cross_strait",
-      "context": "限程式設計語境。「類型」在日常語境表示「種類/範疇」為正確 tw 用法",
+      "context": "@domain 程式設計。限程式設計語境。「類型」在日常語境表示「種類/範疇」為正確 tw 用法",
       "english": "type",
       "context_clues": ["型別", "型態", "變數", "變量", "函式", "函數", "程式碼", "代碼", "泛型", "編譯", "宣告"],
       "negative_context_clues": ["哪些類型", "什麼類型", "各種類型", "某種類型", "這類型"]
@@ -6902,84 +8391,98 @@
       "from": "類定義",
       "to": ["類別定義", "類別定義式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "class definition"
     },
     {
       "from": "類層次體系",
       "to": ["類別繼承體系", "類別階層"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "class hierarchy"
     },
     {
       "from": "類庫",
       "to": ["類別程式庫", "類別庫"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "class library"
     },
     {
       "from": "類模板",
       "to": ["類別模板", "類別範本"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "class template"
     },
     {
       "from": "類模板特化",
       "to": ["類別模板特化"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "class template specializations"
     },
     {
       "from": "類模板部分特化",
       "to": ["類別模板偏特化"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "class template partial specializations"
     },
     {
       "from": "類繼承列表",
       "to": ["類別衍化列"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "class derivation list"
     },
     {
       "from": "類聲明",
       "to": ["類別宣告", "類別宣告式"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "class declaration"
     },
     {
       "from": "類頭",
       "to": ["類別表頭"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "class head"
     },
     {
       "from": "類體",
       "to": ["類別本體"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "class body"
     },
     {
       "from": "顯像管",
       "to": ["映象管"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "cathode-ray tube (CRT)"
     },
     {
       "from": "顯卡",
       "to": ["顯示卡"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "graphics card"
     },
     {
       "from": "顯存",
       "to": ["視訊記憶體"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "video memory (VRAM)"
     },
     {
       "from": "飛行模式",
       "to": ["飛航模式"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "airplane mode"
     },
     {
@@ -6994,51 +8497,63 @@
       "from": "首席信息官",
       "to": ["資訊長"],
       "type": "cross_strait",
+      "context": "@domain 金融",
       "english": "Chief Information Officer (CIO)"
     },
     {
       "from": "首席執行官",
       "to": ["執行長"],
       "type": "cross_strait",
-      "context": "「執行長」一詞翻譯不佳，可改寫為 CEO",
+      "context": "@domain 商業。「執行長」一詞翻譯不佳，可改寫為 CEO",
       "english": "CEO"
     },
     {
       "from": "首席技術官",
       "to": ["技術長"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "Chief Technology Officer (CTO)"
     },
     {
       "from": "首席運營官",
       "to": ["營運長"],
       "type": "cross_strait",
+      "context": "@domain 金融",
       "english": "Chief Operating Officer (COO)"
     },
     {
       "from": "首選項",
       "to": ["偏好設定"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "preferences"
     },
     {
       "from": "香農",
       "to": ["夏農"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "Shannon"
     },
     {
       "from": "馬爾代夫",
       "to": ["馬爾地夫"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Maldives"
+    },
+    {
+      "from": "馬裡共和國",
+      "to": ["馬利共和國"],
+      "type": "cross_strait",
+      "context": "@geo country (國名)",
+      "english": "Mali"
     },
     {
       "from": "馬里共和國",
       "to": ["馬利共和國"],
       "type": "cross_strait",
-      "context": "國名",
+      "context": "@geo country (國名)",
       "english": "Republic of Mali"
     },
     {
@@ -7061,62 +8576,85 @@
       "from": "驅動程序",
       "to": ["驅動程式"],
       "type": "cross_strait",
-      "context": "cn「程序」= program, tw「程式」= program; 「驅動程式」= device driver",
+      "context": "@domain IT。cn「程序」= program, tw「程式」= program; 「驅動程式」= device driver",
       "english": "driver"
+    },
+    {
+      "from": "骨架屏",
+      "to": ["骨架畫面"],
+      "type": "cross_strait",
+      "context": "@domain UI",
+      "english": "skeleton screen",
+      "context_clues": ["載入", "UI", "介面", "佔位", "載入中"]
     },
     {
       "from": "體系結構",
       "to": ["架構", "系統架構"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "architecture"
     },
     {
       "from": "高亮",
       "to": ["醒目標示"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "highlight"
+    },
+    {
+      "from": "高可用",
+      "to": ["高可用性"],
+      "type": "cross_strait",
+      "context": "@domain IT",
+      "english": "high availability / HA",
+      "context_clues": ["叢集", "容錯", "備援", "伺服器"]
     },
     {
       "from": "高性能計算",
       "to": ["高效能運算"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "high-performance computing (HPC)"
     },
     {
       "from": "高檔",
       "to": ["高階"],
       "type": "cross_strait",
+      "context": "@domain 日常",
       "english": "high-grade"
     },
     {
       "from": "高清",
       "to": ["高畫質"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "high definition (HD)"
     },
     {
       "from": "高端",
       "to": ["高階", "進階"],
       "type": "cross_strait",
-      "context": "產品定位 vs 技術層級/難度",
+      "context": "@domain IT。產品定位 vs 技術層級/難度",
       "english": "high-end"
     },
     {
       "from": "高級",
       "to": ["高階", "進階"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "high-level/advanced"
     },
     {
       "from": "高速緩存",
       "to": ["快取記憶體", "快取"],
       "type": "cross_strait",
+      "context": "@domain IT",
       "english": "cache memory"
     },
     {
       "from": "髮生",
       "to": ["發生"],
-      "type": "confusable",
+      "type": "variant",
       "context": "OpenCC 轉換時可能誤植「發」為「髮」(hair)",
       "english": "occur/happen"
     },
@@ -7124,6 +8662,7 @@
       "from": "魔法數",
       "to": ["魔術數字", "魔術數值"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "magic number"
     },
     {
@@ -7142,44 +8681,57 @@
       "from": "黏貼",
       "to": ["貼上"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "paste"
     },
     {
       "from": "黑客",
-      "to": [""],
+      "to": ["駭客"],
       "type": "cross_strait",
-      "context": "指電腦技術高人一等者，並非蓄意破壞 (cracker)",
+      "context": "@domain IT。指電腦技術高人一等者，並非蓄意破壞 (cracker)",
       "english": "hacker"
+    },
+    {
+      "from": "黑帽",
+      "to": ["黑帽駭客"],
+      "type": "cross_strait",
+      "context": "@domain 資安",
+      "english": "black hat",
+      "context_clues": ["駭客", "攻擊", "安全", "漏洞"]
     },
     {
       "from": "默認",
       "to": ["預設"],
       "type": "cross_strait",
-      "context": "「默認」意指「默許/默示承認」(tacitly approve)，與 default (預設值) 語意不同",
+      "context": "@domain 程式設計。「默認」意指「默許/默示承認」(tacitly approve)，與 default (預設值) 語意不同",
       "english": "default"
     },
     {
       "from": "默認值",
       "to": ["預設值"],
       "type": "cross_strait",
+      "context": "@domain 程式設計",
       "english": "default value"
     },
     {
       "from": "點擊",
       "to": ["點選", "按一下"],
       "type": "cross_strait",
+      "context": "@domain UI",
       "english": "click"
     },
     {
       "from": "點贊",
       "to": ["按讚"],
       "type": "cross_strait",
+      "context": "@domain 社群",
       "english": "like (social media)"
     },
     {
       "from": "鼠標",
       "to": ["滑鼠"],
       "type": "cross_strait",
+      "context": "@domain 硬體",
       "english": "mouse"
     },
     {

--- a/scripts/check-ruleset.py
+++ b/scripts/check-ruleset.py
@@ -396,22 +396,64 @@ def verify_terms(
     return warnings, net_errors
 
 
+# Valid @domain labels (canonical single-label taxonomy).
+VALID_DOMAINS = {
+    "IT",
+    "UI",
+    "程式設計",
+    "作業系統",
+    "硬體",
+    "電子",
+    "網路",
+    "通訊",
+    "資安",
+    "資料結構",
+    "資料庫",
+    "資料",
+    "雲端",
+    "數學",
+    "科學",
+    "語言學",
+    "醫學",
+    "金融",
+    "商業",
+    "電商",
+    "社群",
+    "教育",
+    "日常",
+    "圖形",
+    "航太",
+    "文書",
+    "版本控制",
+    "系統程式",
+    "軟體授權",
+    "生物學",
+    "能源",
+    "材料",
+}
+
+# Valid @geo sub-types.
+VALID_GEO_TYPES = {"country", "city", "landmark", "university"}
+
+
 def detect_conflicts(spelling_rules: list[dict[str, Any]]) -> list[str]:
     """Detect semantic conflicts between spelling rules.
 
     Skips disabled rules.  Returns a list of warning strings for:
-    1. Circular mappings (to of rule A is from of rule B)
-    2. Empty to without english fallback
-    3. Variant rule invariants (single non-empty to)
-    4. Orphaned seealso references in context fields
-    5. AC compound decomposition conflicts (individual rules would produce
-       wrong output for a compound term that lacks its own rule)
-    6. Suggestion-is-from conflicts (a rule's to[] value is another rule's
-       from, creating unintended re-flagging)
-    7. Schema validation (required fields, valid types, unknown keys)
-    8. Compound suffix preservation (longer rules must not drop suffixes
-       that the base rule would preserve)
-    9. context_clues / negative_context_clues field validation
+    1.  Circular mappings (to of rule A is from of rule B)
+    2.  Empty to without english fallback
+    3.  Variant rule invariants (single non-empty to)
+    4.  Orphaned seealso references in context fields
+    5.  AC compound decomposition conflicts (individual rules would produce
+        wrong output for a compound term that lacks its own rule)
+    6.  Suggestion-is-from conflicts (a rule's to[] value is another rule's
+        from, creating unintended re-flagging)
+    7.  Schema validation (required fields, valid types, unknown keys)
+    8.  Compound suffix preservation (longer rules must not drop suffixes
+        that the base rule would preserve)
+    9.  context_clues / negative_context_clues field validation
+    10. Self-referencing to (from value appears in its own to array)
+    11. Annotation validation (@domain/@geo tag format and coverage)
     """
     warnings: list[str] = []
 
@@ -655,6 +697,127 @@ def detect_conflicts(spelling_rules: list[dict[str, Any]]) -> list[str]:
             warnings.append(
                 f'clue-overlap: "{frm}" has terms in both context_clues '
                 f"and negative_context_clues: {sorted(overlap)}"
+            )
+
+    # 10. Self-referencing to: from value must not appear in its own to array.
+    for rule in from_set.values():
+        frm = rule["from"]
+        if frm in rule.get("to", []):
+            warnings.append(
+                f'self-ref: "{frm}" appears in its own to array '
+                f"(identity suggestion)"
+            )
+
+    # 11. Annotation validation: @domain and @geo tags.
+    #
+    # Rules that use structured annotations:
+    #   @geo TYPE (LABEL)        -- geographic entities
+    #   @domain LABEL            -- domain-specific terms
+    #   @domain LABEL。note      -- domain + disambiguation
+    #
+    # cross_strait rules must have one of: @domain, @geo, (@seealso ...),
+    # or compound: prefix.  Bare prose without a structured tag is flagged.
+    # Anchored: after the tag, only 。(note) or end-of-string is valid.
+    geo_re = re.compile(r"^@geo\s+(\w+)\s*(?:\([^)]*\))?\s*(?:。|$)")
+    domain_re = re.compile(r"^@domain\s+([^。\s]+)\s*(?:。|$)")
+
+    for rule in from_set.values():
+        frm = rule["from"]
+        ctx = rule.get("context", "")
+        rtype = rule.get("type", "")
+
+        # Only cross_strait rules need annotation.
+        if rtype != "cross_strait":
+            continue
+
+        # Check @geo format.
+        geo_m = geo_re.match(ctx)
+        if geo_m:
+            geo_type = geo_m.group(1)
+            if geo_type not in VALID_GEO_TYPES:
+                warnings.append(
+                    f'geo-type: "{frm}" has unknown @geo type '
+                    f'"{geo_type}" (valid: {", ".join(sorted(VALID_GEO_TYPES))})'
+                )
+            continue  # has @geo -- skip further annotation checks
+
+        # Detect malformed @geo (starts with @geo but regex didn't match).
+        if ctx.startswith("@geo"):
+            warnings.append(
+                f'geo-malformed: "{frm}" has malformed @geo tag: ' f'"{ctx[:40]}"'
+            )
+            continue
+
+        # Check @domain format.
+        dom_m = domain_re.match(ctx)
+        if dom_m:
+            domain = dom_m.group(1)
+            if domain not in VALID_DOMAINS:
+                warnings.append(
+                    f'domain-label: "{frm}" has unknown @domain ' f'"{domain}"'
+                )
+            continue  # has @domain -- skip further annotation checks
+
+        # Detect malformed @domain (starts with @domain but regex didn't match).
+        if ctx.startswith("@domain"):
+            warnings.append(
+                f'domain-malformed: "{frm}" has malformed @domain tag: ' f'"{ctx[:40]}"'
+            )
+            continue
+
+        # Other structured annotations: (@seealso ...) and compound: are
+        # acceptable without a @domain/@geo prefix.  Match the actual
+        # (@seealso REF) syntax, not a bare substring.
+        if "(@seealso " in ctx or ctx.startswith("compound:"):
+            continue
+
+        # cross_strait rules must have a structured annotation tag.
+        # Bare prose context without @domain/@geo is flagged so new rules
+        # are required to declare their domain explicitly.
+        warnings.append(
+            f'annotation-missing: "{frm}" has no @domain/@geo tag'
+            + (f' (context: "{ctx[:30]}...")' if ctx.strip() else "")
+        )
+
+    # Duplicate @geo: same to[0] from multiple from values.
+    # OpenCC character variants (裡/里, 羣/群, 託/托) intentionally produce
+    # duplicate from→to mappings so both text forms are caught.  Only flag
+    # true duplicates where the from values are identical or differ by more
+    # than single-character variant swaps.
+    geo_to_map: dict[str, list[str]] = {}
+    for rule in from_set.values():
+        ctx = rule.get("context", "")
+        if not ctx.startswith("@geo"):
+            continue
+        targets = [t for t in rule.get("to", []) if t]
+        if targets:
+            geo_to_map.setdefault(targets[0], []).append(rule["from"])
+    for to_val, froms in geo_to_map.items():
+        if len(froms) <= 1:
+            continue
+        # Check if all pairs differ by only single-char substitutions
+        # (OpenCC variant pairs like 裡/里).  If so, it is intentional.
+        # NOTE: this is a Hamming-distance heuristic, not true OpenCC
+        # normalization.  It tolerates ≤2 char diffs at equal length.
+        # For geographic names this is sufficient — two unrelated countries
+        # with same-length names differing by ≤2 chars is not realistic.
+        is_variant_pair = True
+        for i in range(len(froms)):
+            for j in range(i + 1, len(froms)):
+                a, b = froms[i], froms[j]
+                if len(a) != len(b):
+                    is_variant_pair = False
+                    break
+                diffs = sum(1 for x, y in zip(a, b) if x != y)
+                if diffs > 2:  # allow up to 2 char differences
+                    is_variant_pair = False
+                    break
+            if not is_variant_pair:
+                break
+        if not is_variant_pair:
+            warnings.append(
+                f'geo-duplicate: {froms} all map to "{to_val}" '
+                f"(redundant @geo rules)"
             )
 
     return warnings


### PR DESCRIPTION
This adds new cross_strait rules across IT, geography, UI, finance, medical, education, and daily life domains. Update 5 existing rules with additional to-suggestions.

Annotate all cross_strait rules with structured tags:
- @geo country/city/landmark/university for geographic rules
- @domain LABEL (31 canonical single-label categories)
- Strip redundant cn/tw boilerplate from context fields
- Restore disambiguation notes for ambiguous multi-to rules

Enhance check-ruleset.py with three new lint checks:
- Check 10: self-referencing to (from in own to-array)
- Check 11: @domain/@geo annotation format, label, and coverage
- Geo-duplicate detection with OpenCC variant tolerance
- Malformed @domain/@geo tag detection
- VALID_DOMAINS (31 labels) and VALID_GEO_TYPES constants

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 122 new `cross_strait` rules with structured annotations and tightens the linter to enforce `@domain`/`@geo` format and coverage, catch self-references, and flag duplicate geos with variant tolerance.

- **New Features**
  - Added 122 `cross_strait` rules across IT, geo, UI, finance, education, and daily life; updated some rules with extra suggestions.
  - Annotated all `cross_strait` rules with `@geo` (country/city/landmark/university) or `@domain` (31 labels); restored disambiguation notes; removed redundant cn/tw boilerplate.
  - Linter: self-referencing `to` check; strict anchored validation for `@domain`/`@geo`; malformed-tag detection; require structured tags on all `cross_strait` rules (`@domain`, `@geo`, `(@seealso ...)`, or `compound:`); geo-duplicate detection with variant tolerance; added `VALID_DOMAINS` and `VALID_GEO_TYPES` constants.

<sup>Written for commit 6ca6b0b2477bd505d3985fbf41938d915cb0d774. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

