### PR TITLE
Improve Chrome extension scan packaging and filtering

### DIFF
--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -67,7 +67,16 @@ jobs:
           cp -R extension/dist/snippets "$EXTENSION_PACKAGE_DIR"/dist/
         fi
         cp extension/icons/icon-{16,32,48,128}.png "$EXTENSION_PACKAGE_DIR"/icons/
-        (cd extension-package && zip -r "../$EXTENSION_ZIP" zhtw-mcp-extension)
+        (cd "$EXTENSION_PACKAGE_DIR" && zip -r "../../$EXTENSION_ZIP" .)
+
+    - name: Validate distributable extension
+      run: |
+        test -f "$EXTENSION_PACKAGE_DIR/manifest.json"
+        test -f "$EXTENSION_PACKAGE_DIR/dist/zhtw_mcp_wasm.js"
+        test -f "$EXTENSION_PACKAGE_DIR/dist/zhtw_mcp_wasm_bg.wasm"
+        unzip -l "$EXTENSION_ZIP" manifest.json
+        unzip -l "$EXTENSION_ZIP" dist/zhtw_mcp_wasm.js
+        unzip -l "$EXTENSION_ZIP" dist/zhtw_mcp_wasm_bg.wasm
 
     - name: Upload unpacked extension artifact
       uses: actions/upload-artifact@v4

--- a/extension/README.md
+++ b/extension/README.md
@@ -24,6 +24,8 @@ The generated files are written to `extension/dist/`.
 
 The extension uses `activeTab`, so it scans only after a user gesture and only for the current active tab. Badge counts include warning and error issues; info-level findings appear in the popup but do not increase the badge.
 
