### PR TITLE
Add structural style detectors with domain

### DIFF
--- a/assets/ruleset.json
+++ b/assets/ruleset.json
@@ -5498,6 +5498,13 @@
       "english": "hang up"
     },
     {
+      "from": "掛起",
+      "to": ["凍結", "當機", "卡死", "暫停", "擱置"],
+      "type": "cross_strait",
+      "context": "@domain 作業系統。cn「掛起」兼指 hang（程式/系統凍結，譯為凍結/當機/卡死）與 suspend（任務/執行緒暫停，譯為暫停/擱置）；tw 依語境分別選用",
+      "english": "hang / suspend"
+    },
+    {
       "from": "採樣",
       "to": ["取樣"],
       "type": "cross_strait",
@@ -9751,13 +9758,6 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "scaffolding"
-    },
-    {
-      "from": "腳本",
-      "to": ["指令碼"],
-      "type": "cross_strait",
-      "context": "@domain 作業系統",
-      "english": "script"
     },
     {
       "from": "臨時對象",

--- a/benches/scanner.rs
+++ b/benches/scanner.rs
@@ -471,10 +471,13 @@ fn bench_cpu_attribution_100kb(c: &mut Criterion) {
         grammar_checks: false,
         ai_filler_detection: false,
         translationese_detection: false,
+        translationese_domain:
+            zhtw_mcp::engine::translationese_score::TranslationeseDomain::General,
         ai_semantic_safety: false,
         ai_density_detection: false,
         ai_structural_patterns: false,
         ai_threshold_multiplier: 1.0,
+        heading_severity_boost: false,
         political_stance: PoliticalStance::RocCentric,
         offset_only: false,
     };

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -33,6 +33,10 @@ fn blake3_hex(data: &[u8]) -> String {
     blake3::hash(data).to_hex().to_string()
 }
 
+fn default_translationese_domain() -> String {
+    "general".to_owned()
+}
+
 /// Filesystem metadata used for the fast-path cache check.
 /// Avoids reading the file and computing a content hash when mtime+size match.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -54,6 +58,9 @@ pub struct ScanParams {
     pub detect_ai: bool,
     // Whether translationese detection is active — changes scan results.
     pub detect_translationese: bool,
+    // Translationese domain calibration — changes thresholds and serialized reports.
+    #[serde(default = "default_translationese_domain")]
+    pub translationese_domain: String,
     // AI threshold level (formatted f32) — different multipliers produce different results.
     pub ai_threshold: String,
 }
@@ -327,6 +334,8 @@ fn fast_key(file_path: &str, params: &ScanParams) -> String {
         b""
     });
     hasher.update(b"\0");
+    hasher.update(params.translationese_domain.as_bytes());
+    hasher.update(b"\0");
     hasher.update(params.ai_threshold.as_bytes());
     hasher.finalize().to_hex()[..32].to_string()
 }
@@ -383,6 +392,7 @@ mod tests {
             issues: vec![],
             detected_script: ChineseType::Traditional,
             ai_signature: None,
+            translationese_signature: None,
             coverage: None,
             oral_density: None,
             quality_flags: Vec::new(),
@@ -397,6 +407,7 @@ mod tests {
             fix_mode: "none".into(),
             detect_ai: false,
             detect_translationese: false,
+            translationese_domain: "general".into(),
             ai_threshold: "1.0".into(),
         }
     }
@@ -409,6 +420,7 @@ mod tests {
             fix_mode: "none".into(),
             detect_ai: false,
             detect_translationese: false,
+            translationese_domain: "general".into(),
             ai_threshold: "1.0".into(),
         }
     }
@@ -510,6 +522,35 @@ mod tests {
         };
         assert!(matches!(
             cache.check_fast("a.md", 1000, 5, &p_high),
+            CacheResult::Miss
+        ));
+    }
+
+    #[test]
+    fn translationese_domain_changes_cache_key() {
+        let dir = TempDir::new().unwrap();
+        let mut cache = ScanCache::open(dir.path().join("c.bin"));
+        let p = ScanParams {
+            detect_translationese: true,
+            translationese_domain: "general".into(),
+            ..test_params()
+        };
+
+        cache.put("a.md", b"hello", 1000, 5, &p, empty_output(), false);
+
+        // Same domain: hit.
+        assert!(matches!(
+            cache.check_fast("a.md", 1000, 5, &p),
+            CacheResult::Hit(_)
+        ));
+
+        // Same file + mtime + size but different calibration domain: miss.
+        let p_technical = ScanParams {
+            translationese_domain: "technical".into(),
+            ..p.clone()
+        };
+        assert!(matches!(
+            cache.check_fast("a.md", 1000, 5, &p_technical),
             CacheResult::Miss
         ));
     }

