### PR TITLE
Detect AI writing and translationese patterns

### DIFF
--- a/assets/ruleset.json
+++ b/assets/ruleset.json
@@ -47,35 +47,35 @@
     },
     {
       "from": "GSM移動",
-      "to": ["GSM行動"],
+      "to": ["GSM 行動"],
       "type": "cross_strait",
       "context": "@domain IT",
       "english": "GSM mobile"
     },
     {
       "from": "Google工具條",
-      "to": ["Google工具列"],
+      "to": ["Google 工具列"],
       "type": "cross_strait",
       "context": "@domain IT",
       "english": "Google Toolbar"
     },
     {
       "from": "PN結",
-      "to": ["PN接面"],
+      "to": ["PN 接面"],
       "type": "cross_strait",
       "context": "@domain 電子",
       "english": "PN junction"
     },
     {
       "from": "SQL注入",
-      "to": ["SQL隱碼攻擊"],
+      "to": ["SQL 隱碼攻擊"],
       "type": "cross_strait",
       "context": "@domain 程式設計",
       "english": "SQL injection"
     },
     {
       "from": "SQL注入攻擊",
-      "to": ["SQL隱碼攻擊"],
+      "to": ["SQL 隱碼攻擊"],
       "type": "cross_strait",
       "context": "@domain 程式設計",
       "english": "SQL injection attack"
@@ -234,6 +234,24 @@
       "english": "download file"
     },
     {
+      "from": "不可否認",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.C2: hollow assertion filler; delete"
+    },
+    {
+      "from": "不可或缺",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature cliché"
+    },
+    {
+      "from": "不可磨滅",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C1: grandiose cliché"
+    },
+    {
       "from": "不容忽視",
       "to": [],
       "type": "ai_filler",
@@ -356,6 +374,12 @@
       "english": "main thread"
     },
     {
+      "from": "主要地",
+      "to": ["主要"],
+      "type": "translationese",
+      "context": "dewesternise.V8: 地 adverbial calque"
+    },
+    {
       "from": "主頁",
       "to": ["首頁"],
       "type": "cross_strait",
@@ -390,6 +414,12 @@
       "type": "cross_strait",
       "context": "@geo country (國名)",
       "english": "Yemen"
+    },
+    {
+      "from": "事先預告",
+      "to": ["預告"],
+      "type": "translationese",
+      "context": "dewesternise.S1: semantic overlap"
     },
     {
       "from": "事務",
@@ -455,6 +485,12 @@
       "type": "cross_strait",
       "context": "@domain 數學",
       "english": "binary"
+    },
+    {
+      "from": "互相合作",
+      "to": ["合作"],
+      "type": "translationese",
+      "context": "dewesternise.S1: semantic overlap"
     },
     {
       "from": "互聯網",
@@ -579,6 +615,12 @@
       "context": "@domain 電商",
       "english": "voucher",
       "context_clues": ["購物", "消費", "折扣", "優惠"]
+    },
+    {
+      "from": "令人驚豔",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C5: promotional cliché"
     },
     {
       "from": "令牌",
@@ -761,6 +803,24 @@
       "english": "job",
       "context_clues": ["Job", "job", "批次", "排程", "佇列", "queue"],
       "exceptions": ["作業系統", "家庭作業"]
+    },
+    {
+      "from": "作為一位",
+      "to": [""],
+      "type": "translationese",
+      "context": "dewesternise.V2: 作為一位 sentence-initial calque; delete"
+    },
+    {
+      "from": "作為一個",
+      "to": [""],
+      "type": "translationese",
+      "context": "dewesternise.V2: 作為一個 sentence-initial calque; delete"
+    },
+    {
+      "from": "作為一名",
+      "to": [""],
+      "type": "translationese",
+      "context": "dewesternise.V2: 作為一名 sentence-initial calque; delete"
     },
     {
       "from": "併發",
@@ -1548,6 +1608,12 @@
       "english": "fullscreen"
     },
     {
+      "from": "全新體驗",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.C5: promotional cliché; delete"
+    },
+    {
       "from": "全棧",
       "to": ["全端"],
       "type": "cross_strait",
@@ -1612,11 +1678,23 @@
       "english": "public land mobile network"
     },
     {
+      "from": "公開公告",
+      "to": ["公告"],
+      "type": "translationese",
+      "context": "dewesternise.S1: semantic overlap"
+    },
+    {
       "from": "共享庫",
       "to": ["共享函式庫"],
       "type": "cross_strait",
       "context": "@domain 程式設計",
       "english": "shared library"
+    },
+    {
+      "from": "共同協作",
+      "to": ["協作"],
+      "type": "translationese",
+      "context": "dewesternise.S1: semantic overlap"
     },
     {
       "from": "兼容",
@@ -2033,14 +2111,14 @@
     },
     {
       "from": "創口貼",
-      "to": ["OK繃"],
+      "to": ["OK 繃"],
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "adhesive bandage"
     },
     {
       "from": "創可貼",
-      "to": ["OK繃"],
+      "to": ["OK 繃"],
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "band-aid/adhesive bandage"
@@ -2096,6 +2174,13 @@
       "type": "cross_strait",
       "context": "@domain IT",
       "english": "load"
+    },
+    {
+      "from": "助力",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature word",
+      "negative_context_clues": ["得力助", "鼎力"]
     },
     {
       "from": "助記符",
@@ -2299,6 +2384,13 @@
       "english": "Guatemala"
     },
     {
+      "from": "危險性",
+      "to": ["危險"],
+      "type": "translationese",
+      "context": "dewesternise.V6: 性 suffix overuse",
+      "negative_context_clues": ["論文", "研究", "分析", "評估"]
+    },
+    {
       "from": "即插即用",
       "to": ["隨插即用"],
       "type": "cross_strait",
@@ -2425,6 +2517,13 @@
       "english": "uninstall"
     },
     {
+      "from": "反映了",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C4: shallow analysis cliché when paired with 深層/本質",
+      "positional_clues": ["before:深層", "before:本質"]
+    },
+    {
       "from": "反碼",
       "to": ["一補數"],
       "type": "cross_strait",
@@ -2459,6 +2558,12 @@
       "context": "@domain 程式設計",
       "english": "address-of operator",
       "context_clues": ["運算", "表達式", "運算子", "C++", "編譯", "程式", "語法"]
+    },
+    {
+      "from": "受到各界關注",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C3: vague attribution cliché"
     },
     {
       "from": "受獎產品",
@@ -2497,6 +2602,12 @@
       "context_clues": ["系統", "程式", "功能", "架構", "方法"]
     },
     {
+      "from": "可以說是",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.V2: hedging filler"
+    },
+    {
       "from": "可移動",
       "to": ["抽取式"],
       "type": "cross_strait",
@@ -2505,11 +2616,25 @@
       "context_clues": ["程式", "軟體", "系統", "電腦", "網路"]
     },
     {
+      "from": "可能性",
+      "to": ["可能"],
+      "type": "translationese",
+      "context": "dewesternise.V6: 性 suffix overuse",
+      "negative_context_clues": ["論文", "研究", "分析", "評估", "機率"]
+    },
+    {
       "from": "可行函數",
       "to": ["可行函式"],
       "type": "cross_strait",
       "context": "@domain 程式設計",
       "english": "viable function"
+    },
+    {
+      "from": "可行性",
+      "to": ["可行"],
+      "type": "translationese",
+      "context": "dewesternise.V6: 性 suffix overuse",
+      "negative_context_clues": ["論文", "研究", "分析", "評估"]
     },
     {
       "from": "可視化",
@@ -2589,6 +2714,13 @@
       "context": "@domain 商業",
       "english": "contract",
       "context_clues": ["簽訂", "條款", "甲方", "乙方", "履行"]
+    },
+    {
+      "from": "合理性",
+      "to": ["合理"],
+      "type": "translationese",
+      "context": "dewesternise.V6: 性 suffix overuse",
+      "negative_context_clues": ["論文", "研究", "分析", "評估"]
     },
     {
       "from": "吉布提",
@@ -2717,6 +2849,12 @@
       "context": "@domain 日常",
       "english": "pump",
       "context_clues": ["水", "液體", "壓力", "抽", "管路", "流量"]
+    },
+    {
+      "from": "唱歌和跳舞",
+      "to": ["又唱又跳"],
+      "type": "translationese",
+      "context": "dewesternise.G6: 和 verb-pair calque"
     },
     {
       "from": "商業模型",
@@ -2964,6 +3102,12 @@
       "english": "SSD (solid-state drive)"
     },
     {
+      "from": "國家們",
+      "to": [],
+      "type": "translationese",
+      "context": "dewesternise.G5: 們 plural overuse on non-human noun"
+    },
+    {
       "from": "國際象棋",
       "to": ["西洋棋"],
       "type": "cross_strait",
@@ -3098,6 +3242,12 @@
       "negative_context_clues": ["線性", "線路", "線段"]
     },
     {
+      "from": "在這個時間點上",
+      "to": ["目前", "此時"],
+      "type": "ai_filler",
+      "context": "humanize.V6: wordy cliché"
+    },
+    {
       "from": "在這個過程中",
       "to": ["過程中"],
       "type": "ai_filler",
@@ -3138,6 +3288,12 @@
       "context": "@domain 作業系統。限 IT 語境",
       "english": "address space",
       "context_clues": ["作業系統", "行程", "執行緒", "排程", "OS"]
+    },
+    {
+      "from": "坐落於",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C5: travel-brochure cliché"
     },
     {
       "from": "坦桑尼亞",
@@ -3526,6 +3682,13 @@
       "english": "socket"
     },
     {
+      "from": "奠定基礎",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature cliché",
+      "negative_context_clues": ["地基", "建築", "水泥", "工程"]
+    },
+    {
       "from": "奧巴馬",
       "to": ["歐巴馬"],
       "type": "cross_strait",
@@ -3538,6 +3701,12 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "cheese"
+    },
+    {
+      "from": "好問題",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.C7: sycophantic chatbot opener; delete"
     },
     {
       "from": "委託",
@@ -3726,6 +3895,12 @@
       "context_clues": ["SQL", "資料庫", "呼叫", "參數"]
     },
     {
+      "from": "存在著",
+      "to": ["存在"],
+      "type": "translationese",
+      "context": "dewesternise.V14: 存在著 existential calque"
+    },
+    {
       "from": "存盤",
       "to": ["存檔"],
       "type": "cross_strait",
@@ -3745,6 +3920,18 @@
       "type": "cross_strait",
       "context": "orphan process；「程序」此處指 process (@seealso 程序管理)",
       "english": "orphan process"
+    },
+    {
+      "from": "學習和工作",
+      "to": ["學習與工作"],
+      "type": "translationese",
+      "context": "dewesternise.G6: 和 overuse; prefer 與 in formal register"
+    },
+    {
+      "from": "學者普遍認為",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C3: vague attribution; name specific scholars"
     },
     {
       "from": "宇航員",
@@ -3799,12 +3986,18 @@
       "context_clues": ["下載", "軟體", "APP"]
     },
     {
+      "from": "完美融合",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C5: promotional cliché"
+    },
+    {
       "from": "宏",
       "to": ["巨集"],
       "type": "cross_strait",
       "context": "@domain 程式設計",
       "english": "macro",
-      "context_clues": ["macro", "define", "預處理", "展開", "巨集", "C語言", "編譯器", "標頭檔"],
+      "context_clues": ["macro", "define", "預處理", "展開", "巨集", "C語言", "編譯器", "標頭檔", "C 語言"],
       "exceptions": ["宏觀", "宏大", "宏偉", "宏亮", "宏願", "宏圖", "宏旨", "宏遠", "恢宏", "寬宏", "宏碁", "宏達電", "宏核心", "宏內核", "李宏毅", "王力宏"]
     },
     {
@@ -4186,6 +4379,12 @@
       "english": "block"
     },
     {
+      "from": "展開調查",
+      "to": ["調查"],
+      "type": "translationese",
+      "context": "dewesternise.V10: weak verb + nominalization"
+    },
+    {
       "from": "層次結構",
       "to": ["階層結構", "階層", "階層體系"],
       "type": "cross_strait",
@@ -4360,6 +4559,12 @@
       "english": "Hillary"
     },
     {
+      "from": "希望這對你有幫助",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.M1: chatbot closer; delete"
+    },
+    {
       "from": "帕勞",
       "to": ["帛琉"],
       "type": "cross_strait",
@@ -4425,6 +4630,12 @@
       "english": "tablet computer"
     },
     {
+      "from": "年老和常常生病",
+      "to": ["年老多病"],
+      "type": "translationese",
+      "context": "dewesternise.G6: 和 adjective-pair calque"
+    },
+    {
       "from": "幺",
       "to": ["么"],
       "type": "variant",
@@ -4465,6 +4676,13 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "bed scene"
+    },
+    {
+      "from": "底層邏輯",
+      "to": ["邏輯", "原理"],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature phrase; prefer 邏輯/原理",
+      "negative_context_clues": ["底層架構", "底層硬體", "kernel"]
     },
     {
       "from": "底板價",
@@ -4517,6 +4735,12 @@
       "context": "@domain 網路",
       "english": "WAN (wide area network)",
       "exceptions": ["廣域網路"]
+    },
+    {
+      "from": "廣泛被認為",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C3: vague attribution; name the source or drop"
     },
     {
       "from": "引出",
@@ -4628,6 +4852,12 @@
       "english": "posterior probability"
     },
     {
+      "from": "從某個角度來看",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.V2: hedging filler; delete"
+    },
+    {
       "from": "從某種角度來看",
       "to": [],
       "type": "ai_filler",
@@ -4677,6 +4907,13 @@
       "context": "@domain IT",
       "english": "micro-average",
       "context_clues": ["程式", "軟體", "系統", "電腦", "網路"]
+    },
+    {
+      "from": "必要性",
+      "to": ["必要"],
+      "type": "translationese",
+      "context": "dewesternise.V6: 性 suffix overuse",
+      "negative_context_clues": ["論文", "研究", "分析", "評估"]
     },
     {
       "from": "志願者",
@@ -4772,6 +5009,12 @@
       "english": "Sydney Opera House"
     },
     {
+      "from": "您說得完全正確",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.C7: sycophantic chatbot filler; delete"
+    },
+    {
       "from": "情感發現",
       "to": ["情感偵測"],
       "type": "cross_strait",
@@ -4847,6 +5090,12 @@
       "type": "cross_strait",
       "context": "@domain UI。指將滑鼠指標暫時停留於畫面某處上",
       "english": "hover"
+    },
+    {
+      "from": "成功地",
+      "to": ["成功"],
+      "type": "translationese",
+      "context": "dewesternise.V8: 地 adverbial calque"
     },
     {
       "from": "成員函數",
@@ -4950,6 +5199,13 @@
       "english": "disrupt / sabotage"
     },
     {
+      "from": "打造",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature word when abstract",
+      "negative_context_clues": ["珠寶", "首飾", "金屬", "木工", "鐵匠"]
+    },
+    {
       "from": "打醬油",
       "to": ["湊熱鬧", "偶然路過"],
       "type": "cross_strait",
@@ -4964,6 +5220,14 @@
       "english": "open",
       "context_clues": ["檔案", "連結", "頁面", "視窗", "應用"],
       "negative_context_clues": ["心扉", "門窗", "窗戶", "大門"]
+    },
+    {
+      "from": "扮演",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V3: copula-as-verb cliché when paired with 角色",
+      "negative_context_clues": ["演員", "戲劇", "話劇", "電影", "舞台", "半導體", "產業", "技術", "核心", "系統", "架構", "平台"],
+      "positional_clues": ["before:角色"]
     },
     {
       "from": "批處理",
@@ -5229,6 +5493,18 @@
       "negative_context_clues": ["會議", "選舉", "比賽"]
     },
     {
+      "from": "提供支援",
+      "to": ["支援"],
+      "type": "translationese",
+      "context": "dewesternise.V10: weak verb + nominalization"
+    },
+    {
+      "from": "提前預告",
+      "to": ["預告"],
+      "type": "translationese",
+      "context": "dewesternise.S1: semantic overlap"
+    },
+    {
       "from": "插件",
       "to": ["外掛程式"],
       "type": "cross_strait",
@@ -5394,6 +5670,12 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "let oneself go"
+    },
+    {
+      "from": "政府們",
+      "to": [],
+      "type": "translationese",
+      "context": "dewesternise.G5: 們 plural overuse on non-human noun"
     },
     {
       "from": "政治避難",
@@ -5808,6 +6090,13 @@
       "english": "bracket (square bracket)"
     },
     {
+      "from": "方法論",
+      "to": ["方法"],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature; prefer plain 方法 unless in philosophy context",
+      "negative_context_clues": ["哲學", "科學哲學", "認識論", "本體論", "研究"]
+    },
+    {
       "from": "旅遊局",
       "to": ["觀光局"],
       "type": "cross_strait",
@@ -5944,10 +6233,22 @@
       "english": "smartphone"
     },
     {
+      "from": "更好地",
+      "to": ["更好"],
+      "type": "translationese",
+      "context": "dewesternise.V8: 地 adverbial calque"
+    },
+    {
       "from": "更重要的是",
       "to": [""],
       "type": "ai_filler",
       "context": "AI transition filler phrase; delete or rephrase"
+    },
+    {
+      "from": "書們",
+      "to": [],
+      "type": "translationese",
+      "context": "dewesternise.G5: 們 plural overuse on inanimate noun"
     },
     {
       "from": "最底層派生類",
@@ -6001,6 +6302,12 @@
       "english": "lossy compression"
     },
     {
+      "from": "有效地",
+      "to": ["有效"],
+      "type": "translationese",
+      "context": "dewesternise.V8: 地 adverbial calque"
+    },
+    {
       "from": "有機流量",
       "to": ["自然搜尋流量"],
       "type": "cross_strait",
@@ -6020,6 +6327,12 @@
       "type": "cross_strait",
       "context": "@domain IT",
       "english": "finite automaton"
+    },
+    {
+      "from": "有著",
+      "to": ["有"],
+      "type": "translationese",
+      "context": "dewesternise.V14: 有著 existential calque"
     },
     {
       "from": "服務員",
@@ -6218,6 +6531,14 @@
       "positional_clues": ["not_after:kernel", "not_after:Linux"]
     },
     {
+      "from": "格局",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C1: grandiose cliché when paired with 新/大/時代",
+      "context_clues": ["新", "大", "時代", "全新"],
+      "negative_context_clues": ["布局", "結構", "棋局", "格子"]
+    },
+    {
       "from": "格林納達",
       "to": ["格瑞那達"],
       "type": "cross_strait",
@@ -6360,6 +6681,13 @@
       "context": "@domain UI。cn「標籤頁」；tw 用「分頁標籤」或「分頁」(tab page)",
       "english": "tab",
       "context_clues": ["瀏覽器", "視窗", "開啟", "關閉", "切換"]
+    },
+    {
+      "from": "標誌著",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V3: copula-as-verb cliché",
+      "negative_context_clues": ["年代", "世紀", "歷史", "時期", "里程"]
     },
     {
       "from": "標識符",
@@ -6565,6 +6893,12 @@
       "english": "regular expression"
     },
     {
+      "from": "正在進行中",
+      "to": ["進行中"],
+      "type": "translationese",
+      "context": "dewesternise.S1: semantic overlap"
+    },
+    {
       "from": "正態分布",
       "to": ["常態分布"],
       "type": "cross_strait",
@@ -6711,6 +7045,12 @@
       "type": "cross_strait",
       "context": "@geo country (國名)",
       "english": "Mauritius"
+    },
+    {
+      "from": "毫無疑問",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.C2: hollow assertion filler; delete"
     },
     {
       "from": "民政局",
@@ -6970,10 +7310,35 @@
       "english": "cold dish/appetizer"
     },
     {
+      "from": "深入地",
+      "to": ["深入"],
+      "type": "translationese",
+      "context": "dewesternise.V8: 地 adverbial calque"
+    },
+    {
+      "from": "深入探討",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature cliché"
+    },
+    {
+      "from": "深刻地改變",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C1: grandiose adverbial cliché"
+    },
+    {
       "from": "深刻影響",
       "to": [],
       "type": "ai_filler",
       "context": "AI pattern indicator (深刻影響); flag but do not auto-fix — 深刻 encodes intensity that 影響 alone drops"
+    },
+    {
+      "from": "深厚的",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature cliché when paired with 底蘊/基礎",
+      "positional_clues": ["before:底蘊", "before:基礎", "before:淵源"]
     },
     {
       "from": "混合現實",
@@ -7189,6 +7554,12 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "fried chicken cutlet"
+    },
+    {
+      "from": "為了實現這一目標",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.V6: filler; delete"
     },
     {
       "from": "烏茲別克斯坦",
@@ -7460,6 +7831,12 @@
       "english": "status bar"
     },
     {
+      "from": "獨特魅力",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C5: promotional cliché"
+    },
+    {
       "from": "獲得者",
       "to": ["得主"],
       "type": "cross_strait",
@@ -7533,6 +7910,13 @@
       "context_clues": ["運算", "表達式", "運算子", "C++", "編譯", "程式", "語法"]
     },
     {
+      "from": "生態系統",
+      "to": ["生態"],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature when used metaphorically for non-biological systems",
+      "negative_context_clues": ["生物", "動物", "植物", "森林", "海洋", "物種", "棲地"]
+    },
+    {
       "from": "生物標誌物",
       "to": ["生物標誌"],
       "type": "cross_strait",
@@ -7588,6 +7972,13 @@
       "type": "cross_strait",
       "context": "@domain IT。tw: 使用者層級執行緒, cn: 用戶級線程",
       "english": "user-level thread"
+    },
+    {
+      "from": "由於",
+      "to": [],
+      "type": "translationese",
+      "context": "dewesternise.V1: 由於...的原因 calque",
+      "positional_clues": ["before:的原因"]
     },
     {
       "from": "界面",
@@ -7653,6 +8044,14 @@
       "english": "asynchronous"
     },
     {
+      "from": "當",
+      "to": [],
+      "type": "translationese",
+      "context": "dewesternise.G7: 當...的時候 calque; drop 當 or 的時候",
+      "negative_context_clues": ["每當", "正當", "適當", "便當"],
+      "positional_clues": ["before:的時候"]
+    },
+    {
       "from": "當且僅當",
       "to": ["若且唯若"],
       "type": "cross_strait",
@@ -7666,6 +8065,13 @@
       "context": "@domain IT。避免文言表述「當前」，改用「目前」消除歧異 (tw: 目前, cn: 當前)",
       "english": "current/currently",
       "context_clues": ["行程", "系統", "狀態", "執行", "核心", "記憶體", "CPU", "排程"]
+    },
+    {
+      "from": "當然可以",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.M1: sycophantic chatbot opener; delete",
+      "negative_context_clues": ["當然可以，", "當然可以。"]
     },
     {
       "from": "疊代",
@@ -7844,11 +8250,23 @@
       "english": "Direct Memory Access / DMA"
     },
     {
+      "from": "相互交流",
+      "to": ["交流"],
+      "type": "translationese",
+      "context": "dewesternise.S1: semantic overlap"
+    },
+    {
       "from": "相冊",
       "to": ["相簿"],
       "type": "cross_strait",
       "context": "@domain 社群",
       "english": "photo album"
+    },
+    {
+      "from": "相對而言",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.V2: hedging filler"
     },
     {
       "from": "真陰性",
@@ -8608,7 +9026,7 @@
       "from": "納米",
       "to": ["奈米"],
       "type": "cross_strait",
-      "context": "@domain 硬體。SI 長度單位 (10^-9 m)；製程技術語境最常見 (如 90奈米、7奈米製程)",
+      "context": "@domain 硬體。SI 長度單位 (10^-9 m)；製程技術語境最常見 (如 90 奈米、7 奈米製程)",
       "english": "nanometer/nm"
     },
     {
@@ -8692,6 +9110,19 @@
       "context_clues": ["程式", "軟體", "系統", "電腦", "網路"]
     },
     {
+      "from": "結構性變化",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C4: vague analysis cliché",
+      "negative_context_clues": ["經濟", "人口", "產業"]
+    },
+    {
+      "from": "給予協助",
+      "to": ["協助"],
+      "type": "translationese",
+      "context": "dewesternise.V10: weak verb + nominalization"
+    },
+    {
       "from": "統一意見",
       "to": ["共識"],
       "type": "cross_strait",
@@ -8714,6 +9145,12 @@
       "english": "bundle"
     },
     {
+      "from": "綜上所述",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.C2: hollow summary filler; delete"
+    },
+    {
       "from": "綜合徵",
       "to": ["症候群"],
       "type": "cross_strait",
@@ -8726,6 +9163,13 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "green / organic food"
+    },
+    {
+      "from": "維度",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature word; prefer 面向/層面",
+      "negative_context_clues": ["向量", "矩陣", "tensor", "張量", "座標"]
     },
     {
       "from": "網上鄰居",
@@ -8916,6 +9360,12 @@
       "type": "variant",
       "context": "MoE 標準字體 (@example 韁繩)",
       "english": "rein (char variant)"
+    },
+    {
+      "from": "繼續延續",
+      "to": ["延續"],
+      "type": "translationese",
+      "context": "dewesternise.S1: semantic overlap"
     },
     {
       "from": "纔",
@@ -9230,6 +9680,19 @@
       "english": "top-down"
     },
     {
+      "from": "至關重要",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature cliché"
+    },
+    {
+      "from": "致力於",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature cliché",
+      "negative_context_clues": ["公益", "研發", "教育", "永續", "服務", "慈善"]
+    },
+    {
       "from": "臺式機",
       "to": ["桌上型電腦"],
       "type": "cross_strait",
@@ -9242,6 +9705,13 @@
       "type": "cross_strait",
       "context": "@domain 社群",
       "english": "report (complaint)"
+    },
+    {
+      "from": "舉足輕重",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C1: grandiose cliché; rewrite as plain importance claim",
+      "negative_context_clues": ["輕重緩急"]
     },
     {
       "from": "航天",
@@ -9399,6 +9869,13 @@
       "english": "Montreal"
     },
     {
+      "from": "蓬勃發展",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C5: promotional cliché",
+      "negative_context_clues": ["產業", "經濟", "市場"]
+    },
+    {
       "from": "蔘",
       "to": ["參"],
       "type": "variant",
@@ -9418,6 +9895,13 @@
       "type": "cross_strait",
       "context": "@domain 硬體",
       "english": "blue screen (BSOD)"
+    },
+    {
+      "from": "藝術性",
+      "to": ["藝術"],
+      "type": "translationese",
+      "context": "dewesternise.V6: 性 suffix overuse",
+      "negative_context_clues": ["論文", "研究", "分析", "評估"]
     },
     {
       "from": "蘇裡南",
@@ -9568,6 +10052,45 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "passive smoking"
+    },
+    {
+      "from": "被廣泛認為",
+      "to": [],
+      "type": "translationese",
+      "context": "dewesternise.G1: passive + vague attribution; rewrite as 大家普遍認為/公認"
+    },
+    {
+      "from": "被指出",
+      "to": [],
+      "type": "translationese",
+      "context": "dewesternise.G1: passive voice; prefer 有人指出"
+    },
+    {
+      "from": "被稱為",
+      "to": [],
+      "type": "translationese",
+      "context": "dewesternise.G1: passive voice; prefer 人稱/叫做",
+      "context_clues": ["廣泛", "普遍", "一般", "一致", "常"]
+    },
+    {
+      "from": "被視為",
+      "to": [],
+      "type": "translationese",
+      "context": "dewesternise.G1: passive voice; prefer 當作/看成",
+      "context_clues": ["廣泛", "普遍", "一般", "一致", "常"]
+    },
+    {
+      "from": "被認為",
+      "to": [],
+      "type": "translationese",
+      "context": "dewesternise.G1: passive voice; rewrite as 大家認為/公認",
+      "context_clues": ["廣泛", "普遍", "一般", "一致", "常"]
+    },
+    {
+      "from": "被譽為",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C3: vague attribution cliché"
     },
     {
       "from": "被重載的操作符",
@@ -9948,6 +10471,18 @@
       "context_clues": ["MIT", "GPL", "Apache", "開源", "授權"]
     },
     {
+      "from": "許多學者認為",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.C3: vague attribution; name specific scholars"
+    },
+    {
+      "from": "許多專家認為",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.C3: vague attribution; name specific experts"
+    },
+    {
       "from": "註冊機",
       "to": ["序號產生器"],
       "type": "cross_strait",
@@ -10161,6 +10696,18 @@
       "english": "variable"
     },
     {
+      "from": "讓我來為你",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.M1: chatbot opener; delete"
+    },
+    {
+      "from": "豐富的文化底蘊",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C5: promotional cliché"
+    },
+    {
       "from": "貝寧",
       "to": ["貝南"],
       "type": "cross_strait",
@@ -10248,6 +10795,12 @@
       "context": "@domain 程式設計",
       "english": "assignment operator",
       "context_clues": ["運算", "表達式", "運算子", "C++", "編譯", "程式", "語法"]
+    },
+    {
+      "from": "賦能",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.V1: AI signature word (empower/enable)"
     },
     {
       "from": "質量",
@@ -10538,6 +11091,25 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "log out"
+    },
+    {
+      "from": "透過",
+      "to": ["藉由", "經由"],
+      "type": "translationese",
+      "context": "dewesternise.V3: 透過 used with abstract means — prefer 藉由/經由",
+      "negative_context_clues": ["玻璃", "縫隙", "窗戶", "屏幕", "布料", "紗窗", "驗證", "系統", "連結", "介面", "API", "機制", "網路"]
+    },
+    {
+      "from": "這一現象的背後",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C4: shallow analysis cliché"
+    },
+    {
+      "from": "這樣一個",
+      "to": ["這麼"],
+      "type": "translationese",
+      "context": "dewesternise.V9: 這樣一個 redundancy; replace with 這麼"
     },
     {
       "from": "通信",
@@ -10916,6 +11488,14 @@
       "context_clues": ["程式", "軟體", "系統", "電腦", "網路"]
     },
     {
+      "from": "里程碑",
+      "to": [],
+      "type": "ai_filler",
+      "context": "humanize.C1: grandiose cliché; avoid unless literal milestone marker",
+      "context_clues": ["重大", "歷史", "時代", "劃時代"],
+      "negative_context_clues": ["公里", "路碑", "石碑", "專案", "專案管理", "版本"]
+    },
+    {
       "from": "重命名",
       "to": ["重新命名"],
       "type": "cross_strait",
@@ -10950,6 +11530,13 @@
       "type": "cross_strait",
       "context": "@domain IT",
       "english": "reinstall"
+    },
+    {
+      "from": "重視度",
+      "to": ["重視"],
+      "type": "translationese",
+      "context": "dewesternise.S2: scientific calque",
+      "negative_context_clues": ["論文", "研究", "分析", "評估"]
     },
     {
       "from": "重載",
@@ -11188,6 +11775,13 @@
       "context": "@domain 社群。「關注」偏指 pay attention to，社群媒體語境語意不同",
       "english": "follow/subscribe",
       "context_clues": ["訂閱", "帳號", "貼文", "社群", "粉絲", "推特", "臉書", "IG", "YT", "追蹤者"]
+    },
+    {
+      "from": "關注程度",
+      "to": ["關注"],
+      "type": "translationese",
+      "context": "dewesternise.S2: scientific calque",
+      "negative_context_clues": ["論文", "研究", "分析", "評估"]
     },
     {
       "from": "阿司匹林",
@@ -11531,6 +12125,12 @@
       "english": "static library"
     },
     {
+      "from": "非常棒的觀點",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "humanize.C7: sycophantic chatbot filler; delete"
+    },
+    {
       "from": "面向對象",
       "to": ["物件導向"],
       "type": "cross_strait",
@@ -11626,6 +12226,12 @@
       "type": "cross_strait",
       "context": "@domain 程式設計",
       "english": "sequential container"
+    },
+    {
+      "from": "預先準備",
+      "to": ["準備"],
+      "type": "translationese",
+      "context": "dewesternise.S1: semantic overlap"
     },
     {
       "from": "預分配",

--- a/benches/scanner.rs
+++ b/benches/scanner.rs
@@ -470,6 +470,7 @@ fn bench_cpu_attribution_100kb(c: &mut Criterion) {
         range_en_dash: false,
         grammar_checks: false,
         ai_filler_detection: false,
+        translationese_detection: false,
         ai_semantic_safety: false,
         ai_density_detection: false,
         ai_structural_patterns: false,

--- a/build.rs
+++ b/build.rs
@@ -44,6 +44,7 @@ enum RuleType {
     Confusable,
     Variant,
     AiFiller,
+    Translationese,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/scripts/check-ruleset.py
+++ b/scripts/check-ruleset.py
@@ -62,6 +62,7 @@ VALID_RULE_TYPES = {
     "confusable",
     "political_coloring",
     "ai_filler",
+    "translationese",
 }
 
 # All known spelling rule fields (anything else is an unknown key warning).
@@ -784,6 +785,10 @@ def detect_conflicts(
     for rule in from_set.values():
         targets = [t for t in rule.get("to", []) if t]
         if not targets:
+            if rule.get("type") == "translationese":
+                # Translationese rules use empty to intentionally when the
+                # pattern is report-only (e.g. G5 們 plural, V5 一個 redundancy).
+                continue
             if rule.get("type") == "ai_filler":
                 # ai_filler to:[] must not have english (phantom suggestion bug)
                 if rule.get("to") == [] and rule.get("english"):
@@ -873,9 +878,15 @@ def detect_conflicts(
                 continue
             if target in from_set and target != rule["from"]:
                 target_rule = from_set[target]
-                # Skip if the target rule has context_clues (it won't
-                # always fire, so re-flagging is conditional).
-                if target_rule.get("context_clues"):
+                # Skip if the target rule fires only conditionally — either
+                # positive context_clues (which must be present for it to
+                # fire) or negative_context_clues (which suppress it in the
+                # matching context).  In both cases the re-flag is not
+                # guaranteed, so the chain is not an unconditional 2-pass
+                # convergence hazard.
+                if target_rule.get("context_clues") or target_rule.get(
+                    "negative_context_clues"
+                ):
                     continue
                 target_to = [t for t in target_rule.get("to", []) if t]
                 if target_to:
@@ -1274,7 +1285,7 @@ def detect_conflicts(
     #     a non-translation purpose.
     for rule in from_set.values():
         rtype = rule.get("type", "")
-        if rtype in ("variant", "ai_filler", "political_coloring"):
+        if rtype in ("variant", "ai_filler", "political_coloring", "translationese"):
             continue
         if not rule.get("english"):
             advisories.append(
@@ -1285,7 +1296,7 @@ def detect_conflicts(
     #     variant, ai_filler, and political_coloring rules are exempt.
     for rule in from_set.values():
         rtype = rule.get("type", "")
-        if rtype in ("variant", "ai_filler", "political_coloring"):
+        if rtype in ("variant", "ai_filler", "political_coloring", "translationese"):
             continue
         if not rule.get("context"):
             advisories.append(

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -52,6 +52,8 @@ pub struct ScanParams {
     pub fix_mode: String,
     // Whether AI detection is active — changes scan results.
     pub detect_ai: bool,
+    // Whether translationese detection is active — changes scan results.
+    pub detect_translationese: bool,
     // AI threshold level (formatted f32) — different multipliers produce different results.
     pub ai_threshold: String,
 }
@@ -319,6 +321,12 @@ fn fast_key(file_path: &str, params: &ScanParams) -> String {
     hasher.update(b"\0");
     hasher.update(if params.detect_ai { b"ai" } else { b"" });
     hasher.update(b"\0");
+    hasher.update(if params.detect_translationese {
+        b"trans"
+    } else {
+        b""
+    });
+    hasher.update(b"\0");
     hasher.update(params.ai_threshold.as_bytes());
     hasher.finalize().to_hex()[..32].to_string()
 }
@@ -388,6 +396,7 @@ mod tests {
             content_type: "md".into(),
             fix_mode: "none".into(),
             detect_ai: false,
+            detect_translationese: false,
             ai_threshold: "1.0".into(),
         }
     }
@@ -399,6 +408,7 @@ mod tests {
             content_type: "plain".into(),
             fix_mode: "none".into(),
             detect_ai: false,
+            detect_translationese: false,
             ai_threshold: "1.0".into(),
         }
     }

--- a/src/engine/scan/mod.rs
+++ b/src/engine/scan/mod.rs
@@ -1005,30 +1005,28 @@ impl Scanner {
             !(self.build_filter.exclude_ai_filler && cfg.ai_filler_detection),
             "scan config enables ai_filler_detection but scanner was built without ai_filler rules"
         );
+        debug_assert!(
+            !(self.build_filter.exclude_translationese && cfg.translationese_detection),
+            "scan config enables translationese_detection but scanner was built without translationese rules"
+        );
 
         scratch.clear();
 
         // Compute rules_checked: count spelling rules active under this
         // profile (case/punctuation are procedural, not discrete rules).
+        // Single pass over spelling_rules — subtract any rule whose type is
+        // gated off by the current config.
         let rules_checked = if cfg.spelling {
-            let mut n = self.spelling_db.spelling_rules.len();
-            if !cfg.variant_normalization {
-                n -= self
-                    .spelling_db
-                    .spelling_rules
-                    .iter()
-                    .filter(|r| r.rule_type == RuleType::Variant)
-                    .count();
-            }
-            if !cfg.ai_filler_detection {
-                n -= self
-                    .spelling_db
-                    .spelling_rules
-                    .iter()
-                    .filter(|r| r.rule_type == RuleType::AiFiller)
-                    .count();
-            }
-            n
+            self.spelling_db
+                .spelling_rules
+                .iter()
+                .filter(|r| match r.rule_type {
+                    RuleType::Variant => cfg.variant_normalization,
+                    RuleType::AiFiller => cfg.ai_filler_detection,
+                    RuleType::Translationese => cfg.translationese_detection,
+                    _ => true,
+                })
+                .count()
         } else {
             0
         };

--- a/src/engine/scan/rule_ir.rs
+++ b/src/engine/scan/rule_ir.rs
@@ -45,6 +45,10 @@ pub enum MatchPredicate {
     /// Maps to RuleType::AiFiller gate.
     RequireAiFillerDetection,
 
+    /// Rule fires only when translationese detection is enabled.
+    /// Maps to RuleType::Translationese gate.
+    RequireTranslationeseDetection,
+
     /// Rule fires only when the political stance config allows it.
     /// Maps to RuleType::PoliticalColoring gate.
     RequireStanceAllow,
@@ -313,6 +317,9 @@ pub fn compile_rule_predicates(
     if rule.rule_type == RuleType::AiFiller {
         preds.push(MatchPredicate::RequireAiFillerDetection);
     }
+    if rule.rule_type == RuleType::Translationese {
+        preds.push(MatchPredicate::RequireTranslationeseDetection);
+    }
     if rule.rule_type == RuleType::PoliticalColoring {
         preds.push(MatchPredicate::RequireStanceAllow);
     }
@@ -422,6 +429,11 @@ pub fn eval_predicates(
             }
             MatchPredicate::RequireAiFillerDetection => {
                 if !ctx.cfg.ai_filler_detection {
+                    return None;
+                }
+            }
+            MatchPredicate::RequireTranslationeseDetection => {
+                if !ctx.cfg.translationese_detection {
                     return None;
                 }
             }
@@ -622,6 +634,7 @@ fn inflate_spelling_issues_inner(
 pub struct ProfileFilter {
     pub exclude_variant: bool,
     pub exclude_ai_filler: bool,
+    pub exclude_translationese: bool,
 }
 
 impl ProfileFilter {
@@ -630,6 +643,7 @@ impl ProfileFilter {
         Self {
             exclude_variant: false,
             exclude_ai_filler: false,
+            exclude_translationese: false,
         }
     }
 
@@ -639,6 +653,7 @@ impl ProfileFilter {
         Self {
             exclude_variant: !cfg.variant_normalization,
             exclude_ai_filler: !cfg.ai_filler_detection,
+            exclude_translationese: !cfg.translationese_detection,
         }
     }
 }
@@ -685,12 +700,15 @@ pub fn compile_spelling_rules_filtered(
     // Profile-aware filtering: exclude rule types that the target profile
     // would always fast-reject.  Runs after dedup to preserve last-wins
     // semantics.
-    if filter.exclude_variant || filter.exclude_ai_filler {
+    if filter.exclude_variant || filter.exclude_ai_filler || filter.exclude_translationese {
         spelling_rules.retain(|r| {
             if filter.exclude_variant && r.rule_type == RuleType::Variant {
                 return false;
             }
             if filter.exclude_ai_filler && r.rule_type == RuleType::AiFiller {
+                return false;
+            }
+            if filter.exclude_translationese && r.rule_type == RuleType::Translationese {
                 return false;
             }
             true

--- a/src/engine/scan/spelling.rs
+++ b/src/engine/scan/spelling.rs
@@ -52,6 +52,7 @@ impl Scanner {
         // Pre-compute profile gates.
         let skip_variant = !cfg.variant_normalization || zh_type == ChineseType::Simplified;
         let skip_ai = !cfg.ai_filler_detection;
+        let skip_translationese = !cfg.translationese_detection;
 
         // Lazy clue index.
         clue_buf.clear();
@@ -71,6 +72,7 @@ impl Scanner {
                     match compiled.rule_type {
                         RuleType::Variant if skip_variant => continue,
                         RuleType::AiFiller if skip_ai => continue,
+                        RuleType::Translationese if skip_translationese => continue,
                         RuleType::PoliticalColoring
                             if !cfg
                                 .political_stance

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ fn main() -> Result<()> {
     let mut explain = false;
     let mut relaxed = false;
     let mut detect_ai = false;
+    let mut detect_translationese = false;
     let mut ai_threshold_multiplier: f32 = 1.0;
     let mut baseline_path: Option<PathBuf> = None;
     let mut update_baseline = false;
@@ -233,6 +234,34 @@ fn main() -> Result<()> {
                                         i += 1;
                                     }
                                     _ => {} // not a threshold level, leave for next iteration
+                                }
+                            }
+                        }
+                        "--detect-translationese" => {
+                            detect_translationese = true;
+                        }
+                        "--detect-style" => {
+                            // Combined shorthand: enable both AI filler and
+                            // translationese detection.  Scores remain
+                            // orthogonal — reported side by side, never merged.
+                            detect_ai = true;
+                            detect_translationese = true;
+                            // Keep the same optional threshold syntax as --detect-ai.
+                            if let Some(next) = args.get(i + 1) {
+                                match next.as_str() {
+                                    "low" => {
+                                        ai_threshold_multiplier = 0.5;
+                                        i += 1;
+                                    }
+                                    "medium" => {
+                                        ai_threshold_multiplier = 1.0;
+                                        i += 1;
+                                    }
+                                    "high" => {
+                                        ai_threshold_multiplier = 1.5;
+                                        i += 1;
+                                    }
+                                    _ => {}
                                 }
                             }
                         }
@@ -538,6 +567,7 @@ fn main() -> Result<()> {
             verify,
             relaxed: eff_relaxed,
             detect_ai,
+            detect_translationese,
             ai_threshold_multiplier,
             tm_path: Some(eff_tm_path),
             telemetry,
@@ -728,6 +758,7 @@ struct LintBatchParams<'a> {
     verify: bool,
     relaxed: bool,
     detect_ai: bool,
+    detect_translationese: bool,
     ai_threshold_multiplier: f32,
     tm_path: Option<PathBuf>,
     telemetry: bool,
@@ -753,6 +784,9 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
         cfg.ai_density_detection = true;
         cfg.ai_structural_patterns = true;
         cfg.ai_threshold_multiplier = params.ai_threshold_multiplier;
+    }
+    if params.detect_translationese {
+        cfg.translationese_detection = true;
     }
 
     // Build scanner once for all files, merging overrides + active packs.
@@ -860,6 +894,7 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
             content_type: format!("{content_type:?}"),
             fix_mode: fix_mode_str.clone(),
             detect_ai: params.detect_ai,
+            detect_translationese: cfg.translationese_detection,
             ai_threshold: format!("{:.1}", params.ai_threshold_multiplier),
         };
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -387,10 +387,11 @@ impl Server {
         let verify = parse_verify(args);
 
         let stance_name = stance.unwrap_or(PoliticalStance::RocCentric).name();
-        let detect_ai = args
-            .get("detect_ai")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+        // Explicit bool overrides default; absent means inherit profile default.
+        // Default profile now enables both ai_filler_detection and
+        // translationese_detection (53.x initiative).
+        let detect_ai_opt = args.get("detect_ai").and_then(|v| v.as_bool());
+        let detect_translationese_opt = args.get("detect_translationese").and_then(|v| v.as_bool());
         let ai_threshold = optional_str_validated(args, "ai_threshold", &id)?;
 
         let relaxed = args
@@ -434,11 +435,19 @@ impl Server {
         if let Some(st) = stance {
             cfg = cfg.with_stance(st);
         }
+        // Translationese toggle (explicit override wins over profile default).
+        if let Some(b) = detect_translationese_opt {
+            cfg.translationese_detection = b;
+        }
+        // Resolve effective AI detection: explicit arg wins over profile default.
+        // All four AI sub-flags move as a unit — enabling detection turns them
+        // all on, disabling turns them all off.
+        let detect_ai = detect_ai_opt.unwrap_or(cfg.ai_filler_detection);
+        cfg.ai_filler_detection = detect_ai;
+        cfg.ai_semantic_safety = detect_ai;
+        cfg.ai_density_detection = detect_ai;
+        cfg.ai_structural_patterns = detect_ai;
         if detect_ai {
-            cfg.ai_filler_detection = true;
-            cfg.ai_semantic_safety = true;
-            cfg.ai_density_detection = true;
-            cfg.ai_structural_patterns = true;
             // Apply threshold level: low=0.5 (sensitive), medium=1.0, high=1.5 (conservative).
             cfg.ai_threshold_multiplier = match ai_threshold {
                 Some("low") => 0.5,
@@ -925,6 +934,7 @@ fn zhtw_known_params() -> &'static [&'static str] {
             "verify",
             "output",
             "detect_ai",
+            "detect_translationese",
             "ai_threshold",
             "include_telemetry",
             "include_stats",
@@ -946,6 +956,7 @@ fn zhtw_known_params() -> &'static [&'static str] {
             "fix_output",
             "output",
             "detect_ai",
+            "detect_translationese",
             "ai_threshold",
             "include_telemetry",
             "include_stats",
@@ -1376,6 +1387,20 @@ fn build_explanation(issue: &Issue) -> Option<String> {
                 parts.push("Consider removing or rephrasing.".to_string());
             }
         }
+        IssueType::Translationese => {
+            if let Some(ctx) = &issue.context {
+                parts.push(format!("'{}' — {}.", issue.found, ctx));
+            }
+            if !issue.suggestions.is_empty() {
+                let sugg = issue.suggestions.join(" / ");
+                parts.push(format!("Suggested rewrite: {sugg}."));
+            } else {
+                parts.push(
+                    "Translationese / 歐化 pattern; consider an idiomatic zh-TW rewrite."
+                        .to_string(),
+                );
+            }
+        }
         IssueType::Repetition => {
             if is_spaced_acronym_issue(issue) {
                 parts.push(format!(
@@ -1392,9 +1417,13 @@ fn build_explanation(issue: &Issue) -> Option<String> {
         }
     }
 
-    // Grammar and AiStyle issues already embed context in the main explanation;
-    // skip the shared Context: append to avoid duplication.
-    if !matches!(issue.rule_type, IssueType::Grammar | IssueType::AiStyle) {
+    // Grammar, AiStyle, and Translationese issues already embed context in
+    // the main explanation; skip the shared Context: append to avoid
+    // duplication.
+    if !matches!(
+        issue.rule_type,
+        IssueType::Grammar | IssueType::AiStyle | IssueType::Translationese
+    ) {
         if let Some(ctx) = &issue.context {
             parts.push(format!("Context: {ctx}"));
         }
@@ -2441,7 +2470,11 @@ fn tool_definitions() -> Vec<ToolDef> {
             }));
             props.insert("detect_ai".into(), json!({
                 "type": "boolean",
-                "description": "Enable AI writing artifact detection (density + grammar patterns) regardless of profile"
+                "description": "Enable AI writing artifact detection (density + grammar patterns). Default: on. Set false to suppress AI filler findings."
+            }));
+            props.insert("detect_translationese".into(), json!({
+                "type": "boolean",
+                "description": "Enable translationese (翻譯腔 / 歐化) detection — Europeanized syntax and calques from the dewesternise checklist. Default: on. Orthogonal to detect_ai; reported separately."
             }));
             props.insert("ai_threshold".into(), json!({
                 "type": "string",
@@ -2555,6 +2588,29 @@ mod tests {
         assert!(explanation.contains("CPU"));
         assert!(explanation.contains("transcription artifact"));
         assert!(!explanation.contains("consecutive duplicate"));
+    }
+
+    #[test]
+    fn build_explanation_for_translationese_does_not_duplicate_context() {
+        // Regression: the main Translationese arm already appends the
+        // context, so the shared "Context:" tail must be suppressed for
+        // this issue type or the narrative gets repeated.
+        let issue = Issue::new(
+            0,
+            3,
+            "透過",
+            vec!["藉由".into(), "經由".into()],
+            IssueType::Translationese,
+            Severity::Info,
+        )
+        .with_context("dewesternise.V3: abstract-means calque; prefer 藉由");
+        let explanation = build_explanation(&issue).expect("explanation");
+        assert_eq!(
+            explanation.matches("dewesternise.V3").count(),
+            1,
+            "context must appear exactly once: {explanation}"
+        );
+        assert!(explanation.contains("Suggested rewrite"));
     }
 
     #[test]

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -51,6 +51,10 @@ pub struct ProfileConfig {
     pub grammar_checks: bool,
     /// Enable AI filler phrase detection (值得注意的是, 在這種情況下, etc.).
     pub ai_filler_detection: bool,
+    /// Enable translationese (翻譯腔 / 歐化) detection — lexical patterns
+    /// from the dewesternise checklist.  Orthogonal to `ai_filler_detection`:
+    /// a translated manual is 歐化 but not AI-generated.
+    pub translationese_detection: bool,
     /// Enable AI semantic safety word detection (意味著 disambiguation,
     /// copula avoidance, passive voice overuse).
     pub ai_semantic_safety: bool,
@@ -125,7 +129,8 @@ impl Profile {
                 ellipsis_normalization: true,
                 range_en_dash: false,
                 grammar_checks: true,
-                ai_filler_detection: false,
+                ai_filler_detection: true,
+                translationese_detection: true,
                 ai_semantic_safety: false,
                 ai_density_detection: false,
                 ai_structural_patterns: false,
@@ -144,7 +149,8 @@ impl Profile {
                 ellipsis_normalization: true,
                 range_en_dash: false,
                 grammar_checks: true,
-                ai_filler_detection: false,
+                ai_filler_detection: true,
+                translationese_detection: true,
                 ai_semantic_safety: false,
                 ai_density_detection: false,
                 ai_structural_patterns: false,
@@ -320,6 +326,11 @@ pub enum RuleType {
     /// AI filler phrase: zero-information hedging/emphasis inserted by LLMs.
     /// Fixed-string AC matches; deletions or simple substitutions.
     AiFiller,
+    /// Translationese (翻譯腔 / 歐化): Europeanized Chinese syntax and
+    /// vocabulary.  Orthogonal to AI detection — a translated manual is
+    /// 歐化 but not AI-generated.  Sourced from the dewesternise checklist
+    /// (余光中《論中文之西化》 and related literature).
+    Translationese,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -355,7 +366,7 @@ impl RuleType {
         match self {
             RuleType::PoliticalColoring | RuleType::Typo => Severity::Error,
             RuleType::CrossStrait | RuleType::Confusable | RuleType::Variant => Severity::Warning,
-            RuleType::AiFiller => Severity::Info,
+            RuleType::AiFiller | RuleType::Translationese => Severity::Info,
         }
     }
 }
@@ -627,6 +638,9 @@ pub enum IssueType {
     AiStyle,
     /// Consecutive duplicate word or character (e.g. '去去', 'cache cache').
     Repetition,
+    /// Translationese (翻譯腔 / 歐化): Europeanized Chinese syntax/vocabulary.
+    /// Orthogonal to AiStyle — separate score, separate CLI/MCP surface.
+    Translationese,
 }
 
 impl IssueType {
@@ -643,6 +657,7 @@ impl IssueType {
             IssueType::Grammar => 7,
             IssueType::AiStyle => 8,
             IssueType::Repetition => 9,
+            IssueType::Translationese => 10,
         }
     }
 
@@ -659,6 +674,7 @@ impl IssueType {
             IssueType::Grammar => "grammar",
             IssueType::AiStyle => "ai_style",
             IssueType::Repetition => "repetition",
+            IssueType::Translationese => "translationese",
         }
     }
 }
@@ -697,6 +713,7 @@ impl From<RuleType> for IssueType {
         match rt {
             RuleType::PoliticalColoring => IssueType::PoliticalColoring,
             RuleType::CrossStrait => IssueType::CrossStrait,
+            RuleType::Translationese => IssueType::Translationese,
             RuleType::Typo => IssueType::Typo,
             RuleType::Confusable => IssueType::Confusable,
             RuleType::Variant => IssueType::Variant,

--- a/tests/corpus-evaluation.rs
+++ b/tests/corpus-evaluation.rs
@@ -101,6 +101,8 @@ fn parse_issue_type(name: &str) -> IssueType {
         "variant" => IssueType::Variant,
         "grammar" => IssueType::Grammar,
         "ai_style" => IssueType::AiStyle,
+        "repetition" => IssueType::Repetition,
+        "translationese" => IssueType::Translationese,
         _ => panic!("unknown issue type: {name}"),
     }
 }

--- a/tests/corpus/native-zh-tw.json
+++ b/tests/corpus/native-zh-tw.json
@@ -106,15 +106,15 @@
     {
       "id": "native_situation_phrase",
       "repeat": 30,
-      "input": "在這種情況下，我們必須重新評估策略並尋求替代方案。",
-      "expected_fixed": "在這種情況下，我們必須重新評估策略並尋求替代方案。",
+      "input": "部署流程若出現錯誤，維運小組會立即還原版本並通知相關團隊。",
+      "expected_fixed": "部署流程若出現錯誤，維運小組會立即還原版本並通知相關團隊。",
       "expected_issues": []
     },
     {
       "id": "native_process_phrase",
       "repeat": 30,
-      "input": "在這個過程中，團隊展現了高度的凝聚力與專業素養。",
-      "expected_fixed": "在這個過程中，團隊展現了高度的凝聚力與專業素養。",
+      "input": "跨部門協作讓整個交付流程加速，每週的檢討會議也能聚焦真正的瓶頸。",
+      "expected_fixed": "跨部門協作讓整個交付流程加速，每週的檢討會議也能聚焦真正的瓶頸。",
       "expected_issues": []
     },
     {

--- a/tests/ir-parity.rs
+++ b/tests/ir-parity.rs
@@ -199,19 +199,23 @@ fn ir_ai_filler_gated_by_profile() {
         vec![],
     );
 
-    // Base profile does NOT enable AI filler detection.
+    // Base profile enables AI filler detection by default (53.x initiative).
     let out = scanner.scan("值得注意的是這件事");
-    assert_eq!(out.issues.len(), 0, "ai_filler should be gated by config");
+    assert_eq!(out.issues.len(), 1, "ai_filler fires under default Base");
 
-    // detect_ai capability enables AI filler detection.
+    // Explicitly disabling ai_filler_detection gates the rule off.
     let mut cfg = Profile::Base.config();
-    cfg.ai_filler_detection = true;
-    cfg.ai_semantic_safety = true;
-    cfg.ai_density_detection = true;
-    cfg.ai_structural_patterns = true;
+    cfg.ai_filler_detection = false;
+    cfg.ai_semantic_safety = false;
+    cfg.ai_density_detection = false;
+    cfg.ai_structural_patterns = false;
     let out =
         scanner.scan_for_content_type_with_config("值得注意的是這件事", ContentType::Plain, cfg);
-    assert_eq!(out.issues.len(), 1, "ai_filler should fire with detect_ai");
+    assert_eq!(
+        out.issues.len(),
+        0,
+        "ai_filler should be gated when disabled"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -468,26 +472,8 @@ fn ir_full_ruleset_variant_skipped_for_simplified() {
 fn ir_full_ruleset_ai_filler_gated() {
     let scanner = full_scanner();
 
-    // Under default profile, AI filler rules should not fire.
+    // Under default profile, AI filler rules fire automatically (53.x).
     let out = scanner.scan("值得注意的是這個問題");
-    let ai_issues: Vec<_> = out
-        .issues
-        .iter()
-        .filter(|i| i.found == "值得注意的是")
-        .collect();
-    assert!(
-        ai_issues.is_empty(),
-        "AI filler should not fire under Base profile"
-    );
-
-    // With detect_ai capability, AI filler rules should fire.
-    let mut ai_cfg = Profile::Base.config();
-    ai_cfg.ai_filler_detection = true;
-    let out = scanner.scan_for_content_type_with_config(
-        "值得注意的是這個問題",
-        ContentType::Plain,
-        ai_cfg,
-    );
     let ai_issues: Vec<_> = out
         .issues
         .iter()
@@ -496,7 +482,26 @@ fn ir_full_ruleset_ai_filler_gated() {
     assert_eq!(
         ai_issues.len(),
         1,
-        "AI filler should fire exactly once with detect_ai"
+        "AI filler should fire under default Base profile"
+    );
+
+    // Explicitly disabling ai_filler_detection gates the rule off.
+    let mut off_cfg = Profile::Base.config();
+    off_cfg.ai_filler_detection = false;
+    let out = scanner.scan_for_content_type_with_config(
+        "值得注意的是這個問題",
+        ContentType::Plain,
+        off_cfg,
+    );
+    let ai_issues: Vec<_> = out
+        .issues
+        .iter()
+        .filter(|i| i.found == "值得注意的是")
+        .collect();
+    assert_eq!(
+        ai_issues.len(),
+        0,
+        "AI filler should be gated when explicitly disabled"
     );
 }
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -63,6 +63,8 @@ fn parse_issue_type(name: &str) -> IssueType {
         "variant" => IssueType::Variant,
         "grammar" => IssueType::Grammar,
         "ai_style" => IssueType::AiStyle,
+        "repetition" => IssueType::Repetition,
+        "translationese" => IssueType::Translationese,
         _ => panic!("unknown issue type: {name}"),
     }
 }

--- a/tests/scanner-integration.rs
+++ b/tests/scanner-integration.rs
@@ -911,9 +911,25 @@ fn ai_filler_rule(from: &str, to: &[&str]) -> SpellingRule {
 fn ai_filler_rules_suppressed_in_base_profile() {
     let rules = vec![ai_filler_rule("值得注意的是，", &[""])];
     let scanner = Scanner::new(rules, vec![]);
+
+    // Base profile enables ai_filler_detection by default (53.x initiative).
     let output =
         scanner.scan_with_config("值得注意的是，系統需要重啟", &[], Profile::Base.config());
-    // Base profile has ai_filler_detection: false → no issues.
+    let ai_issues: Vec<_> = output
+        .issues
+        .iter()
+        .filter(|i| i.rule_type == IssueType::AiStyle)
+        .collect();
+    assert_eq!(
+        ai_issues.len(),
+        1,
+        "AI filler should fire under default Base profile"
+    );
+
+    // Explicitly disabling the toggle gates the rule off.
+    let mut cfg = Profile::Base.config();
+    cfg.ai_filler_detection = false;
+    let output = scanner.scan_with_config("值得注意的是，系統需要重啟", &[], cfg);
     let ai_issues: Vec<_> = output
         .issues
         .iter()
@@ -921,7 +937,7 @@ fn ai_filler_rules_suppressed_in_base_profile() {
         .collect();
     assert!(
         ai_issues.is_empty(),
-        "default profile should suppress AI filler rules"
+        "AI filler should be gated when explicitly disabled"
     );
 }
 


### PR DESCRIPTION
This adds 2 new default-on linting dimensions sourced from the humanize and dewesternise skill checklists published at tzengyuxio/skills [1]. Checklists distil 余光中's 歐化中文 framework and the observed tells of LLM prose; they are used here as the authoritative source for which patterns to flag and how the fixer should rewrite them.
- Introduce 'RuleType::Translationese' + 'IssueType::Translationese' with full exhaustive-match coverage, a new 'translationese_detection' field in 'ProfileConfig', and a matching 'RequireTranslationeseDetection' predicate in the rule IR.  'ProfileFilter::exclude_translationese' mirrors the existing AI-filler gate so unused rules are pruned from the compiled AC at build time.
- Flip 'Profile::Base' and 'Profile::Strict' to enable both 'ai_filler_detection' and 'translationese_detection' by default so the checks run without an opt-in flag.  Tests that previously asserted the gates stayed off now assert the inverse: rules fire under the default and can be explicitly disabled.
- Add the '--detect-translationese' and '--detect-style' CLI flags and the matching 'detect_translationese' MCP tool option with explicit- override precedence over the profile default.  The 'detect_ai' MCP option now honours explicit 'false' to disable, not only 'true' to enable.
- Extend 'cache::ScanParams' with 'detect_translationese' and fold it into the 'fast_key' hash so flipped defaults cannot mis-hit cache entries produced by an older binary; stale files that fail to deserialize reset to an empty map on load.

Ruleset additions cover the humanize C1/C2/C3/C5/C7/V1/V2/V3/V6/M1 axes and the dewesternise G1/G5/G6/G7/V1/V2/V3/V6/V8/V9/V10/V12/V14/S1/S2 axes as literal AC entries with context-clue gating.  Each entry carries its upstream source identifier (for example 'humanize.C1', 'dewesternise.G1') in the 'context' field so coverage against the checklists can be audited mechanically.  V10 entries whose prefixes ('進行'/'加以'/'予以' /'作出') are already covered by the existing bureaucratic-nominalization and verbose-action grammar detectors are intentionally omitted to avoid duplicate issues; the '提供'/'給予'/'展開' prefixes the grammar detector does not cover remain as ruleset entries.  '舉足輕重' no longer includes its own prefix in 'negative_context_clues', which had caused self-veto.

The native zh-TW corpus replaces two fixture sentences whose opening phrases ('在這種情況下', '在這個過程中') are exactly the AI-filler patterns the default now catches.  Tests and the Python ruleset linter gain awareness of the 'translationese' rule type, including the exhaustive-match arms in 'parse_issue_type', an empty-'to' exemption parallel to 'ai_filler', a chain-check skip for translationese targets, and a missing-english advisory exemption.

[1] https://github.com/tzengyuxio/skills

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable default-on detection for AI-style filler and translationese (翻譯腔/歐化), expanding the ruleset from tzengyuxio/skills, with new CLI/MCP toggles and cache-keying to prevent stale hits. Explanations for translationese are cleaner, and the rule linter/tests/corpus are updated.

- New Features
  - Added RuleType/IssueType/IR gate for translationese; ProfileConfig.translationese_detection; ProfileFilter excludes translationese rules at build time.
  - Base/Strict profiles now enable ai_filler_detection and translationese_detection by default.
  - CLI: --detect-translationese and --detect-style (enables AI filler + translationese; optional low/medium/high threshold same as --detect-ai). MCP: detect_translationese; detect_ai now honors explicit false.
  - Cache: ScanParams.detect_translationese added to the fast-key hash.
  - Engine/MCP: counting/matching gate for translationese; rules_checked computation streamlined; translationese explanations avoid duplicate “Context:”.
  - Ruleset: large humanize/dewesternise additions with source IDs; Python linter recognizes translationese, allows empty to for report-only, treats negative_context_clues as conditional for chain checks.

- Migration
  - Behavior change: Base/Strict now report AI filler and translationese by default. To suppress, disable via profile config or set MCP params detect_ai: false and/or detect_translationese: false.
  - Old caches are bypassed by the new key; no manual cleanup needed.
  - If you lint rules, ensure your tooling accepts the new translationese type and empty to for report-only rules.

<sup>Written for commit 853f687e91d9354e2a8226cb078976606907c800. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