+The extension applies browser-only result filtering for common page markup patterns such as `...` and `:::`. These filters do not change the Rust CLI, MCP server, or WASM scanner rules.
+
 ## Test JavaScript helpers
 
 ```sh

--- a/extension/build-wasm.sh
+++ b/extension/build-wasm.sh
@@ -8,6 +8,27 @@ if ! command -v wasm-pack >/dev/null 2>&1; then
   exit 1
 fi
 
+rustup_path_dir=
+cleanup() {
+  if [ -n "$rustup_path_dir" ]; then
+    rm -rf "$rustup_path_dir"
+  fi
+}
+trap cleanup EXIT
+
+if command -v rustup >/dev/null 2>&1; then
+  rustup_rustc="$(rustup which rustc 2>/dev/null || true)"
+  rustup_cargo="$(rustup which cargo 2>/dev/null || true)"
+  if [ -n "$rustup_rustc" ] && [ -n "$rustup_cargo" ]; then
+    rustup target add wasm32-unknown-unknown
+    rustup_path_dir="$(mktemp -d)"
+    ln -s "$rustup_rustc" "$rustup_path_dir/rustc"
+    ln -s "$rustup_cargo" "$rustup_path_dir/cargo"
+    PATH="$rustup_path_dir:$PATH"
+    export PATH
+  fi
+fi
+
 if [ ! -f src/engine/s2t_data.rs ]; then
   python3 scripts/gen-s2t-tables.py
   rustfmt src/engine/s2t_data.rs

--- a/extension/src/scanner.js
+++ b/extension/src/scanner.js
@@ -1,13 +1,14 @@
+import initWasm, { scan_text as scanTextWasm } from "../dist/zhtw_mcp_wasm.js";
+
 let wasmModulePromise;
 let scanTextBinding;
 
 async function loadWasmModule() {
   if (!wasmModulePromise) {
     wasmModulePromise = (async () => {
-      const wasmModule = await import("../dist/zhtw_mcp_wasm.js");
       const wasmUrl = chrome.runtime.getURL("dist/zhtw_mcp_wasm_bg.wasm");
-      await wasmModule.default(wasmUrl);
-      scanTextBinding = wasmModule.scan_text;
+      await initWasm(wasmUrl);
+      scanTextBinding = scanTextWasm;
     })();
   }
   try {

--- a/extension/src/scanner.js
+++ b/extension/src/scanner.js
@@ -1,7 +1,10 @@
+import "./shared.js";
 import initWasm, { scan_text as scanTextWasm } from "../dist/zhtw_mcp_wasm.js";
 
 let wasmModulePromise;
 let scanTextBinding;
+
+const { filterExtensionIgnoredIssues } = globalThis.ZhtwExtensionShared;
 
 async function loadWasmModule() {
   if (!wasmModulePromise) {
@@ -30,5 +33,5 @@ export async function scanText(text, options = {}) {
   }
 
   const resultJson = scanTextBinding(text, JSON.stringify(options));
-  return JSON.parse(resultJson);
+  return filterExtensionIgnoredIssues(JSON.parse(resultJson), text);
 }

--- a/extension/src/shared.js
+++ b/extension/src/shared.js
@@ -45,6 +45,105 @@
     ).length;
   }
 
+  const extensionIgnoredPatterns = ["...", ":::"];
+
+  function filterExtensionIgnoredIssues(scanResult, text = "") {
+    const issues = Array.isArray(scanResult?.issues) ? scanResult.issues : [];
+    const ignoredRanges = ignoredPatternRanges(text);
+    const filteredIssues = issues
+      .map(normalizeDisplayIssue)
+      .filter(
+        (issue) =>
+          !shouldIgnoreExtensionIssue(issue, ignoredRanges) &&
+          !shouldHideExtensionIssue(issue),
+      );
+
+    return {
+      ...scanResult,
+      issues: filteredIssues,
+      issue_count: filteredIssues.length,
+      badge_count: countBadgeIssues(filteredIssues),
+      severity_counts: countSeverityIssues(filteredIssues),
+    };
+  }
+
+  function shouldIgnoreExtensionIssue(issue, ignoredRanges = []) {
+    const found = issue?.found || "";
+    if (extensionIgnoredPatterns.includes(found)) {
+      return true;
+    }
+
+    const offset = Number(issue?.offset);
+    const length = Number(issue?.length);
+    if (!Number.isFinite(offset) || !Number.isFinite(length) || length <= 0) {
+      return false;
+    }
+    const end = offset + length;
+
+    return ignoredRanges.some(
+      (range) => offset < range.byteEnd && end > range.byteStart,
+    );
+  }
+
+  function shouldHideExtensionIssue(issue) {
+    return issue?.severity === "info" && !hasVisibleSuggestion(issue);
+  }
+
+  function hasVisibleSuggestion(issue) {
+    return Array.isArray(issue?.suggestions)
+      ? issue.suggestions.some((suggestion) => String(suggestion).trim())
+      : false;
+  }
+
+  function normalizeDisplayIssue(issue) {
+    return {
+      ...issue,
+      suggestions: Array.isArray(issue?.suggestions)
+        ? issue.suggestions.filter((suggestion) => String(suggestion).trim())
+        : [],
+    };
+  }
+
+  function ignoredPatternRanges(text) {
+    if (!text) {
+      return [];
+    }
+
+    const ranges = [];
+    for (const pattern of extensionIgnoredPatterns) {
+      let searchStart = 0;
+      while (searchStart < text.length) {
+        const index = text.indexOf(pattern, searchStart);
+        if (index < 0) {
+          break;
+        }
+        const byteStart = utf8ByteLength(text.slice(0, index));
+        ranges.push({
+          byteStart,
+          byteEnd: byteStart + utf8ByteLength(pattern),
+        });
+        searchStart = index + pattern.length;
+      }
+    }
+    return ranges;
+  }
+
+  function countSeverityIssues(issues) {
+    return issues.reduce(
+      (counts, issue) => {
+        if (issue.severity === "error") {
+          counts.error += 1;
+        } else if (issue.severity === "warning") {
+          counts.warning += 1;
+        } else {
+          counts.info += 1;
+        }
+        return counts;
+      },
+      { info: 0, warning: 0, error: 0 },
+    );
+  }
+
   function formatBadgeText(count) {
     if (!count) {
       return "";
@@ -68,8 +167,11 @@
   return {
     byteOffsetToCodeUnit,
     countBadgeIssues,
+    filterExtensionIgnoredIssues,
     formatBadgeText,
     normalizeIssue,
+    shouldIgnoreExtensionIssue,
+    shouldHideExtensionIssue,
     utf8ByteLength,
   };
 });

--- a/extension/test/shared.test.js
+++ b/extension/test/shared.test.js
@@ -4,7 +4,10 @@ const assert = require("node:assert/strict");
 const {
   byteOffsetToCodeUnit,
   countBadgeIssues,
+  filterExtensionIgnoredIssues,
   formatBadgeText,
+  shouldHideExtensionIssue,
+  shouldIgnoreExtensionIssue,
   utf8ByteLength,
 } = require("../src/shared.js");
 
@@ -31,4 +34,120 @@ test("badge text is capped for dense pages", () => {
   assert.equal(formatBadgeText(0), "");
   assert.equal(formatBadgeText(7), "7");
   assert.equal(formatBadgeText(125), "99+");
+});
+
+test("extension ignores configured punctuation-only patterns", () => {
+  const text = "流程...結束\n::: note\n這個軟件";
+  const scanResult = {
+    issues: [
+      {
+        offset: utf8ByteLength("流程"),
+        length: utf8ByteLength("..."),
+        found: "...",
+        severity: "warning",
+      },
+      {
+        offset: utf8ByteLength("流程...結束\n"),
+        length: utf8ByteLength(":::"),
+        found: ":::",
+        severity: "error",
+      },
+      {
+        offset: utf8ByteLength("流程...結束\n::: note\n這個"),
+        length: utf8ByteLength("軟件"),
+        found: "軟件",
+        severity: "warning",
+      },
+      {
+        offset: 0,
+        length: utf8ByteLength("流程"),
+        found: "流程",
+        severity: "info",
+      },
+    ],
+    issue_count: 4,
+    badge_count: 3,
+    severity_counts: { info: 1, warning: 2, error: 1 },
+  };
+
+  const filtered = filterExtensionIgnoredIssues(scanResult, text);
+
+  assert.deepEqual(
+    filtered.issues.map((issue) => issue.found),
+    ["軟件"],
+  );
+  assert.equal(filtered.issue_count, 1);
+  assert.equal(filtered.badge_count, 1);
+  assert.deepEqual(filtered.severity_counts, { info: 0, warning: 1, error: 0 });
+});
+
+test("extension ignores scanner issues inside configured pattern ranges", () => {
+  const issue = {
+    offset: utf8ByteLength("提示"),
+    length: utf8ByteLength(":"),
+    found: ":",
+    severity: "warning",
+  };
+
+  const filtered = filterExtensionIgnoredIssues(
+    { issues: [issue] },
+    "提示:::內容",
+  );
+
+  assert.equal(shouldIgnoreExtensionIssue({ found: ":::" }), true);
+  assert.equal(filtered.issues.length, 0);
+});
+
+test("extension hides info issues without visible suggestions", () => {
+  const scanResult = {
+    issues: [
+      {
+        offset: 0,
+        length: utf8ByteLength("可以說是"),
+        found: "可以說是",
+        suggestions: [""],
+        rule_type: "ai_style",
+        severity: "info",
+      },
+      {
+        offset: utf8ByteLength("可以說是中文"),
+        length: 0,
+        found: "",
+        suggestions: [" "],
+        rule_type: "punctuation",
+        severity: "info",
+      },
+      {
+        offset: 0,
+        length: utf8ByteLength("軟件"),
+        found: "軟件",
+        suggestions: ["軟體"],
+        rule_type: "cross_strait",
+        severity: "warning",
+      },
+      {
+        offset: 0,
+        length: utf8ByteLength("刪"),
+        found: "刪",
+        suggestions: [""],
+        rule_type: "grammar",
+        severity: "warning",
+      },
+    ],
+    issue_count: 4,
+    badge_count: 2,
+    severity_counts: { info: 2, warning: 2, error: 0 },
+  };
+
+  const filtered = filterExtensionIgnoredIssues(scanResult, "可以說是中文軟件");
+
+  assert.equal(shouldHideExtensionIssue(scanResult.issues[0]), true);
+  assert.deepEqual(
+    filtered.issues.map((issue) => issue.found),
+    ["軟件", "刪"],
+  );
+  assert.deepEqual(filtered.issues[1].suggestions, []);
+  assert.equal(filtered.issue_count, 2);
+  assert.equal(filtered.badge_count, 2);
+  assert.deepEqual(filtered.severity_counts, { info: 0, warning: 2, error: 0 });
 });


### PR DESCRIPTION
## 變更摘要

本 PR 延續 Chrome extension 掃描器的後續整理，重點放在擴充套件打包流程、WASM 載入穩定性，以及只影響 extension UI 的掃描結果過濾。這些變更不調整 Rust CLI / MCP server 的核心掃描規則；新增的忽略與顯示邏輯都限制在 `extension/` 的瀏覽器端結果處理。

## 詳細變更紀錄

### Chrome extension WASM 打包流程

- 調整 `extension/build-wasm.sh`，讓 WASM 建置輸出更符合 Chrome extension 載入需求。
- 針對 Chrome package layout 修正 CI 流程，確保 extension package 包含必要檔案並排除不應放入發佈包的內容。
- 改善 `extension/src/scanner.js` 的 WASM 載入流程，使用 extension 內的 `dist/zhtw_mcp_wasm_bg.wasm` 路徑，降低載入 glue code / wasm binary 時的路徑錯誤風險。

### Extension 專屬掃描結果過濾

- 新增 `filterExtensionIgnoredIssues()`，在 WASM 掃描結果回傳到 popup / highlight 前進行 extension-only 後處理。
- 忽略網頁與文件常見 markup pattern：
  - `...`
  - `:::`
- 若 scanner 回報的是上述 pattern 內的局部 issue，例如 `:::` 內單一 `:`，也會一併忽略，避免 popup 與頁面 highlight 出現雜訊。
- 過濾後會重新計算：
  - `issues`
  - `issue_count`
  - `badge_count`
  - `severity_counts`

### Popup INFO 顯示修正

- 修正 popup 會顯示空白 INFO 卡片的問題。
- 根因是部分 INFO issue 代表「刪除 / 插入 / 結構提示」類型，WASM 可能回傳 `suggestions: [""]` 或空白字串；原本 popup 只檢查 `suggestions.length`，導致畫面顯示 `ai_style →`、`punctuation →` 這類沒有實質訊息的項目。
- 現在 extension 端會：
  - 清除空白 suggestion。
  - 隱藏 `severity === "info"` 且沒有任何可見建議的 issue。
  - 保留 warning / error，即使 suggestion 為空也不自動隱藏，避免漏掉較高嚴重性的訊息。

### 文件與測試

- 更新 `extension/README.md`，說明 extension 有 browser-only result filtering，且不影響 Rust CLI / MCP server / WASM scanner 規則。
- 擴充 `extension/test/shared.test.js`，覆蓋：
  - `...` / `:::` pattern 忽略。
  - pattern 範圍內局部 issue 忽略。
  - 無可見建議的 INFO issue 隱藏。
  - 過濾後 badge / severity 統計重算。

## 驗證

```sh
npm test --prefix extension
```

測試結果：6 tests passed。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Chrome MV3 extension with stable WASM packaging/loading and browser-only result filtering to reduce UI noise. CLI/MCP scan rules are unchanged.

- New Features
  - Add MV3 extension (background, content, popup, styles, icons) with highlights, badge counts, profiles, and a relaxed mode.
  - Package the scanner to browser WASM via `extension/build-wasm.sh` using `wasm-pack`; loader resolves `dist/zhtw_mcp_wasm_bg.wasm` via `chrome.runtime.getURL`.
  - Add extension-only `filterExtensionIgnoredIssues()` to ignore `...`, `:::` and issues inside them; recompute `issues`, `issue_count`, `badge_count`, and `severity_counts`.
  - Expose `wasm-bindgen` entrypoint `scan_text` behind the `browser-wasm` feature; include `src/wasm.rs`.
  - Add Extension CI to build WASM, run `npm test --prefix extension`, assemble unpacked/zip artifacts, validate dist assets, and upload them.

- Bug Fixes
  - Hide empty INFO cards by trimming blank suggestions; only hide `info`, keep `warning`/`error`.
  - Improve WASM build/load reliability: auto-provision `wasm32-unknown-unknown` in `build-wasm.sh`, add a cleanup trap, and use explicit WASM init imports in the loader.
  - Fix Chrome package zip root and validate `manifest.json` and `dist` assets in CI.

<sup>Written for commit 834a1be999ccc7b1f86fa10e80f9b73e1332744b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