--- a/src/engine/markdown.rs
+++ b/src/engine/markdown.rs
@@ -17,12 +17,11 @@ use super::excluded::{merge_ranges_pub, ByteRange};
 pub fn build_markdown_excluded_ranges(text: &str) -> Vec<ByteRange> {
     let mut ranges = Vec::new();
 
-    // Pre-pass: detect YAML frontmatter (leading --- fence).
+    // Pre-pass: detect YAML frontmatter (leading --- fence).  Exclude only
+    // the structural tokens (--- fences, key+colon spans), leaving value
+    // prose scannable so that linting catches issues in title/description.
     if let Some(fm_end) = detect_frontmatter(text) {
-        ranges.push(ByteRange {
-            start: 0,
-            end: fm_end,
-        });
+        collect_frontmatter_structural_ranges(text, fm_end, &mut ranges);
     }
 
     collect_container_fence_ranges(text, &mut ranges);
@@ -73,12 +72,9 @@ pub fn build_markdown_excluded_ranges(text: &str) -> Vec<ByteRange> {
 pub fn build_markdown_excluded_ranges_no_code(text: &str) -> Vec<ByteRange> {
     let mut ranges = Vec::new();
 
-    // Pre-pass: detect YAML frontmatter.
+    // Pre-pass: detect YAML frontmatter — exclude structural tokens only.
     if let Some(fm_end) = detect_frontmatter(text) {
-        ranges.push(ByteRange {
-            start: 0,
-            end: fm_end,
-        });
+        collect_frontmatter_structural_ranges(text, fm_end, &mut ranges);
     }
 
     collect_container_fence_ranges(text, &mut ranges);
@@ -184,6 +180,157 @@ fn yaml_key_colon_pos(line: &str) -> Option<usize> {
     None
 }
 
+/// A Markdown table cell span with `(row, column)` coordinates.
+#[derive(Debug, Clone, Copy)]
+pub struct TableCellSpan {
+    pub start: usize,
+    pub end: usize,
+    pub row: usize,
+    pub col: usize,
+}
+
+/// Extract byte ranges of all Markdown table cells with their (row, column).
+///
+/// Row 0 is the header row (or row 1 if no separator).  Column index is the
+/// 0-based position within the row.  Returns empty if the document has no
+/// tables.
+pub fn extract_table_cell_spans(text: &str) -> Vec<TableCellSpan> {
+    let opts = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;
+    let parser = Parser::new_ext(text, opts);
+    let mut spans = Vec::new();
+    let mut in_table = false;
+    let mut current_row = 0usize;
+    let mut current_col = 0usize;
+    let mut cell_active = false;
+    let mut cell_start = 0usize;
+
+    for (event, range) in parser.into_offset_iter() {
+        match event {
+            Event::Start(Tag::Table(_)) => {
+                in_table = true;
+                current_row = 0;
+            }
+            Event::End(TagEnd::Table) => {
+                in_table = false;
+            }
+            Event::Start(Tag::TableHead) | Event::Start(Tag::TableRow) => {
+                if in_table {
+                    current_col = 0;
+                }
+            }
+            Event::End(TagEnd::TableHead) | Event::End(TagEnd::TableRow) => {
+                if in_table {
+                    current_row += 1;
+                }
+            }
+            Event::Start(Tag::TableCell) => {
+                if in_table {
+                    cell_active = true;
+                    cell_start = range.start;
+                }
+            }
+            Event::End(TagEnd::TableCell) => {
+                if in_table && cell_active {
+                    spans.push(TableCellSpan {
+                        start: cell_start,
+                        end: range.end,
+                        row: current_row,
+                        col: current_col,
+                    });
+                    current_col += 1;
+                    cell_active = false;
+                }
+            }
+            _ => {}
+        }
+    }
+    spans
+}
+
+/// Extract byte ranges of heading text inline content in Markdown.
+///
+/// Returns ranges covering only the inline text inside heading containers
+/// (H1-H6), excluding the leading `#` markers and trailing whitespace.
+/// Used by the scan pipeline to apply severity boosting on heading text.
+///
+/// Issues outside the inline text (e.g. inside ATX `#` markers) are not
+/// boosted, since they are unlikely to represent real heading prose hits.
+///
+/// YAML frontmatter is excluded: pulldown-cmark would otherwise interpret
+/// the closing `---` as a setext H2 underline, falsely treating frontmatter
+/// values as heading text.
+pub fn extract_heading_ranges(text: &str) -> Vec<ByteRange> {
+    let frontmatter_end = detect_frontmatter(text).unwrap_or(0);
+
+    let opts = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;
+    let parser = Parser::new_ext(text, opts);
+    let mut ranges = Vec::new();
+    let mut in_heading = false;
+    let mut current_inline_start: Option<usize> = None;
+    let mut current_inline_end: Option<usize> = None;
+
+    for (event, range) in parser.into_offset_iter() {
+        match event {
+            Event::Start(Tag::Heading { .. }) => {
+                in_heading = true;
+                current_inline_start = None;
+                current_inline_end = None;
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                if in_heading {
+                    if let (Some(start), Some(end)) = (current_inline_start, current_inline_end) {
+                        // Skip false-positive headings synthesised from
+                        // frontmatter content + closing `---`.
+                        if start >= frontmatter_end {
+                            ranges.push(ByteRange { start, end });
+                        }
+                    }
+                    in_heading = false;
+                }
+            }
+            Event::Text(_) | Event::Code(_) | Event::Html(_) | Event::InlineHtml(_)
+                if in_heading =>
+            {
+                if current_inline_start.is_none() {
+                    current_inline_start = Some(range.start);
+                }
+                current_inline_end = Some(range.end);
+            }
+            _ => {}
+        }
+    }
+    ranges
+}
+
+/// Collect YAML frontmatter structural ranges: opening `---` line, closing
+/// `---` line, and per-line key+colon spans.  Values remain scannable.
+fn collect_frontmatter_structural_ranges(text: &str, fm_end: usize, ranges: &mut Vec<ByteRange>) {
+    let fm = &text[..fm_end];
+    let mut pos = 0usize;
+
+    for raw_line in fm.split('\n') {
+        let line_len = raw_line.len();
+        let trimmed = raw_line.trim_end_matches('\r');
+
+        if trimmed == "---" {
+            // Exclude the entire fence line (and the trailing \n if present).
+            let end = (pos + line_len + 1).min(fm_end);
+            ranges.push(ByteRange { start: pos, end });
+        } else if let Some(colon_pos) = yaml_key_colon_pos(raw_line) {
+            // Exclude the key+colon prefix; value text remains scannable.
+            ranges.push(ByteRange {
+                start: pos,
+                end: pos + colon_pos + 1,
+            });
+        }
+
+        pos += line_len + 1; // +1 for the '\n'
+        if pos >= fm_end {
+            break;
+        }
+    }
+}
+
 /// Collect container-block fence lines (:::keyword / :::) as excluded ranges.
 /// Used by HackMD and Docusaurus for admonitions.  Only the fence lines
 /// themselves are excluded; the prose content between them is still scanned.
@@ -267,19 +414,50 @@ mod tests {
     }
 
     #[test]
-    fn yaml_frontmatter_excluded() {
+    fn yaml_frontmatter_keys_excluded_values_scannable() {
         let md = "---\ntitle: 測試\ndate: 2024-01-01\n---\n正文開始\n";
         let ranges = build_markdown_excluded_ranges(md);
         assert!(!ranges.is_empty());
-        // Frontmatter should be excluded.
-        let fm_range = &ranges[0];
-        let fm_text = &md[fm_range.start..fm_range.end];
-        assert!(fm_text.contains("title:"));
-        // Body should not be excluded.
+        // Key+colon is excluded.
+        let any_covers_title_key = ranges.iter().any(|r| md[r.start..r.end].contains("title:"));
+        assert!(any_covers_title_key, "title: key should be excluded");
+        // Value text is NOT excluded — it's prose to be scanned.
+        let value_excluded = ranges.iter().any(|r| md[r.start..r.end].contains("測試"));
+        assert!(
+            !value_excluded,
+            "frontmatter value 測試 should be scannable"
+        );
+        // Body is not excluded.
         let body_excluded = ranges
             .iter()
             .any(|r| md[r.start..r.end].contains("正文開始"));
         assert!(!body_excluded);
+        // Closing --- fence is excluded.
+        let close_excluded = ranges.iter().any(|r| md[r.start..r.end].trim() == "---");
+        assert!(close_excluded, "closing --- fence should be excluded");
+    }
+
+    #[test]
+    fn extract_heading_ranges_skips_frontmatter_setext() {
+        // pulldown-cmark synthesises a setext H2 from frontmatter content +
+        // closing `---`.  We must skip that false-positive heading so the
+        // severity boost does not apply to frontmatter values.
+        let md = "---\ntitle: 軟件測試指南\ndate: 2026\n---\n# 真標題\n正文。\n";
+        let ranges = extract_heading_ranges(md);
+        // Should contain the real heading "真標題" but NOT the synthesised
+        // frontmatter heading.
+        for r in &ranges {
+            let span = &md[r.start..r.end];
+            assert!(
+                !span.contains("title:"),
+                "frontmatter content leaked into heading ranges: {span:?}"
+            );
+        }
+        let real_heading_present = ranges.iter().any(|r| md[r.start..r.end].contains("真標題"));
+        assert!(
+            real_heading_present,
+            "real heading '真標題' should still be detected: {ranges:?}"
+        );
     }
 
     #[test]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -7,7 +7,9 @@ pub mod normalize;
 pub mod s2t;
 pub mod scan;
 pub mod segment;
+pub mod sentence;
 pub mod suppression;
 #[cfg(feature = "translate")]
 pub mod translate;
+pub mod translationese_score;
 pub mod zhtype;

--- a/src/engine/scan/grammar.rs
+++ b/src/engine/scan/grammar.rs
@@ -1903,11 +1903,11 @@ pub(crate) fn scan_ai_dash_overuse(text: &str, excluded: &[ByteRange], issues: &
     let mut first_offset: Option<usize> = None;
 
     for para in &paragraphs {
-        let dash_count = para.matches('—').count();
+        let para_start = para.as_ptr() as usize - text.as_ptr() as usize;
+        let dash_count = count_non_excluded_matches(para, para_start, "—", excluded).0;
         if dash_count >= 3 {
             heavy_dash_count += 1;
             if first_offset.is_none() {
-                let para_start = para.as_ptr() as usize - text.as_ptr() as usize;
                 first_offset = Some(para_start);
             }
         }
@@ -2081,6 +2081,1015 @@ fn scan_ai_zero_width(text: &str, excluded: &[ByteRange], issues: &mut Vec<Issue
     }
 }
 
+// ========================================================================
+// Structural AI detectors (require BoundaryIndex)
+// ========================================================================
+
+// S1: tricolon detection — three 、-separated spans with identical char
+// length or identical sentence-final particles.
+fn scan_ai_tricolon(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    for sent in &idx.sentences {
+        let s = &text[sent.byte_start..sent.byte_end];
+        // Strip sentence-final punctuation so the trailing span's char count
+        // matches its peers (團結、奮鬥、創新。 should be three 2-char spans).
+        let stripped_end = s
+            .trim_end_matches(['。', '！', '？', '；', '.', '!', '?'])
+            .len();
+        let s = &s[..stripped_end];
+        // Build (byte_start, byte_end, char_count) for each 、-separated span.
+        // Tracking offsets explicitly avoids the s.find(span) hazard where
+        // repeated spans (e.g. 乙、甲、甲) collapse to the first occurrence.
+        let mut spans: Vec<(usize, usize, usize)> = Vec::new();
+        let mut span_start = 0usize;
+        for (idx_byte, _) in s.match_indices('、') {
+            let char_count = s[span_start..idx_byte].chars().count();
+            spans.push((span_start, idx_byte, char_count));
+            span_start = idx_byte + '、'.len_utf8();
+        }
+        // Final span after the last 、.
+        if span_start <= s.len() {
+            let char_count = s[span_start..].chars().count();
+            spans.push((span_start, s.len(), char_count));
+        }
+        if spans.len() < 3 {
+            continue;
+        }
+        // Check consecutive triples for identical char-count pattern.
+        for window in spans.windows(3) {
+            let (s0_start, _, len0) = window[0];
+            let (_, _, len1) = window[1];
+            let (_, s2_end, len2) = window[2];
+            if len0 == len1 && len1 == len2 && len0 > 0 && len0 <= 8 {
+                let abs_start = sent.byte_start + s0_start;
+                let abs_end = sent.byte_start + s2_end;
+                if !is_excluded(abs_start, abs_end, excluded) {
+                    issues.push(
+                        Issue::new(
+                            abs_start,
+                            abs_end - abs_start,
+                            &text[abs_start..abs_end],
+                            vec![],
+                            IssueType::AiStyle,
+                            Severity::Info,
+                        )
+                        .with_context("AI structural: 三連排比（tricolon）— 三個等長的、分隔片段，常見於 AI 生成文本"),
+                    );
+                }
+                break; // One tricolon per sentence is enough.
+            }
+        }
+    }
+}
+
+/// Slice up to `n` characters from a byte offset, char-boundary safe.
+/// Returns the byte range that covers up to n chars from start_byte.
+fn char_bounded_end(text: &str, start_byte: usize, n_chars: usize) -> usize {
+    text[start_byte..]
+        .char_indices()
+        .nth(n_chars)
+        .map(|(i, _)| start_byte + i)
+        .unwrap_or(text.len())
+}
+
+// S2: negative parallel — 不只是/不僅是 + 而是/更是 within ≤30 chars.
+fn scan_ai_negative_parallel(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    const OPENERS: &[&str] = &["不只是", "不僅是", "不僅僅是"];
+    const CLOSERS: &[&str] = &["而是", "更是"];
+
+    for sent in &idx.sentences {
+        let s = &text[sent.byte_start..sent.byte_end];
+        for opener in OPENERS {
+            if let Some(pos) = s.find(opener) {
+                let after_opener = pos + opener.len();
+                // 30-char lookahead, char-boundary safe (not byte-truncated).
+                let search_end = char_bounded_end(s, after_opener, 30);
+                let window = &s[after_opener..search_end];
+                for closer in CLOSERS {
+                    if let Some(cpos) = window.find(closer) {
+                        let abs_start = sent.byte_start + pos;
+                        let abs_end = sent.byte_start + after_opener + cpos + closer.len();
+                        if !is_excluded(abs_start, abs_end, excluded) {
+                            issues.push(
+                                Issue::new(
+                                    abs_start,
+                                    abs_end - abs_start,
+                                    &text[abs_start..abs_end],
+                                    vec![],
+                                    IssueType::AiStyle,
+                                    Severity::Info,
+                                )
+                                .with_context(
+                                    "AI structural: 否定平行結構（不只是…而是/更是），AI 常用公式",
+                                ),
+                            );
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// S3: formulaic section endings — last sentence of a paragraph matching
+// formulaic closing phrases.
+fn scan_ai_formulaic_section_endings(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    const FORMULAIC_ENDINGS: &[&str] = &["展望未來", "拭目以待", "值得期待", "我們有理由相信"];
+    // Regex-like patterns: 隨著.*不斷發展 — handled with substring checks.
+    for para in &idx.paragraphs {
+        let sents = idx.sentences_in_paragraph(para);
+        if let Some(last) = sents.last() {
+            let s = &text[last.byte_start..last.byte_end];
+            for &phrase in FORMULAIC_ENDINGS {
+                if let Some(pos) = s.find(phrase) {
+                    let abs = last.byte_start + pos;
+                    if !is_excluded(abs, abs + phrase.len(), excluded) {
+                        issues.push(
+                            Issue::new(
+                                abs,
+                                phrase.len(),
+                                phrase,
+                                vec![],
+                                IssueType::AiStyle,
+                                Severity::Info,
+                            )
+                            .with_context("AI structural: 段落結尾公式化用語，常見於 AI 生成文本"),
+                        );
+                    }
+                }
+            }
+            // Pattern: 隨著...不斷發展 (gap ≤40 chars; gap can be zero)
+            if let Some(start) = s.find("隨著") {
+                if let Some(end_pos) = s.find("不斷發展") {
+                    let after_kw = start + "隨著".len();
+                    let gap_chars = if end_pos >= after_kw {
+                        s[after_kw..end_pos].chars().count()
+                    } else {
+                        usize::MAX // skip — pattern out of order
+                    };
+                    if gap_chars <= 40 {
+                        let abs = last.byte_start + start;
+                        let abs_end = last.byte_start + end_pos + "不斷發展".len();
+                        if !is_excluded(abs, abs_end, excluded) {
+                            issues.push(
+                                Issue::new(
+                                    abs,
+                                    abs_end - abs,
+                                    &text[abs..abs_end],
+                                    vec![],
+                                    IssueType::AiStyle,
+                                    Severity::Info,
+                                )
+                                .with_context("AI structural: 段落結尾公式化用語（隨著…不斷發展）"),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// S4: mechanical bullet lists — every item starts with **keyword**
+fn scan_ai_mechanical_bullets(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    _idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    // Scan for Markdown list items where every item starts with **bold**.
+    let mut list_start: Option<usize> = None;
+    let mut bold_count = 0;
+    let mut item_count = 0;
+    let mut first_item_offset = 0;
+
+    for (line_offset, line) in line_iter(text) {
+        let trimmed = line.trim_start();
+        // Numbered list items: one or more ASCII digits followed by '.' or ')'
+        // and whitespace.  Matches 1., 10., 123), etc.
+        let numbered_marker_len = numbered_list_marker_len(trimmed);
+        let is_list_item =
+            trimmed.starts_with("- ") || trimmed.starts_with("* ") || numbered_marker_len.is_some();
+
+        if is_list_item {
+            if list_start.is_none() {
+                list_start = Some(line_offset);
+                first_item_offset = line_offset;
+                bold_count = 0;
+                item_count = 0;
+            }
+            item_count += 1;
+            // Check for leading **bold**
+            let content = if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
+                &trimmed[2..]
+            } else if let Some(marker_len) = numbered_marker_len {
+                trimmed[marker_len..].trim_start()
+            } else {
+                ""
+            };
+            if content.starts_with("**") {
+                bold_count += 1;
+            }
+        } else if list_start.is_some() {
+            // End of list.
+            if item_count >= 3
+                && bold_count == item_count
+                && !is_excluded(first_item_offset, first_item_offset + 1, excluded)
+            {
+                issues.push(
+                    Issue::new(
+                        first_item_offset,
+                        1,
+                        "-",
+                        vec![],
+                        IssueType::AiStyle,
+                        Severity::Info,
+                    )
+                    .with_context(format!(
+                        "AI structural: 機械式列表 — {item_count} 項全部以粗體關鍵字開頭"
+                    )),
+                );
+            }
+            list_start = None;
+        }
+    }
+    // Flush trailing list.
+    if list_start.is_some()
+        && item_count >= 3
+        && bold_count == item_count
+        && !is_excluded(first_item_offset, first_item_offset + 1, excluded)
+    {
+        issues.push(
+            Issue::new(
+                first_item_offset,
+                1,
+                "-",
+                vec![],
+                IssueType::AiStyle,
+                Severity::Info,
+            )
+            .with_context(format!(
+                "AI structural: 機械式列表 — {item_count} 項全部以粗體關鍵字開頭"
+            )),
+        );
+    }
+}
+
+// S5: excessive bold — ≥3 **...** runs per 200 chars in a paragraph.
+fn count_non_excluded_bold_runs(text: &str, base_offset: usize, excluded: &[ByteRange]) -> usize {
+    text.match_indices("**")
+        .filter(|(offset, marker)| {
+            let abs = base_offset + *offset;
+            !is_excluded(abs, abs + marker.len(), excluded)
+        })
+        .count()
+        / 2
+}
+
+fn scan_ai_excessive_bold(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    for para in &idx.paragraphs {
+        let p = &text[para.byte_start..para.byte_end];
+        let char_count = p.chars().count();
+        if char_count < 30 {
+            continue;
+        }
+        // Count **...** runs.
+        let bold_count = count_non_excluded_bold_runs(p, para.byte_start, excluded);
+        // Threshold: ≥3 per 200 chars.
+        let threshold = ((char_count as f32 / 200.0) * 3.0).ceil() as usize;
+        if bold_count >= 3
+            && bold_count >= threshold
+            && !is_excluded(para.byte_start, para.byte_start + 1, excluded)
+        {
+            // First 2 chars as preview, char-boundary safe.
+            let preview_end = char_bounded_end(p, 0, 2);
+            issues.push(
+                Issue::new(
+                    para.byte_start,
+                    preview_end,
+                    &p[..preview_end],
+                    vec![],
+                    IssueType::AiStyle,
+                    Severity::Info,
+                )
+                .with_context(format!(
+                    "AI structural: 段落粗體過多 — {bold_count} 處粗體標記（每 200 字 ≥3 處）"
+                )),
+            );
+        }
+    }
+}
+
+fn count_non_excluded_matches(
+    text: &str,
+    base_offset: usize,
+    needle: &str,
+    excluded: &[ByteRange],
+) -> (usize, Option<usize>) {
+    let mut count = 0;
+    let mut first_offset = None;
+    let mut search_from = 0;
+
+    while let Some(pos) = text[search_from..].find(needle) {
+        let rel = search_from + pos;
+        let abs = base_offset + rel;
+        if !is_excluded(abs, abs + needle.len(), excluded) {
+            count += 1;
+            first_offset.get_or_insert(abs);
+        }
+        search_from = rel + needle.len();
+    }
+
+    (count, first_offset)
+}
+
+// S6: em-dash overuse — ≥1 '——' per paragraph.
+fn scan_ai_emdash_overuse(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    for para in &idx.paragraphs {
+        let p = &text[para.byte_start..para.byte_end];
+        let (count, first_offset) = count_non_excluded_matches(p, para.byte_start, "——", excluded);
+        if count < 2 {
+            continue;
+        }
+        if let Some(abs) = first_offset {
+            issues.push(
+                Issue::new(
+                    abs,
+                    "——".len(),
+                    "——",
+                    vec![],
+                    IssueType::AiStyle,
+                    Severity::Info,
+                )
+                .with_context(format!(
+                    "AI structural: 破折號過度使用 — 段落內 {count} 處（AI 常見模式）"
+                )),
+            );
+        }
+    }
+}
+
+// S7: formulaic 'despite' — 儘管.*挑戰 + forward-looking verb within one sentence.
+fn scan_ai_formulaic_despite(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    const FORWARD_VERBS: &[&str] = &["仍然", "持續", "蓬勃發展", "繼續"];
+
+    for sent in &idx.sentences {
+        let s = &text[sent.byte_start..sent.byte_end];
+        if let Some(start) = s.find("儘管") {
+            let after_despite_start = start + "儘管".len();
+            let after_despite = &s[after_despite_start..];
+            if let Some(challenge_rel) = after_despite.find("挑戰") {
+                let challenge = after_despite_start + challenge_rel;
+                // Char-counted gap (≤40 chars) — encoding-independent.
+                let gap_chars = s[after_despite_start..challenge].chars().count();
+                if gap_chars <= 40 {
+                    // Check for forward-looking verb in the rest of the sentence.
+                    let rest = &s[challenge + "挑戰".len()..];
+                    for verb in FORWARD_VERBS {
+                        if rest.contains(verb) {
+                            let abs = sent.byte_start + start;
+                            let abs_end = sent.byte_end;
+                            if !is_excluded(abs, abs_end, excluded) {
+                                issues.push(
+                                    Issue::new(
+                                        abs,
+                                        abs_end - abs,
+                                        &text[abs..abs_end],
+                                        vec![],
+                                        IssueType::AiStyle,
+                                        Severity::Info,
+                                    )
+                                    .with_context(
+                                        "AI structural: 公式化轉折（儘管…挑戰…仍然），AI 常見句型",
+                                    ),
+                                );
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// S8: false ranges — 從...到...再到 chains.
+fn scan_ai_false_ranges(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    for sent in &idx.sentences {
+        let s = &text[sent.byte_start..sent.byte_end];
+        if let Some(cong) = s.find("從") {
+            let after_cong = cong + "從".len();
+            if let Some(dao) = s[after_cong..].find("到") {
+                let after_dao = after_cong + dao + "到".len();
+                if let Some(zaidao) = s[after_dao..].find("再到") {
+                    let chain_end = after_dao + zaidao + "再到".len();
+                    let chain_chars = s[cong..chain_end].chars().count();
+                    if chain_chars >= 10 {
+                        // ≥10 chars chain
+                        let abs = sent.byte_start + cong;
+                        let abs_end = sent.byte_start + chain_end;
+                        if !is_excluded(abs, abs_end, excluded) {
+                            issues.push(
+                                Issue::new(
+                                    abs,
+                                    abs_end - abs,
+                                    &text[abs..abs_end],
+                                    vec![],
+                                    IssueType::AiStyle,
+                                    Severity::Info,
+                                )
+                                .with_context(
+                                    "AI structural: 假範圍鏈（從…到…再到），AI 常見列舉模式",
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// V2: hedging density — promote Info to Warning when ≥3 hedging hits per 200 chars.
+fn scan_ai_hedging_density(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut [Issue],
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    const HEDGING_PHRASES: &[&str] = &["在某種程度上", "從某個角度來看", "可以說是", "相對而言"];
+
+    for para in &idx.paragraphs {
+        let p = &text[para.byte_start..para.byte_end];
+        let char_count = p.chars().count();
+        if char_count < 50 {
+            continue;
+        }
+        let mut count = 0;
+        for phrase in HEDGING_PHRASES {
+            count += count_non_excluded_matches(p, para.byte_start, phrase, excluded).0;
+        }
+        // Threshold: ≥3 per 200 chars.
+        let threshold = ((char_count as f32 / 200.0) * 3.0).ceil() as usize;
+        if count >= 3 && count >= threshold {
+            // Promote existing hedging Info issues in this paragraph to Warning.
+            for issue in issues.iter_mut() {
+                if issue.offset >= para.byte_start
+                    && issue.offset < para.byte_end
+                    && issue.rule_type == IssueType::AiStyle
+                    && issue.severity == Severity::Info
+                {
+                    if let Some(ref ctx) = issue.context {
+                        if HEDGING_PHRASES
+                            .iter()
+                            .any(|h| ctx.contains(h) || issue.found.contains(h))
+                        {
+                            issue.severity = Severity::Warning;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ========================================================================
+// Syntactic translationese detectors (require BoundaryIndex)
+// ========================================================================
+
+// G1: passive voice density — count 被 per paragraph, flag at >2 per 100 chars.
+fn scan_trans_passive_density(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    // Technical whitelist: these passive forms are standard in zh-TW technical prose.
+    const WHITELIST: &[&str] = &[
+        "被定義為",
+        "被廣泛採用",
+        "被置於",
+        "被稱作",
+        "被觀察到",
+        "被記錄為",
+    ];
+    // Note: per-occurrence flagging of specific calques (被廣泛認為, 被視為,
+    // 被稱為, etc.) is handled by the spelling ruleset, not duplicated here.
+    // This detector contributes only the density-based signal.
+
+    for para in &idx.paragraphs {
+        let p = &text[para.byte_start..para.byte_end];
+        let char_count = p.chars().count();
+        if char_count < 20 {
+            continue;
+        }
+
+        // Count 被 occurrences not in whitelist.
+        let mut bei_count = 0;
+        let mut search_from = 0;
+        while let Some(pos) = p[search_from..].find('被') {
+            let abs_pos = para.byte_start + search_from + pos;
+            let bei_start = search_from + pos;
+            // 10-char lookahead, char-boundary safe.
+            let context_end = char_bounded_end(p, bei_start, 10);
+            let context = &p[bei_start..context_end];
+
+            if !is_excluded(abs_pos, abs_pos + '被'.len_utf8(), excluded) {
+                let whitelisted = WHITELIST.iter().any(|w| context.starts_with(w));
+                if !whitelisted {
+                    bei_count += 1;
+                }
+            }
+            search_from += pos + '被'.len_utf8();
+        }
+
+        // Density check: >2 per 100 chars.
+        let density_threshold = ((char_count as f32 / 100.0) * 2.0).ceil() as usize;
+        if bei_count > density_threshold.max(2) {
+            // First 2 chars as preview, char-boundary safe.
+            let preview_end = char_bounded_end(p, 0, 2);
+            issues.push(
+                Issue::new(
+                    para.byte_start,
+                    preview_end,
+                    &p[..preview_end],
+                    vec![],
+                    IssueType::Translationese,
+                    Severity::Warning,
+                )
+                .with_context(format!(
+                    "翻譯腔 G1: 被動語態密度過高 — 段落內 {bei_count} 處 '被' 字句"
+                )),
+            );
+        }
+    }
+}
+
+// G2: abstract subject — noun phrase ending in 的(減少|增加|...) at sentence
+// head followed by 導致|標誌著|意味著.
+fn scan_trans_abstract_subject(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    const ABSTRACT_NOUNS: &[&str] = &["的減少", "的增加", "的提高", "的下降", "的通過", "的實施"];
+    const ABSTRACT_VERBS: &[&str] = &["導致", "標誌著", "意味著"];
+
+    'sentences: for sent in &idx.sentences {
+        let s = &text[sent.byte_start..sent.byte_end];
+        // Check sentence head (first 20 chars).
+        let head = &s[..char_bounded_end(s, 0, 20)];
+        for noun in ABSTRACT_NOUNS {
+            if head.contains(noun) {
+                for verb in ABSTRACT_VERBS {
+                    if s.contains(verb) {
+                        let abs = sent.byte_start;
+                        if !is_excluded(abs, abs + s.len().min(12), excluded) {
+                            issues.push(
+                                Issue::new(
+                                    abs,
+                                    s.len(),
+                                    s,
+                                    vec![],
+                                    IssueType::Translationese,
+                                    Severity::Info,
+                                )
+                                .with_context(
+                                    "翻譯腔 G2: 抽象主語（的+抽象名詞+導致/意味著），歐化句型",
+                                ),
+                            );
+                            continue 'sentences; // One per sentence.
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// G3/G4: displaced conditionals — 如果 after main clause.
+fn scan_trans_displaced_conditional(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    const CONDITIONALS: &[&str] = &["如果", "假如", "若"];
+
+    for sent in &idx.sentences {
+        let s = &text[sent.byte_start..sent.byte_end];
+        let char_len = s.chars().count();
+        if char_len < 6 {
+            continue;
+        }
+        // A displaced conditional is one that appears after the halfway point.
+        let midpoint = char_bounded_end(s, 0, char_len / 2);
+
+        for &cond in CONDITIONALS {
+            // Search only after the halfway point; sentence-initial occurrences
+            // are correctly placed and naturally excluded by this slice.
+            if let Some(pos) = s[midpoint..].find(cond) {
+                let abs = sent.byte_start + midpoint + pos;
+                if !is_excluded(abs, abs + cond.len(), excluded) {
+                    // Check for 的話 after the conditional (extra calque signal).
+                    let after = &s[midpoint + pos + cond.len()..];
+                    let has_dehua = after.contains("的話");
+                    let ctx = if has_dehua {
+                        "翻譯腔 G3: 後置條件句（…如果…的話），建議將條件前置"
+                    } else {
+                        "翻譯腔 G4: 後置條件句，建議將條件前置"
+                    };
+                    issues.push(
+                        Issue::new(
+                            abs,
+                            cond.len(),
+                            cond,
+                            vec![],
+                            IssueType::Translationese,
+                            Severity::Info,
+                        )
+                        .with_context(ctx),
+                    );
+                }
+                break; // One per sentence.
+            }
+        }
+    }
+}
+
+// G8: pronoun overuse — ≥3 consecutive sentences starting with 他/她/它/他們.
+fn scan_trans_pronoun_overuse(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    const PRONOUNS: &[&str] = &["他", "她", "它", "他們", "她們"];
+
+    for para in &idx.paragraphs {
+        let sents = idx.sentences_in_paragraph(para);
+        let mut consecutive = 0;
+        let mut first_offset = 0;
+
+        for sent in &sents {
+            let s = &text[sent.byte_start..sent.byte_end];
+            let starts_with_pronoun = PRONOUNS.iter().any(|p| s.starts_with(p));
+            if starts_with_pronoun {
+                if consecutive == 0 {
+                    first_offset = sent.byte_start;
+                }
+                consecutive += 1;
+            } else {
+                if consecutive >= 3 && !is_excluded(first_offset, first_offset + 3, excluded) {
+                    issues.push(
+                        Issue::new(
+                            first_offset,
+                            3,
+                            &text[first_offset..first_offset + 3],
+                            vec![],
+                            IssueType::Translationese,
+                            Severity::Info,
+                        )
+                        .with_context(format!(
+                            "翻譯腔 G8: 代詞過度使用 — 連續 {consecutive} 句以代詞開頭"
+                        )),
+                    );
+                }
+                consecutive = 0;
+            }
+        }
+        // Flush trailing run.
+        if consecutive >= 3 && !is_excluded(first_offset, first_offset + 3, excluded) {
+            issues.push(
+                Issue::new(
+                    first_offset,
+                    3,
+                    &text[first_offset..first_offset + 3],
+                    vec![],
+                    IssueType::Translationese,
+                    Severity::Info,
+                )
+                .with_context(format!(
+                    "翻譯腔 G8: 代詞過度使用 — 連續 {consecutive} 句以代詞開頭"
+                )),
+            );
+        }
+    }
+}
+
+// Y1: copula+classifier inflation — 他是一個/名/位...的...人
+fn scan_trans_copula_classifier(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    const COPULA_PATTERNS: &[&str] = &["是一個", "是一名", "是一位"];
+
+    for sent in &idx.sentences {
+        let s = &text[sent.byte_start..sent.byte_end];
+        for &pattern in COPULA_PATTERNS {
+            if let Some(pos) = s.find(pattern) {
+                // Check if followed by 的...人 within the sentence.
+                let after = &s[pos + pattern.len()..];
+                if after.contains("的") {
+                    let abs = sent.byte_start + pos;
+                    if !is_excluded(abs, abs + pattern.len(), excluded) {
+                        issues.push(
+                            Issue::new(
+                                abs,
+                                pattern.len(),
+                                pattern,
+                                vec![format!("是")],
+                                IssueType::Translationese,
+                                Severity::Info,
+                            )
+                            .with_context(
+                                "翻譯腔 Y1: 繫詞+量詞膨脹（是一個/名/位…的…），建議刪除繫詞+量詞",
+                            ),
+                        );
+                    }
+                    break; // One per sentence.
+                }
+            }
+        }
+    }
+}
+
+// Y2: 的/地 confusion — adjective + 的 + verb where 地 is correct.
+fn scan_trans_adverbial_particle_mixup(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    _idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    // Finite list of common adj+的+verb confusions (should be 地).
+    const CONFUSIONS: &[(&str, &str)] = &[
+        ("仔細的看", "仔細地看"),
+        ("認真的聽", "認真地聽"),
+        ("慢慢的走", "慢慢地走"),
+        ("靜靜的坐", "靜靜地坐"),
+        ("快速的跑", "快速地跑"),
+        ("努力的工作", "努力地工作"),
+        ("安靜的離開", "安靜地離開"),
+        ("輕輕的放", "輕輕地放"),
+        ("默默的承受", "默默地承受"),
+        ("悄悄的走", "悄悄地走"),
+    ];
+
+    for &(wrong, correct) in CONFUSIONS {
+        let mut search_from = 0;
+        while let Some(pos) = text[search_from..].find(wrong) {
+            let abs = search_from + pos;
+            if !is_excluded(abs, abs + wrong.len(), excluded) {
+                issues.push(
+                    Issue::new(
+                        abs,
+                        wrong.len(),
+                        wrong,
+                        vec![correct.to_string()],
+                        IssueType::Translationese,
+                        Severity::Warning,
+                    )
+                    .with_context("翻譯腔 Y2: 的/地混淆 — 副詞修飾動詞應用「地」"),
+                );
+            }
+            search_from = abs + wrong.len();
+        }
+    }
+}
+
+// S3: 的的不休 (余光中) — ≥4 的 in one continuous span without comma.
+fn scan_trans_excessive_de_chain(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    for sent in &idx.sentences {
+        let s = &text[sent.byte_start..sent.byte_end];
+        // Walk clause boundaries with explicit byte offsets so repeated
+        // identical clauses do not collapse to the first occurrence.
+        let mut clause_start = 0usize;
+        for (sep_byte, sep_ch) in s.match_indices(['，', ',']) {
+            emit_excessive_de_chain(
+                text,
+                s,
+                sent.byte_start,
+                clause_start,
+                sep_byte,
+                excluded,
+                issues,
+            );
+            clause_start = sep_byte + sep_ch.len();
+        }
+        // Final clause after the last separator.
+        emit_excessive_de_chain(
+            text,
+            s,
+            sent.byte_start,
+            clause_start,
+            s.len(),
+            excluded,
+            issues,
+        );
+    }
+}
+
+fn emit_excessive_de_chain(
+    text: &str,
+    sent_text: &str,
+    sent_offset: usize,
+    clause_start: usize,
+    clause_end: usize,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+) {
+    if clause_start >= clause_end {
+        return;
+    }
+    let clause = &sent_text[clause_start..clause_end];
+    let de_count = clause.matches('的').count();
+    if de_count < 4 {
+        return;
+    }
+    let abs = sent_offset + clause_start;
+    let abs_end = sent_offset + clause_end;
+    if is_excluded(abs, abs_end, excluded) {
+        return;
+    }
+    issues.push(
+        Issue::new(
+            abs,
+            clause.len(),
+            &text[abs..abs_end],
+            vec![],
+            IssueType::Translationese,
+            Severity::Warning,
+        )
+        .with_context(format!(
+            "翻譯腔 S3: 的的不休 — 一個子句中出現 {de_count} 個「的」（余光中）"
+        )),
+    );
+}
+
+// V7: 地 overuse on disyllabic adverbs — 慢慢地、靜靜地、認真地.
+fn scan_trans_adverbial_particle_redundant(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    _idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    // Finite whitelist: these adverbs can drop 地 in natural Chinese.
+    const ADVERBS: &[(&str, &str)] = &[
+        ("慢慢地", "慢慢"),
+        ("靜靜地", "靜靜"),
+        ("認真地", "認真"),
+        ("安靜地", "安靜"),
+        ("輕輕地", "輕輕"),
+        ("默默地", "默默"),
+        ("悄悄地", "悄悄"),
+        ("漸漸地", "漸漸"),
+        ("緩緩地", "緩緩"),
+        ("偷偷地", "偷偷"),
+    ];
+
+    for &(with_di, without_di) in ADVERBS {
+        let mut search_from = 0;
+        while let Some(pos) = text[search_from..].find(with_di) {
+            let abs = search_from + pos;
+            if !is_excluded(abs, abs + with_di.len(), excluded) {
+                issues.push(
+                    Issue::new(
+                        abs,
+                        with_di.len(),
+                        with_di,
+                        vec![without_di.to_string()],
+                        IssueType::Translationese,
+                        Severity::Info,
+                    )
+                    .with_context("翻譯腔 V7: 雙音節副詞+「地」冗餘，可省略「地」"),
+                );
+            }
+            search_from = abs + with_di.len();
+        }
+    }
+}
+
+// V13: tense marker overuse — multiple 曾/已/過/了 in one sentence when
+// an explicit date is present.
+fn scan_trans_tense_marker(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    const TENSE_MARKERS: &[char] = &['曾', '已', '過', '了'];
+
+    for sent in &idx.sentences {
+        let s = &text[sent.byte_start..sent.byte_end];
+        // Check for explicit date marker (年/月/日 or digits).
+        let has_date = s.contains('年')
+            || s.contains('月')
+            || s.contains('日')
+            || s.chars().any(|c| c.is_ascii_digit());
+
+        if !has_date {
+            continue;
+        }
+
+        let marker_count: usize = TENSE_MARKERS.iter().map(|&m| s.matches(m).count()).sum();
+
+        if marker_count >= 3
+            && !is_excluded(sent.byte_start, sent.byte_start + s.len().min(6), excluded)
+        {
+            issues.push(
+                Issue::new(
+                    sent.byte_start,
+                    s.len(),
+                    s,
+                    vec![],
+                    IssueType::Translationese,
+                    Severity::Info,
+                )
+                .with_context(format!(
+                    "翻譯腔 V13: 時態標記冗餘 — 句中已有日期，{marker_count} 個時態詞多餘"
+                )),
+            );
+        }
+    }
+}
+
+/// Iterate over lines with their byte offsets.  Strips trailing \r so
+/// callers see consistent line content on both LF and CRLF inputs; the
+/// returned offset still points at the original line start.
+/// Return the byte length of an ordered-list marker (e.g. "1.", "10.", "123)")
+/// at the start of `s`, including the trailing `.` or `)`.  Returns `None` if
+/// `s` does not start with such a marker followed by whitespace.
+///
+/// Handles multi-digit numbers (10., 12)), not just single digits.
+fn numbered_list_marker_len(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let digits = bytes.iter().take_while(|b| b.is_ascii_digit()).count();
+    if digits == 0 {
+        return None;
+    }
+    match bytes.get(digits) {
+        Some(&b'.') | Some(&b')') => {}
+        _ => return None,
+    }
+    // Marker must be followed by whitespace or end-of-line.
+    match bytes.get(digits + 1) {
+        None | Some(&b' ') | Some(&b'\t') => Some(digits + 1),
+        _ => None,
+    }
+}
+
+fn line_iter(text: &str) -> impl Iterator<Item = (usize, &str)> {
+    let mut offset = 0;
+    text.split('\n').map(move |line| {
+        let start = offset;
+        offset += line.len() + 1; // +1 for the \n
+        (start, line.strip_suffix('\r').unwrap_or(line))
+    })
+}
+
 // Entry point: run all structural AI pattern checks.
 // Gated by ProfileConfig::ai_structural_patterns.
 pub(crate) fn scan_ai_structural(
@@ -2095,6 +3104,49 @@ pub(crate) fn scan_ai_structural(
     scan_ai_formulaic_headings(text, excluded, issues);
     scan_ai_list_density(text, excluded, issues, threshold_multiplier);
     scan_ai_zero_width(text, excluded, issues);
+}
+
+// Structural AI pattern detectors that require sentence/paragraph
+// boundary index.  S1 tricolon, S2 negative parallel, S3 formulaic
+// section endings, S4 mechanical bullets, S5 excessive bold, S6 em-dash
+// overuse, S7 formulaic despite, S8 false ranges, V2 hedging density.
+pub(crate) fn scan_ai_structural_phase2(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    boundary_index: &crate::engine::sentence::BoundaryIndex,
+) {
+    scan_ai_tricolon(text, excluded, issues, boundary_index);
+    scan_ai_negative_parallel(text, excluded, issues, boundary_index);
+    scan_ai_formulaic_section_endings(text, excluded, issues, boundary_index);
+    scan_ai_mechanical_bullets(text, excluded, issues, boundary_index);
+    scan_ai_excessive_bold(text, excluded, issues, boundary_index);
+    scan_ai_emdash_overuse(text, excluded, issues, boundary_index);
+    scan_ai_formulaic_despite(text, excluded, issues, boundary_index);
+    scan_ai_false_ranges(text, excluded, issues, boundary_index);
+    scan_ai_hedging_density(text, excluded, issues, boundary_index);
+}
+
+// Syntactic translationese detectors that require
+// sentence/paragraph boundary index.  G1 passive density,
+// G2 abstract subject, G3/G4 displaced conditionals, G8 pronoun overuse,
+// Y1 copula+classifier, Y2 的/地 confusion, S3 的的不休, V7 地 overuse,
+// V13 tense markers.
+pub(crate) fn scan_translationese_syntactic(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    boundary_index: &crate::engine::sentence::BoundaryIndex,
+) {
+    scan_trans_passive_density(text, excluded, issues, boundary_index);
+    scan_trans_abstract_subject(text, excluded, issues, boundary_index);
+    scan_trans_displaced_conditional(text, excluded, issues, boundary_index);
+    scan_trans_pronoun_overuse(text, excluded, issues, boundary_index);
+    scan_trans_copula_classifier(text, excluded, issues, boundary_index);
+    scan_trans_adverbial_particle_mixup(text, excluded, issues, boundary_index);
+    scan_trans_excessive_de_chain(text, excluded, issues, boundary_index);
+    scan_trans_adverbial_particle_redundant(text, excluded, issues, boundary_index);
+    scan_trans_tense_marker(text, excluded, issues, boundary_index);
 }
 
 // Entry point for AI writing detection grammar checks.
@@ -2165,11 +3217,137 @@ fn scan_grammar_legacy(text: &str, excluded: &[ByteRange], issues: &mut Vec<Issu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::sentence::BoundaryIndex;
 
     fn scan(text: &str) -> Vec<Issue> {
         let mut issues = Vec::new();
         scan_grammar(text, &[], &mut issues);
         issues
+    }
+
+    fn scan_phase2(text: &str) -> Vec<Issue> {
+        let idx = BoundaryIndex::build(text, &[]);
+        let mut issues = Vec::new();
+        scan_ai_structural_phase2(text, &[], &mut issues, &idx);
+        scan_translationese_syntactic(text, &[], &mut issues, &idx);
+        issues
+    }
+
+    // =======================================================================
+    // Phase 2 panic-safety regression tests (from Codex/Gemini review)
+    // =======================================================================
+
+    #[test]
+    fn tricolon_with_repeated_spans_does_not_panic() {
+        // Codex high #1: 乙、甲、甲、乙 used to confuse find()-based offset
+        // calculation when the same span repeats.  Should not panic and
+        // should detect the central tricolon (甲、甲).
+        let text = "乙、甲、甲、乙、丙。";
+        let _ = scan_phase2(text);
+    }
+
+    #[test]
+    fn negative_parallel_mixed_ascii_cjk_does_not_panic() {
+        // Codex high #2: byte-counted lookahead used to split UTF-8 chars.
+        let text = "不只是A，而是中文混合內容。";
+        let _ = scan_phase2(text);
+    }
+
+    #[test]
+    fn passive_density_short_paragraph_does_not_panic() {
+        // Codex high #3 + #5: short ASCII-leading paragraphs used to panic
+        // when slicing first-N bytes.
+        let text = "A被B。\n\n中文段落以「被」字開頭，被廣泛認為是好的。";
+        let _ = scan_phase2(text);
+    }
+
+    #[test]
+    fn excessive_bold_short_ascii_paragraph_does_not_panic() {
+        // Codex high #4: short ASCII-leading paragraph slicing.
+        let text = "**A** 中文 **B** 中文 **C** 中文 **D**";
+        let _ = scan_phase2(text);
+    }
+
+    #[test]
+    fn tricolon_detects_simple_pattern() {
+        // Three consecutive identical-length 2-char spans (團結、奮鬥、創新)
+        // form a tricolon when isolated as the entire sentence content.
+        let text = "團結、奮鬥、創新。";
+        let issues = scan_phase2(text);
+        let has_tricolon = issues
+            .iter()
+            .any(|i| i.context.as_ref().is_some_and(|c| c.contains("tricolon")));
+        assert!(
+            has_tricolon,
+            "Expected tricolon detection, got {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn excessive_de_chain_reports_each_occurrence_with_correct_offset() {
+        // Codex round 2: repeated identical clauses must report distinct
+        // offsets, not collapse to the first one via s.find(clause).
+        let text = "我的他的她的它的東西，我的他的她的它的物品。";
+        let issues = scan_phase2(text);
+        let de_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("的的不休")))
+            .collect();
+        assert_eq!(
+            de_issues.len(),
+            2,
+            "Expected 2 distinct clauses, got {de_issues:?}"
+        );
+        // The two issues must have different offsets.
+        assert_ne!(de_issues[0].offset, de_issues[1].offset);
+    }
+
+    #[test]
+    fn numbered_list_marker_len_matches_multi_digit() {
+        assert_eq!(numbered_list_marker_len("1. item"), Some(2));
+        assert_eq!(numbered_list_marker_len("10. item"), Some(3));
+        assert_eq!(numbered_list_marker_len("123) item"), Some(4));
+        // No whitespace after marker → not a list item.
+        assert_eq!(numbered_list_marker_len("10.foo"), None);
+        // Letter before the period → not a list item.
+        assert_eq!(numbered_list_marker_len("a. item"), None);
+        // Missing trailing marker → not a list item.
+        assert_eq!(numbered_list_marker_len("10 item"), None);
+    }
+
+    #[test]
+    fn mechanical_bullets_detects_multi_digit_list() {
+        // cubic review: 10+ item list must still be detected.  All items use
+        // **bold** prefix — the detector should fire on the full set, not
+        // cut off at single-digit markers.
+        let mut text = String::new();
+        for i in 1..=12 {
+            text.push_str(&format!("{i}. **項目** 內容文字。\n"));
+        }
+        let issues = scan_phase2(&text);
+        let has_mechanical = issues
+            .iter()
+            .any(|i| i.context.as_ref().is_some_and(|c| c.contains("機械式列表")));
+        assert!(
+            has_mechanical,
+            "expected mechanical bullets detection across 12-item list, got {issues:?}"
+        );
+    }
+
+    #[test]
+    fn displaced_conditional_finds_late_when_sentence_starts_with_one() {
+        // Gemini round 2: a sentence that starts with 如果 but has another
+        // displaced 如果 should still flag the second one.
+        let text = "如果你來，我會走，但他不會走，如果他不想來。";
+        let issues = scan_phase2(text);
+        let has_displaced = issues
+            .iter()
+            .any(|i| i.context.as_ref().is_some_and(|c| c.contains("後置條件")));
+        assert!(
+            has_displaced,
+            "Expected displaced conditional, got {issues:?}"
+        );
     }
 
     // =======================================================================
@@ -3747,6 +4925,20 @@ mod tests {
     }
 
     #[test]
+    fn ai_formulaic_despite_ignores_challenge_before_despite() {
+        let text = "這些挑戰很多，儘管如此，團隊仍然持續改善。";
+        let issues = scan_structural(text);
+        let despite_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("公式化轉折")))
+            .collect();
+        assert!(
+            despite_issues.is_empty(),
+            "challenge before despite should not trigger formulaic despite: {despite_issues:?}"
+        );
+    }
+
+    #[test]
     fn ai_structural_list_density() {
         let mut text = String::new();
         for i in 0..10 {
@@ -3814,6 +5006,126 @@ mod tests {
     }
 
     #[test]
+    fn ai_excessive_bold_ignores_excluded_markers() {
+        let text =
+            "這是一段正常說明文字，內容足夠長但是沒有真的使用粗體標記，只有內嵌程式碼 `**a** **b** **c**` 作為示例。";
+        let code_start = text.find('`').unwrap();
+        let code_end = text.rfind('`').unwrap() + '`'.len_utf8();
+        let excluded = vec![ByteRange {
+            start: code_start,
+            end: code_end,
+        }];
+        let idx = BoundaryIndex::build(text, &excluded);
+        let mut issues = Vec::new();
+
+        scan_ai_excessive_bold(text, &excluded, &mut issues, &idx);
+
+        let bold_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| {
+                i.context
+                    .as_ref()
+                    .is_some_and(|c| c.contains("段落粗體過多"))
+            })
+            .collect();
+        assert!(
+            bold_issues.is_empty(),
+            "excluded bold markers should not trigger excessive-bold: {bold_issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_emdash_overuse_ignores_excluded_markers() {
+        let text = "`——` 這段文字——持續補充——結尾";
+        let code_start = text.find('`').unwrap();
+        let code_end = text.rfind('`').unwrap() + '`'.len_utf8();
+        let excluded = vec![ByteRange {
+            start: code_start,
+            end: code_end,
+        }];
+        let idx = BoundaryIndex::build(text, &excluded);
+        let mut issues = Vec::new();
+
+        scan_ai_emdash_overuse(text, &excluded, &mut issues, &idx);
+
+        let dash_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("破折號")))
+            .collect();
+        assert_eq!(dash_issues.len(), 1, "real dashes should trigger once");
+        assert_eq!(
+            dash_issues[0].offset,
+            text.find("文字——").unwrap() + "文字".len()
+        );
+        assert!(
+            dash_issues[0]
+                .context
+                .as_ref()
+                .is_some_and(|c| c.contains("段落內 2 處")),
+            "excluded dash should not inflate count: {dash_issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_dash_overuse_ignores_excluded_markers() {
+        let text = "`———` 這是正常段落。\n\n`———` 這也是正常段落。\n\n`———` 這仍然是正常段落。";
+        let excluded: Vec<ByteRange> = text
+            .match_indices('`')
+            .collect::<Vec<_>>()
+            .chunks(2)
+            .map(|pair| ByteRange {
+                start: pair[0].0,
+                end: pair[1].0 + '`'.len_utf8(),
+            })
+            .collect();
+        let mut issues = Vec::new();
+
+        scan_ai_dash_overuse(text, &excluded, &mut issues);
+
+        let dash_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| {
+                i.context
+                    .as_ref()
+                    .is_some_and(|c| c.contains("含 ≥3 個破折號"))
+            })
+            .collect();
+        assert!(
+            dash_issues.is_empty(),
+            "excluded code dashes should not create dash-overuse density: {dash_issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_hedging_density_ignores_excluded_markers() {
+        let text = "在某種程度上，這段正常文字提供足夠長的段落內容，用來測試密度提升不會被程式碼範例影響，並保留一個真正的提示。`從某個角度來看 可以說是`";
+        let code_start = text.find('`').unwrap();
+        let code_end = text.rfind('`').unwrap() + '`'.len_utf8();
+        let excluded = vec![ByteRange {
+            start: code_start,
+            end: code_end,
+        }];
+        let idx = BoundaryIndex::build(text, &excluded);
+        let mut issues = vec![Issue::new(
+            0,
+            "在某種程度上".len(),
+            "在某種程度上",
+            vec![],
+            IssueType::AiStyle,
+            Severity::Info,
+        )
+        .with_context("AI hedging: 在某種程度上")];
+
+        scan_ai_hedging_density(text, &excluded, &mut issues, &idx);
+
+        assert_eq!(
+            issues[0].severity,
+            Severity::Info,
+            "excluded hedging examples should not promote the real issue"
+        );
+    }
+
+    #[test]
     fn ai_zero_width_no_false_positive() {
         let text = "完全正常的文字，沒有任何零寬字元。";
         let issues = scan_structural(text);
@@ -3822,6 +5134,25 @@ mod tests {
             .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("零寬字元")))
             .collect();
         assert!(zw.is_empty(), "clean text should have no zero-width issues");
+    }
+
+    #[test]
+    fn abstract_subject_reports_more_than_first_sentence() {
+        let text = "預算的減少導致服務縮減。品質的提高意味著效率提升。";
+        let idx = BoundaryIndex::build(text, &[]);
+        let mut issues = Vec::new();
+
+        scan_trans_abstract_subject(text, &[], &mut issues, &idx);
+
+        let abstract_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("抽象主語")))
+            .collect();
+        assert_eq!(
+            abstract_issues.len(),
+            2,
+            "should report one abstract-subject issue per matching sentence"
+        );
     }
 
     #[test]

--- a/src/engine/scan/mod.rs
+++ b/src/engine/scan/mod.rs
@@ -38,6 +38,7 @@ use super::markdown::{
 };
 use super::normalize::{map_offset, normalize_nfc, Normalized};
 use super::segment::{BoundaryBitmap, Segmenter};
+use super::sentence::BoundaryIndex;
 use super::suppression::build_suppression_ranges;
 use serde::{Deserialize, Serialize};
 
@@ -118,6 +119,10 @@ pub struct ScanOutput {
     /// requested (detect_ai flag or explicit ai_score).
     #[serde(default)]
     pub ai_signature: Option<crate::engine::ai_score::AiSignatureReport>,
+    /// Translationese (翻譯腔/歐化) signature report.  Present only when
+    /// translationese detection is active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub translationese_signature: Option<crate::engine::translationese_score::TranslationeseReport>,
     /// Coverage statistics for this scan.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub coverage: Option<CoverageReport>,
@@ -430,6 +435,58 @@ fn detect_type_lineindex_and_bitmap<'a>(
     };
 
     (zh_type, line_index, bitmap)
+}
+
+/// Attach `(row, col)` coordinates to issues that fall inside a Markdown
+/// table cell.  Cells are typically small spans, so a linear scan per issue
+/// is sufficient.
+fn annotate_table_cells(
+    issues: &mut [crate::rules::ruleset::Issue],
+    cell_spans: &[super::markdown::TableCellSpan],
+) {
+    for issue in issues.iter_mut() {
+        let issue_end = issue.offset.saturating_add(issue.length);
+        for span in cell_spans {
+            if issue.offset >= span.start && issue_end <= span.end {
+                issue.table_cell = Some(crate::rules::ruleset::TableCell {
+                    row: span.row,
+                    col: span.col,
+                });
+                break;
+            }
+        }
+    }
+}
+
+/// Boost severity for issues fully contained in Markdown heading ranges.
+/// Info -> Warning, Warning -> Error.  Error stays Error.
+///
+/// Uses strict containment (not overlap) so that issues spanning heading
+/// boundaries (rare but possible across sectioned blocks) are not boosted.
+///
+/// Returns `true` when at least one issue was boosted, signalling to the
+/// caller that the severity-descending sort contract may now be violated
+/// and the issue vec should be re-sorted.
+fn boost_heading_severity(issues: &mut [Issue], heading_ranges: &[ByteRange]) -> bool {
+    let mut changed = false;
+    for issue in issues.iter_mut() {
+        let issue_end = issue.offset.saturating_add(issue.length);
+        let inside_heading = heading_ranges
+            .iter()
+            .any(|r| issue.offset >= r.start && issue_end <= r.end);
+        if inside_heading {
+            let new_sev = match issue.severity {
+                Severity::Info => Severity::Warning,
+                Severity::Warning => Severity::Error,
+                Severity::Error => Severity::Error,
+            };
+            if new_sev != issue.severity {
+                issue.severity = new_sev;
+                changed = true;
+            }
+        }
+    }
+    changed
 }
 
 /// Remap issue offsets from NFC-normalized text back to original positions.
@@ -948,6 +1005,48 @@ impl Scanner {
             remap_issues_to_original(&mut output.issues, text, &norm);
         }
 
+        // Heading severity boost for Markdown content: issues inside headings
+        // get +1 severity because heading text is high-visibility.  Gated by
+        // ProfileConfig::heading_severity_boost (default true).
+        if cfg.heading_severity_boost
+            && matches!(
+                content_type,
+                ContentType::Markdown | ContentType::MarkdownScanCode
+            )
+        {
+            let heading_ranges =
+                super::markdown::extract_heading_ranges(if nfc_changed { text } else { scan_text });
+            if !heading_ranges.is_empty()
+                && boost_heading_severity(&mut output.issues, &heading_ranges)
+            {
+                // Mutating severity can break the (offset asc, severity desc)
+                // sort contract for issues sharing the same offset.  Re-sort
+                // to preserve the documented deterministic output order.
+                output.issues.sort_by(|a, b| {
+                    a.offset
+                        .cmp(&b.offset)
+                        .then(b.severity.cmp(&a.severity))
+                        .then(a.rule_type.sort_order().cmp(&b.rule_type.sort_order()))
+                });
+            }
+        }
+
+        // Annotate issues that fall inside Markdown table cells with their
+        // (row, col) coordinates for editor integration.
+        if matches!(
+            content_type,
+            ContentType::Markdown | ContentType::MarkdownScanCode
+        ) {
+            let cell_spans = super::markdown::extract_table_cell_spans(if nfc_changed {
+                text
+            } else {
+                scan_text
+            });
+            if !cell_spans.is_empty() {
+                annotate_table_cells(&mut output.issues, &cell_spans);
+            }
+        }
+
         output
     }
 
@@ -1036,6 +1135,7 @@ impl Scanner {
                 issues: Vec::new(),
                 detected_script: ChineseType::Unknown,
                 ai_signature: None,
+                translationese_signature: None,
                 coverage: Some(CoverageReport {
                     rules_checked,
                     rules_matched: 0,
@@ -1172,6 +1272,31 @@ impl Scanner {
             grammar::scan_ai_density(text, excluded, issues, cfg.ai_threshold_multiplier);
         }
 
+        // Build sentence/paragraph boundary index for structural detectors.
+        // Computed lazily -- only when Phase 2 detectors are active.
+        let needs_boundary_index = cfg.ai_structural_patterns || cfg.translationese_detection;
+        let boundary_index = if needs_boundary_index {
+            Some(BoundaryIndex::build(text, excluded))
+        } else {
+            None
+        };
+
+        // Structural AI pattern detectors (S1-S8, V2 density).
+        // Requires sentence/paragraph boundary index.
+        if cfg.ai_structural_patterns {
+            if let Some(ref idx) = boundary_index {
+                grammar::scan_ai_structural_phase2(text, excluded, issues, idx);
+            }
+        }
+
+        // Syntactic translationese detectors (G1-G8, Y1-Y2, S3, V7, V13).
+        // Requires sentence/paragraph boundary index.
+        if cfg.translationese_detection {
+            if let Some(ref idx) = boundary_index {
+                grammar::scan_translationese_syntactic(text, excluded, issues, idx);
+            }
+        }
+
         // Fix CN quotation mark pairing with depth-based nesting:
         // well-formed quotes use character-based depth tracking; misordered
         // or all-same-char quotes fall back to positional alternation.
@@ -1198,6 +1323,18 @@ impl Scanner {
             None
         };
 
+        // Compute translationese signature when detection is active.
+        let translationese_signature = if cfg.translationese_detection {
+            crate::engine::translationese_score::compute_translationese_score_with_domain(
+                text,
+                issues,
+                excluded,
+                cfg.translationese_domain,
+            )
+        } else {
+            None
+        };
+
         let oral_density = compute_oral_density(text);
 
         // Skip O(n) line index construction when no issues found (common case).
@@ -1210,6 +1347,7 @@ impl Scanner {
                 issues: std::mem::take(issues),
                 detected_script: zh_type,
                 ai_signature,
+                translationese_signature,
                 coverage: Some(CoverageReport {
                     rules_checked,
                     rules_matched: 0,
@@ -1246,6 +1384,7 @@ impl Scanner {
             issues: std::mem::take(issues),
             detected_script: zh_type,
             ai_signature,
+            translationese_signature,
             coverage: Some(CoverageReport {
                 rules_checked,
                 rules_matched,

--- a/src/engine/scan/tests_generated.rs
+++ b/src/engine/scan/tests_generated.rs
@@ -825,15 +825,75 @@
     }
 
     #[test]
-    fn markdown_frontmatter_excluded() {
+    fn markdown_frontmatter_values_are_scanned() {
+        // Frontmatter VALUES are now scanned (key+colon and `---` fences are
+        // still excluded).  This catches lint issues in title/description
+        // that were previously hidden.
         let scanner = Scanner::new(sample_spelling_rules(), vec![]);
         let md = "---\ntitle: 軟件測試\n---\n這是正文\n";
-        let issues = scanner.scan(md).issues;
-        // "軟件" in YAML frontmatter should be excluded; "正文" is clean.
-        assert!(
-            issues.is_empty(),
-            "frontmatter content should be excluded: {issues:?}"
-        );
+        let issues = scanner
+            .scan_for_content_type(md, ContentType::Markdown, Profile::Base)
+            .issues;
+        // "軟件" in the value should now be detected.
+        assert_eq!(issues.len(), 1, "expected one issue, got: {issues:?}");
+        assert_eq!(issues[0].found, "軟件");
+    }
+
+    #[test]
+    fn markdown_table_cell_coordinates_attached() {
+        // Issues inside a Markdown table cell get (row, col) coordinates
+        // for editor integration / SARIF region output.
+        let scanner = Scanner::new(sample_spelling_rules(), vec![]);
+        let md = "| 標題 A | 標題 B |\n|---|---|\n| 正文 | 軟件 |\n";
+        let issues = scanner
+            .scan_for_content_type(md, ContentType::Markdown, Profile::Base)
+            .issues;
+        let cell_issue = issues
+            .iter()
+            .find(|i| i.found == "軟件")
+            .expect("expected 軟件 issue");
+        let cell = cell_issue
+            .table_cell
+            .expect("issue inside table cell should have table_cell metadata");
+        // The body row is row index 1 (header is 0).  Column 1 is the second cell.
+        assert_eq!(cell.row, 1, "expected body row 1, got {cell:?}");
+        assert_eq!(cell.col, 1, "expected column 1, got {cell:?}");
+    }
+
+    #[test]
+    fn heading_boost_preserves_sort_contract() {
+        // cubic review: mutating severity post-sort can leave issues out of
+        // (offset asc, severity desc) order.  Ensure the output remains
+        // sorted after the heading boost promotes Warning → Error.
+        let scanner = Scanner::new(sample_spelling_rules(), vec![]);
+        let md = "# 軟件與硬盤管理\n\n軟件是正文的一部分。\n";
+        let issues = scanner
+            .scan_for_content_type(md, ContentType::Markdown, Profile::Base)
+            .issues;
+        // Verify sort contract: offsets ascending.
+        for pair in issues.windows(2) {
+            assert!(
+                pair[0].offset <= pair[1].offset,
+                "issue offsets must be ascending, got {} > {}: {issues:?}",
+                pair[0].offset,
+                pair[1].offset
+            );
+            if pair[0].offset == pair[1].offset {
+                // Severity descending on offset tie (Error > Warning > Info).
+                assert!(
+                    pair[0].severity >= pair[1].severity,
+                    "severity must be descending on offset tie, got {:?} < {:?}",
+                    pair[0].severity,
+                    pair[1].severity
+                );
+            }
+        }
+        // The heading issues should be Error; body issues Warning.
+        let heading_issue = issues
+            .iter()
+            .find(|i| i.found == "軟件" && i.line == 1)
+            .expect("expected 軟件 in heading");
+        assert_eq!(heading_issue.severity, Severity::Error);
     }
 
     #[test]

--- a/src/engine/sentence.rs
+++ b/src/engine/sentence.rs
@@ -1,0 +1,503 @@
+// Sentence and paragraph boundary index.
+//
+// Provides reusable boundary detection for grammar checks, structural AI
+// pattern detection, and translationese scoring.  Computed once per scan,
+// shared across consumers.
+//
+// Chinese sentence boundaries: 。？！；and blank-line paragraph breaks.
+// Mixed CJK/Latin: also split on .?! followed by whitespace + uppercase.
+// Abbreviation deny-list prevents false splits (Mr., P.S., etc.).
+
+use crate::engine::excluded::{is_excluded, ByteRange};
+
+/// A sentence span identified by byte offsets into the source text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SentenceBound {
+    pub byte_start: usize,
+    pub byte_end: usize,
+}
+
+/// A paragraph span identified by byte offsets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParagraphBound {
+    pub byte_start: usize,
+    pub byte_end: usize,
+}
+
+/// Pre-computed sentence and paragraph boundary index for a document.
+#[derive(Debug)]
+pub struct BoundaryIndex {
+    pub sentences: Vec<SentenceBound>,
+    pub paragraphs: Vec<ParagraphBound>,
+}
+
+// CJK terminal punctuation that always ends a sentence.
+const CJK_TERMINATORS: &[char] = &['。', '！', '？'];
+
+// Semicolons act as sentence boundaries in Chinese text.
+const CJK_SOFT_TERMINATORS: &[char] = &['；'];
+
+// Latin terminal punctuation -- only triggers a split when followed by
+// whitespace + uppercase letter (to avoid splitting on abbreviations).
+const LATIN_TERMINATORS: &[char] = &['.', '?', '!'];
+
+// Abbreviation patterns that end with '.' but are NOT sentence boundaries.
+// Checked by looking at the text preceding a Latin period.
+const ABBREVIATION_SUFFIXES: &[&str] = &[
+    "Mr", "Mrs", "Ms", "Dr", "Prof", "Jr", "Sr", "vs", "etc", "i.e", "e.g", "P.S", "p.s", "cf",
+    "al", "Vol", "No", "Fig", "Eq", "Rev",
+];
+
+impl BoundaryIndex {
+    /// Build a boundary index for the given text, respecting exclusion zones.
+    ///
+    /// Exclusion zones (code blocks, URLs, etc.) are treated as opaque:
+    /// boundaries inside them are ignored, and entering/leaving an exclusion
+    /// zone acts as a sentence break.
+    pub fn build(text: &str, excluded: &[ByteRange]) -> Self {
+        let sentences = build_sentences(text, excluded);
+        let paragraphs = build_paragraphs(text);
+        BoundaryIndex {
+            sentences,
+            paragraphs,
+        }
+    }
+
+    /// Find the sentence containing byte offset `pos`.
+    /// Returns None if pos is outside all sentences (e.g. inside an exclusion zone).
+    pub fn sentence_at(&self, pos: usize) -> Option<&SentenceBound> {
+        self.sentences
+            .iter()
+            .find(|s| s.byte_start <= pos && pos < s.byte_end)
+    }
+
+    /// Find the paragraph containing byte offset `pos`.
+    pub fn paragraph_at(&self, pos: usize) -> Option<&ParagraphBound> {
+        self.paragraphs
+            .iter()
+            .find(|p| p.byte_start <= pos && pos < p.byte_end)
+    }
+
+    /// Return all sentences within a given paragraph.
+    pub fn sentences_in_paragraph(&self, para: &ParagraphBound) -> Vec<&SentenceBound> {
+        self.sentences
+            .iter()
+            .filter(|s| s.byte_start >= para.byte_start && s.byte_end <= para.byte_end)
+            .collect()
+    }
+
+    /// Extract the text slice for a sentence bound.
+    pub fn sentence_text<'a>(&self, text: &'a str, s: &SentenceBound) -> &'a str {
+        &text[s.byte_start..s.byte_end]
+    }
+
+    /// Extract the text slice for a paragraph bound.
+    pub fn paragraph_text<'a>(&self, text: &'a str, p: &ParagraphBound) -> &'a str {
+        &text[p.byte_start..p.byte_end]
+    }
+}
+
+/// Build sentence boundaries from text.
+fn build_sentences(text: &str, excluded: &[ByteRange]) -> Vec<SentenceBound> {
+    let mut sentences = Vec::new();
+    let mut sent_start: usize = 0;
+    let mut in_excluded = false;
+    let mut last_was_content = false;
+
+    let bytes = text.as_bytes();
+    let mut byte_offset = 0;
+
+    for ch in text.chars() {
+        let ch_len = ch.len_utf8();
+        let ch_end = byte_offset + ch_len;
+
+        // Handle exclusion zone transitions.
+        let currently_excluded = is_excluded(byte_offset, ch_end, excluded);
+        if currently_excluded && !in_excluded {
+            // Entering exclusion: flush current sentence if non-empty.
+            if last_was_content && byte_offset > sent_start {
+                push_sentence(&mut sentences, text, sent_start, byte_offset);
+            }
+            in_excluded = true;
+            last_was_content = false;
+        } else if !currently_excluded && in_excluded {
+            // Leaving exclusion: start new sentence.
+            sent_start = byte_offset;
+            in_excluded = false;
+        }
+
+        if currently_excluded {
+            byte_offset = ch_end;
+            continue;
+        }
+
+        let paragraph_break_len = if ch == '\r'
+            && ch_end + 2 < text.len()
+            && bytes[ch_end] == b'\n'
+            && bytes[ch_end + 1] == b'\r'
+            && bytes[ch_end + 2] == b'\n'
+        {
+            Some(4)
+        } else if ch == '\n' && ch_end < text.len() && bytes[ch_end] == b'\n' {
+            Some(2)
+        } else {
+            None
+        };
+
+        // Paragraph break: \n\n or \r\n\r\n.
+        if let Some(break_len) = paragraph_break_len {
+            if last_was_content && byte_offset > sent_start {
+                push_sentence(&mut sentences, text, sent_start, byte_offset);
+            }
+            last_was_content = false;
+            sent_start = byte_offset + break_len;
+            byte_offset = ch_end;
+            continue;
+        }
+
+        // CJK hard terminators: always split.
+        if CJK_TERMINATORS.contains(&ch) || CJK_SOFT_TERMINATORS.contains(&ch) {
+            // Include the terminator in the sentence.
+            push_sentence(&mut sentences, text, sent_start, ch_end);
+            sent_start = ch_end;
+            last_was_content = false;
+            byte_offset = ch_end;
+            continue;
+        }
+
+        // Latin terminators: split only if followed by whitespace + uppercase.
+        if LATIN_TERMINATORS.contains(&ch) && is_latin_sentence_end(text, byte_offset, ch_end) {
+            push_sentence(&mut sentences, text, sent_start, ch_end);
+            sent_start = ch_end;
+            last_was_content = false;
+            byte_offset = ch_end;
+            continue;
+        }
+
+        if !ch.is_whitespace() {
+            last_was_content = true;
+        }
+
+        byte_offset = ch_end;
+    }
+
+    // Flush trailing sentence.
+    if sent_start < text.len() && last_was_content {
+        push_sentence(&mut sentences, text, sent_start, text.len());
+    }
+
+    sentences
+}
+
+/// Check if a Latin period/question/exclamation at `dot_start..dot_end` is a
+/// real sentence boundary (followed by whitespace + uppercase letter) and not
+/// an abbreviation.
+fn is_latin_sentence_end(text: &str, dot_start: usize, dot_end: usize) -> bool {
+    let rest = &text[dot_end..];
+    let mut chars = rest.chars().peekable();
+
+    // Must be followed by at least one whitespace char; consume the full
+    // whitespace run (not just the first) so "home.  He" still splits.
+    match chars.peek() {
+        Some(c) if c.is_whitespace() => {}
+        _ => return false,
+    }
+    while let Some(c) = chars.peek() {
+        if c.is_whitespace() {
+            chars.next();
+        } else {
+            break;
+        }
+    }
+
+    // Then an uppercase letter (or CJK, which counts as a new sentence).
+    match chars.next() {
+        Some(c) if c.is_uppercase() || is_cjk(c) => {}
+        _ => return false,
+    }
+
+    // Check abbreviation deny-list: look at text before the dot.
+    // Word boundary = start of text, ASCII whitespace/punct, or CJK char
+    // (no ASCII letter immediately before the abbreviation).
+    let before = &text[..dot_start];
+    for abbr in ABBREVIATION_SUFFIXES {
+        if before.ends_with(abbr) {
+            let prefix_start = before.len() - abbr.len();
+            if prefix_start == 0 {
+                return false;
+            }
+            let prev_char = before[..prefix_start].chars().next_back();
+            match prev_char {
+                None => return false,
+                Some(c) if !c.is_alphanumeric() => return false,
+                Some(c) if is_cjk(c) => return false,
+                _ => {}
+            }
+        }
+    }
+
+    true
+}
+
+/// Push a sentence if it contains any non-whitespace content.
+fn push_sentence(sentences: &mut Vec<SentenceBound>, text: &str, start: usize, end: usize) {
+    // Trim leading whitespace from the sentence start.
+    let trimmed_start = text[start..end]
+        .char_indices()
+        .find(|(_, c)| !c.is_whitespace())
+        .map(|(i, _)| start + i)
+        .unwrap_or(end);
+
+    if trimmed_start < end {
+        // Trim trailing whitespace.
+        let trimmed_end = text[trimmed_start..end]
+            .char_indices()
+            .rev()
+            .find(|(_, c)| !c.is_whitespace())
+            .map(|(i, c)| trimmed_start + i + c.len_utf8())
+            .unwrap_or(trimmed_start);
+
+        if trimmed_start < trimmed_end {
+            sentences.push(SentenceBound {
+                byte_start: trimmed_start,
+                byte_end: trimmed_end,
+            });
+        }
+    }
+}
+
+/// Build paragraph boundaries from text (split on \n\n or \r\n\r\n).
+fn build_paragraphs(text: &str) -> Vec<ParagraphBound> {
+    let mut result = Vec::new();
+    let mut prev = 0;
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        // CRLF paragraph break.
+        if i + 3 < len
+            && bytes[i] == b'\r'
+            && bytes[i + 1] == b'\n'
+            && bytes[i + 2] == b'\r'
+            && bytes[i + 3] == b'\n'
+        {
+            push_paragraph(&mut result, text, prev, i);
+            prev = i + 4;
+            i = prev;
+            continue;
+        }
+        // LF paragraph break.
+        if i + 1 < len && bytes[i] == b'\n' && bytes[i + 1] == b'\n' {
+            push_paragraph(&mut result, text, prev, i);
+            prev = i + 2;
+            i = prev;
+            continue;
+        }
+        i += 1;
+    }
+
+    // Trailing paragraph.
+    if prev < text.len() {
+        push_paragraph(&mut result, text, prev, text.len());
+    }
+
+    result
+}
+
+fn push_paragraph(paragraphs: &mut Vec<ParagraphBound>, text: &str, start: usize, end: usize) {
+    let slice = &text[start..end];
+    if slice.chars().any(|c| !c.is_whitespace()) {
+        paragraphs.push(ParagraphBound {
+            byte_start: start,
+            byte_end: end,
+        });
+    }
+}
+
+fn is_cjk(ch: char) -> bool {
+    matches!(ch as u32,
+        0x4E00..=0x9FFF |  // CJK Unified Ideographs
+        0x3400..=0x4DBF |  // CJK Extension A
+        0x2E80..=0x2EFF |  // CJK Radicals Supplement
+        0x3000..=0x303F |  // CJK Symbols and Punctuation
+        0xF900..=0xFAFF    // CJK Compatibility Ideographs
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bounds(text: &str) -> BoundaryIndex {
+        BoundaryIndex::build(text, &[])
+    }
+
+    #[test]
+    fn cjk_sentence_split() {
+        let text = "你好。世界！測試？完成";
+        let idx = bounds(text);
+        assert_eq!(idx.sentences.len(), 4);
+        assert_eq!(
+            &text[idx.sentences[0].byte_start..idx.sentences[0].byte_end],
+            "你好。"
+        );
+        assert_eq!(
+            &text[idx.sentences[1].byte_start..idx.sentences[1].byte_end],
+            "世界！"
+        );
+        assert_eq!(
+            &text[idx.sentences[2].byte_start..idx.sentences[2].byte_end],
+            "測試？"
+        );
+        assert_eq!(
+            &text[idx.sentences[3].byte_start..idx.sentences[3].byte_end],
+            "完成"
+        );
+    }
+
+    #[test]
+    fn semicolon_splits_sentence() {
+        let text = "前半句；後半句。";
+        let idx = bounds(text);
+        assert_eq!(idx.sentences.len(), 2);
+        assert_eq!(
+            &text[idx.sentences[0].byte_start..idx.sentences[0].byte_end],
+            "前半句；"
+        );
+        assert_eq!(
+            &text[idx.sentences[1].byte_start..idx.sentences[1].byte_end],
+            "後半句。"
+        );
+    }
+
+    #[test]
+    fn paragraph_break_splits_sentence() {
+        let text = "第一段\n\n第二段";
+        let idx = bounds(text);
+        assert_eq!(idx.sentences.len(), 2);
+        assert_eq!(idx.paragraphs.len(), 2);
+    }
+
+    #[test]
+    fn latin_sentence_with_abbreviation() {
+        let text = "Mr. Smith went home. He is here.";
+        let idx = bounds(text);
+        // "Mr." should NOT split. "home." should split. "here." should end.
+        assert_eq!(idx.sentences.len(), 2);
+        assert!(idx.sentences[0].byte_end <= text.find("He").unwrap());
+    }
+
+    #[test]
+    fn latin_sentence_splits_across_multiple_whitespaces() {
+        // cubic review: must handle multiple spaces / tabs / newlines
+        // between the terminator and the next capital letter.
+        let text = "Alice went home.  Bob followed.";
+        let idx = bounds(text);
+        assert_eq!(idx.sentences.len(), 2);
+
+        let text = "One ended.\n\nTwo started.";
+        let idx = bounds(text);
+        assert!(idx.sentences.len() >= 2);
+
+        let text = "Foo.\tBar is next.";
+        let idx = bounds(text);
+        assert_eq!(idx.sentences.len(), 2);
+    }
+
+    #[test]
+    fn mixed_cjk_latin() {
+        let text = "這是測試。This is a test. 第二句。";
+        let idx = bounds(text);
+        assert_eq!(idx.sentences.len(), 3);
+    }
+
+    #[test]
+    fn cjk_adjacent_abbreviation_not_a_sentence_end() {
+        // Codex/Gemini review: abbreviation with CJK preceding char should
+        // still be recognized as an abbreviation, not a sentence end.
+        let text = "這由Mr. Smith處理過。";
+        let idx = bounds(text);
+        // "Mr." should NOT split. Whole thing is one sentence.
+        assert_eq!(idx.sentences.len(), 1);
+    }
+
+    #[test]
+    fn exclusion_zone_breaks_sentence() {
+        let text = "前面的文字`code`後面的文字。";
+        // Simulate exclusion zone over `code` (bytes for the backtick-wrapped part).
+        let code_start = text.find('`').unwrap();
+        let code_end = text.rfind('`').unwrap() + 1;
+        let excluded = vec![ByteRange {
+            start: code_start,
+            end: code_end,
+        }];
+        let idx = BoundaryIndex::build(text, &excluded);
+        // Should have at least 2 sentence fragments.
+        assert!(idx.sentences.len() >= 2);
+    }
+
+    #[test]
+    fn empty_text() {
+        let idx = bounds("");
+        assert!(idx.sentences.is_empty());
+        assert!(idx.paragraphs.is_empty());
+    }
+
+    #[test]
+    fn whitespace_only() {
+        let idx = bounds("   \n\n   ");
+        assert!(idx.sentences.is_empty());
+    }
+
+    #[test]
+    fn sentence_at_lookup() {
+        let text = "第一句。第二句。";
+        let idx = bounds(text);
+        let s1_mid = text.find('一').unwrap();
+        let found = idx.sentence_at(s1_mid);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().byte_start, 0);
+    }
+
+    #[test]
+    fn paragraph_at_lookup() {
+        let text = "段落一\n\n段落二";
+        let idx = bounds(text);
+        let p2_start = text.rfind('段').unwrap();
+        let found = idx.paragraph_at(p2_start);
+        assert!(found.is_some());
+        assert!(found.unwrap().byte_start > 0);
+    }
+
+    #[test]
+    fn sentences_in_paragraph() {
+        let text = "第一句。第二句。\n\n第三句。";
+        let idx = bounds(text);
+        assert_eq!(idx.paragraphs.len(), 2);
+        let sents = idx.sentences_in_paragraph(&idx.paragraphs[0]);
+        assert_eq!(sents.len(), 2);
+        let sents2 = idx.sentences_in_paragraph(&idx.paragraphs[1]);
+        assert_eq!(sents2.len(), 1);
+    }
+
+    #[test]
+    fn crlf_paragraph_break() {
+        let text = "段落一\r\n\r\n段落二";
+        let idx = bounds(text);
+        assert_eq!(idx.paragraphs.len(), 2);
+    }
+
+    #[test]
+    fn crlf_paragraph_break_splits_sentence() {
+        let text = "第一段\r\n\r\n展望未來";
+        let idx = bounds(text);
+        assert_eq!(idx.sentences.len(), 2);
+        assert_eq!(idx.paragraphs.len(), 2);
+
+        let first_para_sents = idx.sentences_in_paragraph(&idx.paragraphs[0]);
+        let second_para_sents = idx.sentences_in_paragraph(&idx.paragraphs[1]);
+        assert_eq!(first_para_sents.len(), 1);
+        assert_eq!(second_para_sents.len(), 1);
+    }
+}

--- a/src/engine/translationese_score.rs
+++ b/src/engine/translationese_score.rs
@@ -1,0 +1,644 @@
+// Document-level translationese (翻譯腔/歐化) scoring.
+//
+// Orthogonal to AI signature scoring. A translated technical manual is
+// 歐化 but not AI-generated. Separate output struct, separate threshold.
+//
+// Composite score from:
+// 1. Passive voice density (被 per 1000 chars)
+// 2. 的-chain depth (max consecutive 的 without comma)
+// 3. Weak-verb decomposition count (進行/加以/予以 + nominalized verb)
+// 4. Pronoun density (他/她/它/他們 per 1000 chars)
+// 5. Translationese issue density (from per-occurrence detectors)
+
+use serde::{Deserialize, Serialize};
+
+use crate::engine::excluded::{is_excluded, ByteRange};
+use crate::rules::ruleset::{Issue, IssueType};
+
+/// A single translationese signal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranslationeseMarker {
+    pub signal: String,
+    pub count: usize,
+    pub density: f32,
+    pub threshold: f32,
+}
+
+/// Aggregated translationese scoring report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranslationeseReport {
+    /// Composite score: 0.0 = natural zh-TW, 1.0 = heavily westernized.
+    pub score: f32,
+    /// Individual signal breakdown.
+    pub markers: Vec<TranslationeseMarker>,
+    /// Top contributing signal descriptions.
+    pub top_signals: Vec<String>,
+    /// Maximum consecutive 的 count found in any clause.
+    pub max_de_chain: usize,
+    /// Domain calibration profile applied.  Defaults to `General` when
+    /// deserializing reports from older cache entries that predate the
+    /// per-domain calibration feature, so a single missing field does not
+    /// invalidate the entire cache file.
+    #[serde(default)]
+    pub domain: TranslationeseDomain,
+}
+
+/// Per-domain calibration profile for translationese scoring.
+///
+/// Different document genres tolerate different rates of westernized
+/// constructions: technical writing accepts more passive voice and weak-verb
+/// nominalization than literary prose; news writing falls between the two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TranslationeseDomain {
+    /// Balanced thresholds suitable for general prose.
+    #[default]
+    General,
+    /// Technical writing — looser thresholds for passive voice and weak verbs.
+    Technical,
+    /// Literary writing — tighter thresholds, especially for de-chains.
+    Literary,
+    /// News writing — moderate thresholds, favors active voice.
+    News,
+}
+
+impl TranslationeseDomain {
+    /// Human-readable name (matches the CLI flag value).
+    pub fn name(self) -> &'static str {
+        match self {
+            TranslationeseDomain::General => "general",
+            TranslationeseDomain::Technical => "technical",
+            TranslationeseDomain::Literary => "literary",
+            TranslationeseDomain::News => "news",
+        }
+    }
+
+    /// Strict parse from string.  Returns `None` on unrecognized input.
+    pub fn from_str_strict(s: &str) -> Option<Self> {
+        match s {
+            "general" => Some(TranslationeseDomain::General),
+            "technical" => Some(TranslationeseDomain::Technical),
+            "literary" => Some(TranslationeseDomain::Literary),
+            "news" => Some(TranslationeseDomain::News),
+            _ => None,
+        }
+    }
+
+    /// Per-domain threshold table.
+    pub fn thresholds(self) -> DomainThresholds {
+        match self {
+            TranslationeseDomain::General => DomainThresholds {
+                passive: 3.0,
+                weak_verb: 2.0,
+                pronoun: 8.0,
+                de_chain: 4,
+                issue_density: 5.0,
+            },
+            TranslationeseDomain::Technical => DomainThresholds {
+                // Technical prose tolerates more passive voice (specs commonly
+                // use "被定義為", "被觀察到") and weak-verb nominalization
+                // ("進行測試", "加以分析" are idiomatic in lab reports).
+                passive: 6.0,
+                weak_verb: 4.0,
+                pronoun: 6.0,
+                de_chain: 5,
+                issue_density: 7.0,
+            },
+            TranslationeseDomain::Literary => DomainThresholds {
+                // Literary prose should be lean: tighter thresholds catch the
+                // patterns 余光中 specifically warned against.
+                passive: 1.5,
+                weak_verb: 1.0,
+                pronoun: 10.0,
+                de_chain: 3,
+                issue_density: 3.0,
+            },
+            TranslationeseDomain::News => DomainThresholds {
+                // News writing favors active voice and concise sentences.
+                passive: 2.5,
+                weak_verb: 2.0,
+                pronoun: 7.0,
+                de_chain: 4,
+                issue_density: 4.0,
+            },
+        }
+    }
+}
+
+/// Per-signal threshold values for a given domain calibration.
+#[derive(Debug, Clone, Copy)]
+pub struct DomainThresholds {
+    pub passive: f32,
+    pub weak_verb: f32,
+    pub pronoun: f32,
+    pub de_chain: usize,
+    pub issue_density: f32,
+}
+
+// Per-signal weights — kept constant across domains; only thresholds shift.
+const PASSIVE_WEIGHT: f32 = 1.0;
+const WEAK_VERB_WEIGHT: f32 = 0.8;
+const PRONOUN_WEIGHT: f32 = 0.6;
+const DE_CHAIN_WEIGHT: f32 = 0.7;
+const ISSUE_DENSITY_WEIGHT: f32 = 0.5;
+
+// Weak-verb prefixes that signal bureaucratic nominalization.
+const WEAK_VERB_PREFIXES: &[&str] = &["進行", "加以", "予以", "展開", "作出", "給予", "提供"];
+
+// Objects that, when following a weak-verb prefix, confirm the pattern is a
+// real bureaucratic nominalization ("進行討論" → "討論") rather than a
+// literal standalone use of the prefix ("進行" alone = "in progress").
+// Kept in sync with src/engine/scan/grammar.rs NOMINALIZED_VERBS /
+// VERBOSE_ACTION_OBJECTS so the scoring signal aligns with per-issue flagging.
+const WEAK_VERB_OBJECTS: &[&str] = &[
+    "討論", "分析", "研究", "調查", "測試", "開發", "設計", "評估", "檢查", "審查", "修改", "更新",
+    "比較", "溝通", "合作", "訓練", "處理", "管理", "規劃", "改善", "調整", "整合", "驗證", "觀察",
+    "監控", "維護", "決定", "回應", "貢獻", "改變", "承諾", "解釋", "判斷", "選擇", "反應", "讓步",
+    "保證", "回答", "犧牲", "努力", "支援", "協助", "檢討", "投票", "改革", "發表", "發展",
+];
+
+// Pronouns to count for density.  Multi-character forms come first so the
+// longest-match scan does not double-count "他們" as "他" + "他們".
+const PRONOUNS: &[&str] = &["他們", "她們", "他", "她", "它"];
+
+/// Compute translationese report from text and post-scan issues using the
+/// general-purpose threshold table.  Returns None for texts too short
+/// (< 200 chars).  Convenience wrapper for callers that don't need
+/// domain-specific calibration.
+pub fn compute_translationese_score(
+    text: &str,
+    issues: &[Issue],
+    excluded: &[ByteRange],
+) -> Option<TranslationeseReport> {
+    compute_translationese_score_with_domain(text, issues, excluded, TranslationeseDomain::General)
+}
+
+/// Compute translationese report with a specified domain calibration.
+///
+/// Different domains use different threshold tables — see
+/// [`TranslationeseDomain::thresholds`] for the values.
+pub fn compute_translationese_score_with_domain(
+    text: &str,
+    issues: &[Issue],
+    excluded: &[ByteRange],
+    domain: TranslationeseDomain,
+) -> Option<TranslationeseReport> {
+    let char_count = {
+        let mut count = 0usize;
+        let mut byte_offset = 0usize;
+        for ch in text.chars() {
+            let ch_len = ch.len_utf8();
+            if !is_excluded(byte_offset, byte_offset + ch_len, excluded) {
+                count += 1;
+            }
+            byte_offset += ch_len;
+        }
+        count
+    };
+    if char_count < 200 {
+        return None;
+    }
+    let text_k = char_count as f32 / 1000.0;
+    let t = domain.thresholds();
+
+    let mut markers = Vec::new();
+    let mut weighted_sum: f32 = 0.0;
+    let mut total_weight: f32 = 0.0;
+
+    // Record a signal: push its marker, and add its excess contribution to
+    // the weighted sum when `over_threshold` is true.  Excess is clamped at
+    // 2x the threshold to prevent a single runaway signal from dominating.
+    let mut record = |signal: &str,
+                      count: usize,
+                      density: f32,
+                      threshold: f32,
+                      weight: f32,
+                      over_threshold: bool| {
+        markers.push(TranslationeseMarker {
+            signal: signal.into(),
+            count,
+            density,
+            threshold,
+        });
+        if over_threshold {
+            // Excess is capped at 2.0; floor at 0.1 so an exact threshold
+            // hit still contributes (matches the >= semantics for de-chain).
+            let raw_excess = ((density - threshold) / threshold).min(2.0);
+            let excess = raw_excess.max(0.1);
+            weighted_sum += excess * weight;
+        }
+        total_weight += weight;
+    };
+
+    // Signal 1: passive voice density (被 count).
+    let passive_count = count_pattern(text, "被", excluded);
+    let passive_density = passive_count as f32 / text_k;
+    record(
+        "被動語態",
+        passive_count,
+        passive_density,
+        t.passive,
+        PASSIVE_WEIGHT,
+        passive_density > t.passive,
+    );
+
+    // Signal 2: 的-chain depth.  Uses >= so that exactly hitting the
+    // threshold still contributes.
+    let max_de_chain = compute_max_de_chain(text, excluded);
+    record(
+        "的字鏈",
+        max_de_chain,
+        max_de_chain as f32,
+        t.de_chain as f32,
+        DE_CHAIN_WEIGHT,
+        max_de_chain >= t.de_chain,
+    );
+
+    // Signal 3: weak-verb decomposition density.
+    let weak_verb_count = count_weak_verbs(text, excluded);
+    let weak_verb_density = weak_verb_count as f32 / text_k;
+    record(
+        "弱動詞分解",
+        weak_verb_count,
+        weak_verb_density,
+        t.weak_verb,
+        WEAK_VERB_WEIGHT,
+        weak_verb_density > t.weak_verb,
+    );
+
+    // Signal 4: pronoun density. Use longest-match scan to avoid counting
+    // 他們 as both 他 and 他們.
+    let pronoun_count = count_longest_match(text, PRONOUNS, excluded);
+    let pronoun_density = pronoun_count as f32 / text_k;
+    record(
+        "代詞密度",
+        pronoun_count,
+        pronoun_density,
+        t.pronoun,
+        PRONOUN_WEIGHT,
+        pronoun_density > t.pronoun,
+    );
+
+    // Signal 5: translationese issue density from per-occurrence detectors.
+    let trans_issue_count = issues
+        .iter()
+        .filter(|i| i.rule_type == IssueType::Translationese)
+        .count();
+    let trans_density = trans_issue_count as f32 / text_k;
+    record(
+        "翻譯腔偵測",
+        trans_issue_count,
+        trans_density,
+        t.issue_density,
+        ISSUE_DENSITY_WEIGHT,
+        trans_density > t.issue_density,
+    );
+
+    // Composite score: weighted average of excess ratios, clamped to [0, 1].
+    let score = if total_weight > 0.0 {
+        (weighted_sum / total_weight).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+
+    // Top signals: sorted by contribution. Use >= so an exact threshold hit
+    // (e.g. exactly 4 consecutive 的) appears in the listing.
+    let mut top: Vec<(String, f32)> = markers
+        .iter()
+        .filter(|m| m.density >= m.threshold)
+        .map(|m| {
+            let excess = ((m.density - m.threshold) / m.threshold).clamp(0.1, 2.0);
+            (
+                format!(
+                    "{}: {:.1}/千字 (閾值 {:.1})",
+                    m.signal, m.density, m.threshold
+                ),
+                excess,
+            )
+        })
+        .collect();
+    top.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    let top_signals: Vec<String> = top.into_iter().take(3).map(|(s, _)| s).collect();
+
+    Some(TranslationeseReport {
+        score,
+        markers,
+        top_signals,
+        max_de_chain,
+        domain,
+    })
+}
+
+/// Count occurrences of any pattern in the list, using longest-match-first
+/// semantics so that "他們" does not get counted as "他" + "他們".
+/// Patterns are tried in input order at each position; callers should
+/// pre-sort longest-first.
+fn count_longest_match(text: &str, patterns: &[&str], excluded: &[ByteRange]) -> usize {
+    let bytes = text.as_bytes();
+    let mut count = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let mut matched_len = 0;
+        for pat in patterns {
+            let plen = pat.len();
+            if i + plen <= bytes.len() && &bytes[i..i + plen] == pat.as_bytes() {
+                matched_len = plen;
+                break;
+            }
+        }
+        if matched_len > 0 {
+            if !is_excluded(i, i + matched_len, excluded) {
+                count += 1;
+            }
+            i += matched_len;
+        } else {
+            // Advance by one codepoint to keep i on a char boundary.
+            let ch_len = text[i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+            i += ch_len;
+        }
+    }
+    count
+}
+
+/// Count non-overlapping occurrences of a pattern, excluding exclusion zones.
+fn count_pattern(text: &str, pattern: &str, excluded: &[ByteRange]) -> usize {
+    let pattern_len = pattern.len();
+    let mut count = 0;
+    let mut start = 0;
+    while let Some(pos) = text[start..].find(pattern) {
+        let abs = start + pos;
+        if !is_excluded(abs, abs + pattern_len, excluded) {
+            count += 1;
+        }
+        start = abs + pattern_len;
+    }
+    count
+}
+
+/// Find the maximum consecutive 的 count in any clause (split on commas).
+fn compute_max_de_chain(text: &str, excluded: &[ByteRange]) -> usize {
+    let mut max_chain = 0;
+    let mut current_chain = 0;
+    let mut byte_offset = 0;
+
+    for ch in text.chars() {
+        let ch_len = ch.len_utf8();
+        let in_excluded = is_excluded(byte_offset, byte_offset + ch_len, excluded);
+        byte_offset += ch_len;
+
+        if in_excluded {
+            current_chain = 0;
+            continue;
+        }
+
+        if ch == '的' {
+            current_chain += 1;
+            max_chain = max_chain.max(current_chain);
+        } else if matches!(ch, '，' | ',' | '。' | '！' | '？' | '；' | '\n') {
+            current_chain = 0;
+        }
+        // Non-的 CJK characters don't reset the chain -- we're counting
+        // 的 in patterns like X的Y的Z的W.
+    }
+    max_chain
+}
+
+/// Count weak-verb + nominalized-verb compounds (e.g. "進行討論", "加以分析").
+///
+/// Bare prefix hits without a known object do not count: 進行 alone means
+/// "in progress" and is fine on its own; the translationese signal fires
+/// only when the prefix precedes a nominalized verb.
+fn count_weak_verbs(text: &str, excluded: &[ByteRange]) -> usize {
+    let mut count = 0;
+    for &prefix in WEAK_VERB_PREFIXES {
+        let prefix_len = prefix.len();
+        let mut start = 0;
+        while let Some(pos) = text[start..].find(prefix) {
+            let abs = start + pos;
+            let after = abs + prefix_len;
+            start = after;
+            if is_excluded(abs, after, excluded) {
+                continue;
+            }
+            // Require a known weak-verb object starting at `after`.
+            // Look ahead up to 4 chars (handles optional 了/的 between
+            // prefix and object, e.g. "進行了討論").
+            let lookahead_end = text[after..]
+                .char_indices()
+                .nth(4)
+                .map(|(i, _)| after + i)
+                .unwrap_or(text.len());
+            let window = &text[after..lookahead_end];
+            // Both prefix and object must be outside excluded zones; an
+            // object span buried inside a code fence does not count.
+            if WEAK_VERB_OBJECTS.iter().any(|obj| {
+                window.find(obj).is_some_and(|obj_pos| {
+                    let obj_start = after + obj_pos;
+                    !is_excluded(obj_start, obj_start + obj.len(), excluded)
+                })
+            }) {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn score(text: &str) -> Option<TranslationeseReport> {
+        compute_translationese_score(text, &[], &[])
+    }
+
+    #[test]
+    fn short_text_returns_none() {
+        assert!(score("短文").is_none());
+    }
+
+    #[test]
+    fn clean_text_scores_low() {
+        // Natural zh-TW prose, no translationese patterns (>200 chars).
+        let text = "台灣是一個美麗的島嶼。\
+                    這裡有豐富的自然景觀和人文風情。\
+                    山脈縱貫全島，海岸線變化多端。\
+                    人民友善熱情，文化多元而包容。\
+                    教育普及，科技產業蓬勃發展。\
+                    美食種類繁多，從夜市小吃到精緻料理。\
+                    四季分明的氣候適合各種戶外活動。\
+                    歷史悠久的寺廟和現代建築並存。\
+                    交通便利，鐵路和公路網路完善。\
+                    醫療水準在亞洲名列前茅。\
+                    城市規劃相當完善，公共運輸覆蓋率極高。\
+                    都市農業開始萌芽，屋頂菜園數量逐年增加。\
+                    博物館藏品豐富，展覽內容定期更新。\
+                    圖書館遍布各區，閱讀風氣盛行。\
+                    社區活動中心提供多樣化課程。\
+                    夜市文化獨樹一幟，吸引各國觀光客。\
+                    傳統節慶慶典保留完整的民俗活動。\
+                    志工服務精神深入民間組織運作。\
+                    環保意識逐年提升，垃圾分類成效顯著。\
+                    全民健保制度獲得國際社會高度肯定。";
+        let report = score(text);
+        assert!(report.is_some());
+        let r = report.unwrap();
+        assert!(
+            r.score < 0.3,
+            "Clean text should score low, got {}",
+            r.score
+        );
+    }
+
+    #[test]
+    fn westernized_text_scores_higher() {
+        // Text with heavy translationese markers (>200 chars).
+        let text = "在這個過程中，問題被充分地討論了。\
+                    她被認為是最優秀的人選。\
+                    政府進行了全面的調查和分析。\
+                    他們對這個問題加以研究和討論。\
+                    這個方案被廣泛認為是最好的選擇。\
+                    她被授予了最高榮譽的獎項。\
+                    他們進行了長時間的討論和辯論。\
+                    結果被公布在最新的報告中。\
+                    這些措施被視為非常必要的步驟。\
+                    整個計劃被認為是成功的典範。\
+                    他們的努力被證明是值得的。\
+                    她被選為年度最佳員工的候選人。\
+                    這項政策被認為對經濟發展有重大影響。\
+                    他們進行了深入的市場分析和評估。\
+                    這個決定被視為具有里程碑意義的轉折。\
+                    她被指派負責整個專案的執行工作。\
+                    他們加以整合並予以重新規劃。\
+                    這些成果被廣泛報導和討論。\
+                    她的表現被評價為出色的領導典範。\
+                    他們對問題進行了全面的檢討和改善。";
+        let report = score(text);
+        assert!(report.is_some());
+        let r = report.unwrap();
+        assert!(
+            r.score > 0.0,
+            "Westernized text should score higher, got {}",
+            r.score
+        );
+    }
+
+    #[test]
+    fn technical_domain_scores_lower_than_literary_on_passive_text() {
+        // Identical text scored under technical (lenient) vs literary (strict)
+        // domains: literary should always score >= technical for the same
+        // passive-heavy input.
+        let text = "他被認為是優秀的學者。她被視為傑出領袖。整個項目被認為是成功的。\
+                    她被授予了榮譽。她被選為主席。他們進行了討論。\
+                    她被廣泛認為是優秀的人選。他被任命為主管。\
+                    他被指派負責這個專案。他們進行了完整的評估。\
+                    這個方案被認為是最好的選擇。他們予以支援。\
+                    這些成果被報導出來。她被評為年度典範。\
+                    他被推舉為代表。整體計畫被視為一大進展。\
+                    研究結果被廣泛發表並被多次引用。這個提案被多方採納。\
+                    他們的努力被證明是值得的。她被選為年度最佳員工。\
+                    這項政策被認為對發展有重大影響。\
+                    她被授予最高榮譽。他被廣泛認可為傑出領袖。"; // >200 chars
+        let r_tech = compute_translationese_score_with_domain(
+            text,
+            &[],
+            &[],
+            TranslationeseDomain::Technical,
+        )
+        .expect("technical score");
+        let r_lit = compute_translationese_score_with_domain(
+            text,
+            &[],
+            &[],
+            TranslationeseDomain::Literary,
+        )
+        .expect("literary score");
+        assert!(
+            r_lit.score >= r_tech.score,
+            "literary ({}) should score >= technical ({}) on passive-heavy text",
+            r_lit.score,
+            r_tech.score
+        );
+        assert_eq!(r_tech.domain, TranslationeseDomain::Technical);
+        assert_eq!(r_lit.domain, TranslationeseDomain::Literary);
+    }
+
+    #[test]
+    fn domain_from_str_round_trips() {
+        for d in [
+            TranslationeseDomain::General,
+            TranslationeseDomain::Technical,
+            TranslationeseDomain::Literary,
+            TranslationeseDomain::News,
+        ] {
+            assert_eq!(TranslationeseDomain::from_str_strict(d.name()), Some(d));
+        }
+        assert_eq!(TranslationeseDomain::from_str_strict("invalid"), None);
+    }
+
+    #[test]
+    fn de_chain_detection() {
+        let chain = compute_max_de_chain("這是我的朋友的妹妹的同學的書", &[]);
+        assert_eq!(chain, 4);
+    }
+
+    #[test]
+    fn passive_count_basic() {
+        let count = count_pattern("他被打了，她也被罵了", "被", &[]);
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn weak_verb_count_basic() {
+        let count = count_weak_verbs("我們進行討論並加以分析", &[]);
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn weak_verb_count_rejects_bare_prefix() {
+        // "進行" alone = "in progress" (legitimate standalone use); must
+        // not inflate the weak-verb signal.
+        assert_eq!(count_weak_verbs("專案正在進行，尚未完成。", &[]), 0);
+        // "進行中" likewise has no nominalized object.
+        assert_eq!(count_weak_verbs("工作進行中，請稍候。", &[]), 0);
+    }
+
+    #[test]
+    fn weak_verb_count_allows_intervening_particles() {
+        // "進行了討論" — the 了 between prefix and object should still count.
+        assert_eq!(count_weak_verbs("他們進行了討論並加以了分析", &[]), 2);
+    }
+
+    #[test]
+    fn weak_verb_count_skips_excluded_object() {
+        // Codex round 4: an object span inside an exclusion zone (e.g. inline
+        // code) must not count toward the weak-verb signal even when the
+        // prefix itself is in clean prose.
+        let text = "他們進行討論之後，我們進行討論再次回顧。";
+        // Mark the second "討論" (bytes 33..39 in this string) as excluded.
+        let second_obj_start = text.rfind("討論").unwrap();
+        let excluded = vec![ByteRange {
+            start: second_obj_start,
+            end: second_obj_start + "討論".len(),
+        }];
+        // Without the fix: count = 2.  With the fix: only the unexcluded
+        // first occurrence counts → 1.
+        assert_eq!(count_weak_verbs(text, &excluded), 1);
+    }
+
+    #[test]
+    fn report_deserializes_without_domain_field() {
+        // Codex round 4: pre-domain cache entries must still load.  Without
+        // serde(default) on `domain`, a single old entry would cause
+        // load_entries() to discard the whole cache file.
+        let json = r#"{
+            "score": 0.5,
+            "markers": [],
+            "top_signals": [],
+            "max_de_chain": 0
+        }"#;
+        let r: TranslationeseReport =
+            serde_json::from_str(json).expect("missing domain field must default, not fail");
+        assert_eq!(r.domain, TranslationeseDomain::General);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,8 @@ fn main() -> Result<()> {
     let mut relaxed = false;
     let mut detect_ai = false;
     let mut detect_translationese = false;
+    let mut translationese_domain =
+        zhtw_mcp::engine::translationese_score::TranslationeseDomain::General;
     let mut ai_threshold_multiplier: f32 = 1.0;
     let mut baseline_path: Option<PathBuf> = None;
     let mut update_baseline = false;
@@ -239,6 +241,28 @@ fn main() -> Result<()> {
                         }
                         "--detect-translationese" => {
                             detect_translationese = true;
+                        }
+                        "--translationese-domain" => {
+                            // Per-domain threshold calibration for the
+                            // translationese score: general | technical |
+                            // literary | news.
+                            if let Some(next) = args.get(i + 1) {
+                                match zhtw_mcp::engine::translationese_score::TranslationeseDomain::from_str_strict(next) {
+                                    Some(d) => {
+                                        translationese_domain = d;
+                                        i += 1;
+                                    }
+                                    None => {
+                                        anyhow::bail!(
+                                            "unknown --translationese-domain value '{next}' (expected: general|technical|literary|news)"
+                                        );
+                                    }
+                                }
+                            } else {
+                                anyhow::bail!(
+                                    "--translationese-domain requires a value (general|technical|literary|news)"
+                                );
+                            }
                         }
                         "--detect-style" => {
                             // Combined shorthand: enable both AI filler and
@@ -568,6 +592,7 @@ fn main() -> Result<()> {
             relaxed: eff_relaxed,
             detect_ai,
             detect_translationese,
+            translationese_domain,
             ai_threshold_multiplier,
             tm_path: Some(eff_tm_path),
             telemetry,
@@ -657,6 +682,8 @@ struct CliFileOutput {
     fixes_skipped: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     ai_signature: Option<zhtw_mcp::engine::ai_score::AiSignatureReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    translationese_signature: Option<zhtw_mcp::engine::translationese_score::TranslationeseReport>,
 }
 
 #[derive(serde::Serialize)]
@@ -759,6 +786,7 @@ struct LintBatchParams<'a> {
     relaxed: bool,
     detect_ai: bool,
     detect_translationese: bool,
+    translationese_domain: zhtw_mcp::engine::translationese_score::TranslationeseDomain,
     ai_threshold_multiplier: f32,
     tm_path: Option<PathBuf>,
     telemetry: bool,
@@ -788,6 +816,7 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
     if params.detect_translationese {
         cfg.translationese_detection = true;
     }
+    cfg.translationese_domain = params.translationese_domain;
 
     // Build scanner once for all files, merging overrides + active packs.
     let ruleset = zhtw_mcp::rules::loader::load_embedded_ruleset()?;
@@ -895,6 +924,7 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
             fix_mode: fix_mode_str.clone(),
             detect_ai: params.detect_ai,
             detect_translationese: cfg.translationese_detection,
+            translationese_domain: cfg.translationese_domain.name().to_owned(),
             ai_threshold: format!("{:.1}", params.ai_threshold_multiplier),
         };
 
@@ -1027,6 +1057,7 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
             output.detected_script.name()
         };
         let mut ai_signature = output.ai_signature;
+        let mut translationese_signature = output.translationese_signature;
         let mut issues = output.issues;
 
         // Tier 2: local disambiguation.
@@ -1116,6 +1147,9 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
                 || cfg.ai_structural_patterns;
             if ai_active {
                 ai_signature = rescan_output.ai_signature;
+            }
+            if cfg.translationese_detection {
+                translationese_signature = rescan_output.translationese_signature;
             }
             let mut rescan = rescan_output.issues;
             if let Some(ref fix) = fix_result {
@@ -1242,6 +1276,7 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
                     fixes_applied: fix_result.as_ref().map(|f| f.applied),
                     fixes_skipped: fix_result.as_ref().map(|f| f.skipped),
                     ai_signature: ai_signature.clone(),
+                    translationese_signature: translationese_signature.clone(),
                 };
                 if multi {
                     all_file_results.push(output);
@@ -1320,6 +1355,23 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
                     };
                     eprintln!(
                         "{prefix}{}AI score:{} {:.2} ({level})",
+                        c.cyan, c.reset, sig.score
+                    );
+                    for signal in &sig.top_signals {
+                        eprintln!("  {}{signal}{}", c.dim, c.reset);
+                    }
+                }
+                // Translationese signature score (when computed).
+                if let Some(ref sig) = translationese_signature {
+                    let level = if sig.score >= 0.7 {
+                        "high"
+                    } else if sig.score >= 0.4 {
+                        "medium"
+                    } else {
+                        "low"
+                    };
+                    eprintln!(
+                        "{prefix}{}翻譯腔 score:{} {:.2} ({level})",
                         c.cyan, c.reset, sig.score
                     );
                     for signal in &sig.top_signals {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -392,6 +392,10 @@ impl Server {
         // translationese_detection (53.x initiative).
         let detect_ai_opt = args.get("detect_ai").and_then(|v| v.as_bool());
         let detect_translationese_opt = args.get("detect_translationese").and_then(|v| v.as_bool());
+        let translationese_domain_opt = args
+            .get("translationese_domain")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
         let ai_threshold = optional_str_validated(args, "ai_threshold", &id)?;
 
         let relaxed = args
@@ -439,6 +443,21 @@ impl Server {
         if let Some(b) = detect_translationese_opt {
             cfg.translationese_detection = b;
         }
+        if let Some(domain_str) = &translationese_domain_opt {
+            match crate::engine::translationese_score::TranslationeseDomain::from_str_strict(
+                domain_str,
+            ) {
+                Some(d) => cfg.translationese_domain = d,
+                None => {
+                    return Err(param_error(
+                        &id,
+                        "translationese_domain",
+                        domain_str,
+                        &["general", "technical", "literary", "news"],
+                    ));
+                }
+            }
+        }
         // Resolve effective AI detection: explicit arg wins over profile default.
         // All four AI sub-flags move as a unit — enabling detection turns them
         // all on, disabling turns them all off.
@@ -479,6 +498,7 @@ impl Server {
                 let oral_density = output.oral_density;
                 let quality_flags = &output.quality_flags;
                 let ai_signature = output.ai_signature;
+                let translationese_signature = output.translationese_signature;
                 let mut issues = output.issues;
                 let scanner_hit_count = issues.len();
                 if let Some(st) = stance {
@@ -562,6 +582,7 @@ impl Server {
                     oral_density,
                     quality_flags,
                     ai_signature: ai_signature.as_ref(),
+                    translationese_signature: translationese_signature.as_ref(),
                     tm_suppressed,
                     sampling_stats,
                     disambig_stats,
@@ -687,6 +708,7 @@ impl Server {
                 let oral_density = rescan_out.oral_density;
                 let quality_flags = &rescan_out.quality_flags;
                 let ai_signature = rescan_out.ai_signature;
+                let translationese_signature = rescan_out.translationese_signature;
                 let mut remaining_issues = rescan_out.issues;
                 if let Some(st) = stance {
                     filter_by_stance(&mut remaining_issues, st);
@@ -778,6 +800,7 @@ impl Server {
                     oral_density,
                     quality_flags,
                     ai_signature: ai_signature.as_ref(),
+                    translationese_signature: translationese_signature.as_ref(),
                     tm_suppressed,
                     sampling_stats,
                     disambig_stats,
@@ -935,6 +958,7 @@ fn zhtw_known_params() -> &'static [&'static str] {
             "output",
             "detect_ai",
             "detect_translationese",
+            "translationese_domain",
             "ai_threshold",
             "include_telemetry",
             "include_stats",
@@ -957,6 +981,7 @@ fn zhtw_known_params() -> &'static [&'static str] {
             "output",
             "detect_ai",
             "detect_translationese",
+            "translationese_domain",
             "ai_threshold",
             "include_telemetry",
             "include_stats",
@@ -1659,6 +1684,8 @@ struct FullOutput<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     ai_signature: Option<&'a crate::engine::ai_score::AiSignatureReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    translationese_signature: Option<&'a crate::engine::translationese_score::TranslationeseReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     telemetry: Option<&'a TelemetryMetrics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     summary_metrics: Option<&'a SummaryMetrics>,
@@ -1693,6 +1720,8 @@ struct CompactOutput<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     ai_signature: Option<&'a crate::engine::ai_score::AiSignatureReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    translationese_signature: Option<&'a crate::engine::translationese_score::TranslationeseReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     telemetry: Option<&'a TelemetryMetrics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     summary_metrics: Option<&'a SummaryMetrics>,
@@ -1714,6 +1743,8 @@ struct SummaryOutput<'a> {
     quality_flags: Option<&'a [String]>,
     #[serde(skip_serializing_if = "Option::is_none")]
     ai_signature: Option<&'a crate::engine::ai_score::AiSignatureReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    translationese_signature: Option<&'a crate::engine::translationese_score::TranslationeseReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
     telemetry: Option<&'a TelemetryMetrics>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1775,6 +1806,7 @@ struct CheckOutputParams<'a> {
     oral_density: Option<f32>,
     quality_flags: &'a [String],
     ai_signature: Option<&'a crate::engine::ai_score::AiSignatureReport>,
+    translationese_signature: Option<&'a crate::engine::translationese_score::TranslationeseReport>,
     /// Number of issues downgraded by translation memory.
     tm_suppressed: usize,
     /// Sampling budget usage statistics.
@@ -1917,6 +1949,7 @@ fn build_check_output(params: &CheckOutputParams<'_>) -> CallToolResult {
                 oral_density: params.oral_density,
                 quality_flags,
                 ai_signature: params.ai_signature,
+                translationese_signature: params.translationese_signature,
                 telemetry: params.telemetry.as_ref(),
                 summary_metrics: stats_metrics.as_ref(),
             };
@@ -1945,6 +1978,7 @@ fn build_check_output(params: &CheckOutputParams<'_>) -> CallToolResult {
                 oral_density: params.oral_density,
                 quality_flags,
                 ai_signature: params.ai_signature,
+                translationese_signature: params.translationese_signature,
                 telemetry: params.telemetry.as_ref(),
                 summary_metrics: stats_metrics.as_ref(),
             };
@@ -1974,6 +2008,7 @@ fn build_check_output(params: &CheckOutputParams<'_>) -> CallToolResult {
                 oral_density: params.oral_density,
                 quality_flags,
                 ai_signature: params.ai_signature,
+                translationese_signature: params.translationese_signature,
                 telemetry: params.telemetry.as_ref(),
                 summary_metrics: stats_metrics.as_ref(),
             };
@@ -2476,6 +2511,11 @@ fn tool_definitions() -> Vec<ToolDef> {
                 "type": "boolean",
                 "description": "Enable translationese (翻譯腔 / 歐化) detection — Europeanized syntax and calques from the dewesternise checklist. Default: on. Orthogonal to detect_ai; reported separately."
             }));
+            props.insert("translationese_domain".into(), json!({
+                "type": "string",
+                "enum": ["general", "technical", "literary", "news"],
+                "description": "Per-domain calibration for translationese scoring thresholds. 'technical' tolerates more passive voice and weak-verb nominalization; 'literary' is the strictest; 'news' favors active voice. Default: 'general'."
+            }));
             props.insert("ai_threshold".into(), json!({
                 "type": "string",
                 "enum": ["low", "medium", "high"],
@@ -2766,6 +2806,7 @@ mod tests {
             oral_density: None,
             quality_flags: None,
             ai_signature: None,
+            translationese_signature: None,
             telemetry: None,
             summary_metrics: None,
         };
@@ -2883,6 +2924,39 @@ mod tests {
         assert_eq!(output["accepted"], true);
         assert_eq!(output["gate"]["enabled"], false);
         assert_eq!(output["text"], "");
+    }
+
+    #[test]
+    fn known_params_list_includes_all_documented_params() {
+        // Round-4 validation regression: every parameter that the schema
+        // documents must also be in zhtw_known_params(), or the strict
+        // validator rejects valid clients with -32602.
+        let known: std::collections::HashSet<&str> = zhtw_known_params().iter().copied().collect();
+        for p in [
+            "text",
+            "fix_mode",
+            "max_errors",
+            "max_warnings",
+            "profile",
+            "relaxed",
+            "content_type",
+            "political_stance",
+            "ignore_terms",
+            "explain",
+            "fix_output",
+            "output",
+            "detect_ai",
+            "detect_translationese",
+            "translationese_domain",
+            "ai_threshold",
+            "include_telemetry",
+            "include_stats",
+        ] {
+            assert!(
+                known.contains(p),
+                "documented parameter {p:?} missing from zhtw_known_params()",
+            );
+        }
     }
 
     #[test]

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -55,6 +55,10 @@ pub struct ProfileConfig {
     /// from the dewesternise checklist.  Orthogonal to `ai_filler_detection`:
     /// a translated manual is 歐化 but not AI-generated.
     pub translationese_detection: bool,
+    /// Domain calibration for translationese scoring thresholds.
+    /// `General` uses balanced thresholds; `Technical`/`Literary`/`News`
+    /// shift the per-signal thresholds to match domain norms.
+    pub translationese_domain: crate::engine::translationese_score::TranslationeseDomain,
     /// Enable AI semantic safety word detection (意味著 disambiguation,
     /// copula avoidance, passive voice overuse).
     pub ai_semantic_safety: bool,
@@ -69,6 +73,10 @@ pub struct ProfileConfig {
     /// 1.0 = balanced (default), >1.0 = conservative (fewer false positives).
     /// Maps to ai_threshold levels: low=0.5, medium=1.0, high=1.5.
     pub ai_threshold_multiplier: f32,
+    /// When true (default for Markdown content), boost severity by one level
+    /// for issues whose span is fully contained inside a heading.  Headings
+    /// are higher-visibility than body prose and warrant stricter treatment.
+    pub heading_severity_boost: bool,
     /// Political stance sub-profile. Controls which PoliticalColoring rules fire.
     pub political_stance: PoliticalStance,
     /// When true, skip line/col computation (byte offsets only).
@@ -135,6 +143,9 @@ impl Profile {
                 ai_density_detection: false,
                 ai_structural_patterns: false,
                 ai_threshold_multiplier: 1.0,
+                translationese_domain:
+                    crate::engine::translationese_score::TranslationeseDomain::General,
+                heading_severity_boost: true,
                 political_stance: PoliticalStance::RocCentric,
                 offset_only: false,
             },
@@ -155,6 +166,9 @@ impl Profile {
                 ai_density_detection: false,
                 ai_structural_patterns: false,
                 ai_threshold_multiplier: 1.0,
+                translationese_domain:
+                    crate::engine::translationese_score::TranslationeseDomain::General,
+                heading_severity_boost: true,
                 political_stance: PoliticalStance::RocCentric,
                 offset_only: false,
             },
@@ -535,6 +549,19 @@ pub struct Issue {
     /// overlap resolution.
     #[serde(skip)]
     pub(crate) spelling_rule_idx: Option<usize>,
+    /// Markdown table cell coordinates `(row, column)` (0-based) when the
+    /// issue falls inside a Markdown table cell.  Useful for editor
+    /// integrations and SARIF region output.  `None` when not in a table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub table_cell: Option<TableCell>,
+}
+
+/// Markdown table cell coordinates: `(row, column)` are 0-based, with row 0
+/// being the header row (or row 1 if the table has no separator).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TableCell {
+    pub row: usize,
+    pub col: usize,
 }
 
 impl Issue {
@@ -564,6 +591,7 @@ impl Issue {
             tier2_outcome: Tier2Outcome::NotEligible,
             llm_judged: false,
             spelling_rule_idx: None,
+            table_cell: None,
         }
     }
 
@@ -598,6 +626,7 @@ impl Issue {
             tier2_outcome: Tier2Outcome::NotEligible,
             llm_judged: false,
             spelling_rule_idx: Some(rule_idx),
+            table_cell: None,
         }
     }
 


### PR DESCRIPTION
- Sentence/paragraph boundary index (BoundaryIndex) — shared infrastructure now consumed by all Phase 2 detectors and the translationese scorer.
- Nine structural AI detectors: tricolon, negative parallel, formulaic section endings, mechanical bullets, excessive bold, em-dash overuse, formulaic despite, false ranges, hedging density.
- Nine syntactic translationese detectors: passive density (with technical-zh-TW whitelist), abstract subject, displaced conditionals, pronoun overuse, copula+classifier inflation, 的/地 confusion, excessive de-chain, disyllabic 地 redundancy, tense marker overuse.
- Translationese composite scoring orthogonal to AI scoring, with per-domain calibration (general/technical/literary/news) selectable via --translationese-domain CLI and translationese_domain MCP arg.
- Heading severity boost gated by ProfileConfig::heading_severity_boost (skips frontmatter to avoid pulldown-cmark setext false positives).
- Markdown table cell coordinates attached to issues for editor integration.
- YAML frontmatter values are now scannable (only key+colon and --- fences excluded) — catches lint issues in title/description that blanket exclusion previously hid.

Fixer behaviour falls out of existing single-vs-multi suggestion semantics: V7 地 drop and Y2 的/地 fixes auto-apply; structural detectors emit empty suggestions and are report-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared sentence/paragraph boundary index and introduces structural style detectors plus domain-calibrated translationese scoring. Also adds CLI/MCP controls, scans YAML frontmatter values, and improves editor integration.

- **New Features**
  - Shared BoundaryIndex for sentence/paragraph splits; used by all Phase 2 detectors and translationese scoring.
  - Structural style detectors: tricolon, negative parallel, formulaic section endings, mechanical bullets, excessive bold, em-dash overuse, formulaic “儘管/雖然…”, false numeric ranges, hedging density.
  - Translationese (歐化) detectors and composite score; orthogonal to AI score with per-domain thresholds (general/technical/literary/news).
  - CLI: --detect-translationese and --translationese-domain; MCP: translationese_domain arg.
  - Output: new translationese_signature in ScanOutput and cache.
  - Markdown: scan YAML frontmatter values (keys and --- fences still excluded); add table cell coordinates to issues.
  - Severity: optional heading severity boost via ProfileConfig::heading_severity_boost (skips frontmatter). Fixers auto-apply for V7 地 drop and Y2 的/地; structural detectors are report-only.

- **Migration**
  - If you enable translationese checks, pass --detect-translationese and choose --translationese-domain general|technical|literary|news (or set translationese_domain via MCP).
  - Consumers of scan output should handle the new translationese_signature field.
  - Expect new lint findings from YAML frontmatter titles/descriptions; update ignores only if needed.
  - Set ProfileConfig.heading_severity_boost=false to disable the Markdown heading severity bump.

<sup>Written for commit 8ecd18e34013cc348f96522475f13f03e70f8725. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

