### PR TITLE
Improve Chrome extension scan packaging and filtering

### DIFF
--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -67,7 +67,16 @@ jobs:
           cp -R extension/dist/snippets "$EXTENSION_PACKAGE_DIR"/dist/
         fi
         cp extension/icons/icon-{16,32,48,128}.png "$EXTENSION_PACKAGE_DIR"/icons/
-        (cd extension-package && zip -r "../$EXTENSION_ZIP" zhtw-mcp-extension)
+        (cd "$EXTENSION_PACKAGE_DIR" && zip -r "../../$EXTENSION_ZIP" .)
+
+    - name: Validate distributable extension
+      run: |
+        test -f "$EXTENSION_PACKAGE_DIR/manifest.json"
+        test -f "$EXTENSION_PACKAGE_DIR/dist/zhtw_mcp_wasm.js"
+        test -f "$EXTENSION_PACKAGE_DIR/dist/zhtw_mcp_wasm_bg.wasm"
+        unzip -l "$EXTENSION_ZIP" manifest.json
+        unzip -l "$EXTENSION_ZIP" dist/zhtw_mcp_wasm.js
+        unzip -l "$EXTENSION_ZIP" dist/zhtw_mcp_wasm_bg.wasm
 
     - name: Upload unpacked extension artifact
       uses: actions/upload-artifact@v4

--- a/extension/README.md
+++ b/extension/README.md
@@ -24,6 +24,8 @@ The generated files are written to `extension/dist/`.
 
 The extension uses `activeTab`, so it scans only after a user gesture and only for the current active tab. Badge counts include warning and error issues; info-level findings appear in the popup but do not increase the badge.
 
+The extension applies browser-only result filtering for common page markup patterns such as `...` and `:::`. These filters do not change the Rust CLI, MCP server, or WASM scanner rules.
+
 ## Test JavaScript helpers
 
 ```sh

--- a/extension/build-wasm.sh
+++ b/extension/build-wasm.sh
@@ -4,7 +4,7 @@ set -eu
 cd "$(dirname "$0")/.."
 
 if ! command -v wasm-pack >/dev/null 2>&1; then
-  echo "wasm-pack is required. Install it from https://rustwasm.github.io/wasm-pack/installer/" >&2
+  echo "wasm-pack is required. Install it with: cargo install wasm-pack" >&2
   exit 1
 fi
 

--- a/extension/build-wasm.sh
+++ b/extension/build-wasm.sh
@@ -8,6 +8,31 @@ if ! command -v wasm-pack >/dev/null 2>&1; then
   exit 1
 fi
 
+rustup_path_dir=
+cleanup() {
+  if [ -n "$rustup_path_dir" ]; then
+    rm -rf "$rustup_path_dir"
+  fi
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+  mktemp -d 2>/dev/null || mktemp -d -t zhtw-mcp-wasm
+}
+
+if command -v rustup >/dev/null 2>&1; then
+  rustup_rustc="$(rustup which rustc 2>/dev/null || true)"
+  rustup_cargo="$(rustup which cargo 2>/dev/null || true)"
+  if [ -n "$rustup_rustc" ] && [ -n "$rustup_cargo" ]; then
+    rustup target add wasm32-unknown-unknown
+    rustup_path_dir="$(make_temp_dir)"
+    ln -s "$rustup_rustc" "$rustup_path_dir/rustc"
+    ln -s "$rustup_cargo" "$rustup_path_dir/cargo"
+    PATH="$rustup_path_dir:$PATH"
+    export PATH
+  fi
+fi
+
 if [ ! -f src/engine/s2t_data.rs ]; then
   python3 scripts/gen-s2t-tables.py
   rustfmt src/engine/s2t_data.rs

--- a/extension/src/scanner.js
+++ b/extension/src/scanner.js
@@ -1,20 +1,18 @@
-let wasmModulePromise;
-let scanTextBinding;
+import init, { scan_text } from "../dist/zhtw_mcp_wasm.js";
+
+let initPromise;
 
 async function loadWasmModule() {
-  if (!wasmModulePromise) {
-    wasmModulePromise = (async () => {
-      const wasmModule = await import("../dist/zhtw_mcp_wasm.js");
+  if (!initPromise) {
+    initPromise = (async () => {
       const wasmUrl = chrome.runtime.getURL("dist/zhtw_mcp_wasm_bg.wasm");
-      await wasmModule.default(wasmUrl);
-      scanTextBinding = wasmModule.scan_text;
+      await init({ module_or_path: wasmUrl });
     })();
   }
   try {
-    return await wasmModulePromise;
+    await initPromise;
   } catch (error) {
-    wasmModulePromise = undefined;
-    scanTextBinding = undefined;
+    initPromise = undefined;
     throw error;
   }
 }
@@ -28,6 +26,6 @@ export async function scanText(text, options = {}) {
     );
   }
 
-  const resultJson = scanTextBinding(text, JSON.stringify(options));
+  const resultJson = scan_text(text, JSON.stringify(options));
   return JSON.parse(resultJson);
 }

--- a/extension/src/scanner.js
+++ b/extension/src/scanner.js
@@ -1,6 +1,9 @@
+import "./shared.js";
 import init, { scan_text } from "../dist/zhtw_mcp_wasm.js";
 
 let initPromise;
+
+const { filterExtensionIgnoredIssues } = globalThis.ZhtwExtensionShared;
 
 async function loadWasmModule() {
   if (!initPromise) {
@@ -27,5 +30,5 @@ export async function scanText(text, options = {}) {
   }
 
   const resultJson = scan_text(text, JSON.stringify(options));
-  return JSON.parse(resultJson);
+  return filterExtensionIgnoredIssues(JSON.parse(resultJson), text);
 }

--- a/extension/src/shared.js
+++ b/extension/src/shared.js
@@ -45,6 +45,128 @@
     ).length;
   }
 
+  const extensionIgnoredPatterns = ["...", ":::"];
+
+  function filterExtensionIgnoredIssues(scanResult, text = "") {
+    const issues = Array.isArray(scanResult?.issues) ? scanResult.issues : [];
+    const ignoredRanges = ignoredPatternRanges(text);
+    const filteredIssues = issues
+      .map(normalizeDisplayIssue)
+      .filter(
+        (issue) =>
+          !shouldIgnoreExtensionIssue(issue, ignoredRanges) &&
+          !shouldHideExtensionIssue(issue),
+      );
+
+    return {
+      ...scanResult,
+      issues: filteredIssues,
+      issue_count: filteredIssues.length,
+      badge_count: countBadgeIssues(filteredIssues),
+      severity_counts: countSeverityIssues(filteredIssues),
+    };
+  }
+
+  function shouldIgnoreExtensionIssue(issue, ignoredRanges = []) {
+    const found = issue?.found || "";
+    if (extensionIgnoredPatterns.includes(found)) {
+      return true;
+    }
+
+    const offset = Number(issue?.offset);
+    const length = Number(issue?.length);
+    if (!Number.isFinite(offset) || !Number.isFinite(length) || length <= 0) {
+      return false;
+    }
+    const end = offset + length;
+
+    return ignoredRanges.some(
+      (range) => offset < range.byteEnd && end > range.byteStart,
+    );
+  }
+
+  function shouldHideExtensionIssue(issue) {
+    return issue?.severity === "info" && !hasVisibleSuggestion(issue);
+  }
+
+  function hasVisibleSuggestion(issue) {
+    return Array.isArray(issue?.suggestions)
+      ? issue.suggestions.some((suggestion) => String(suggestion).trim())
+      : false;
+  }
+
+  function normalizeDisplayIssue(issue) {
+    return {
+      ...issue,
+      suggestions: Array.isArray(issue?.suggestions)
+        ? issue.suggestions.filter((suggestion) => String(suggestion).trim())
+        : [],
+    };
+  }
+
+  function ignoredPatternRanges(text) {
+    if (!text) {
+      return [];
+    }
+
+    const byteOffsets = codeUnitByteOffsets(text);
+    const ranges = [];
+    for (const pattern of extensionIgnoredPatterns) {
+      let searchStart = 0;
+      while (searchStart < text.length) {
+        const index = text.indexOf(pattern, searchStart);
+        if (index < 0) {
+          break;
+        }
+        const byteStart = byteOffsets[index];
+        ranges.push({
+          byteStart,
+          byteEnd: byteOffsets[index + pattern.length],
+        });
+        searchStart = index + pattern.length;
+      }
+    }
+    return ranges;
+  }
+
+  function codeUnitByteOffsets(text) {
+    const offsets = new Array(text.length + 1);
+    let bytes = 0;
+    let index = 0;
+    offsets[0] = 0;
+
+    for (const char of text) {
+      bytes += utf8ByteLength(char);
+      const nextIndex = index + char.length;
+      for (
+        let offsetIndex = index + 1;
+        offsetIndex <= nextIndex;
+        offsetIndex += 1
+      ) {
+        offsets[offsetIndex] = bytes;
+      }
+      index = nextIndex;
+    }
+
+    return offsets;
+  }
+
+  function countSeverityIssues(issues) {
+    return issues.reduce(
+      (counts, issue) => {
+        if (issue.severity === "error") {
+          counts.error += 1;
+        } else if (issue.severity === "warning") {
+          counts.warning += 1;
+        } else {
+          counts.info += 1;
+        }
+        return counts;
+      },
+      { info: 0, warning: 0, error: 0 },
+    );
+  }
+
   function formatBadgeText(count) {
     if (!count) {
       return "";
@@ -68,8 +190,11 @@
   return {
     byteOffsetToCodeUnit,
     countBadgeIssues,
+    filterExtensionIgnoredIssues,
     formatBadgeText,
     normalizeIssue,
+    shouldIgnoreExtensionIssue,
+    shouldHideExtensionIssue,
     utf8ByteLength,
   };
 });

--- a/extension/test/shared.test.js
+++ b/extension/test/shared.test.js
@@ -4,7 +4,10 @@ const assert = require("node:assert/strict");
 const {
   byteOffsetToCodeUnit,
   countBadgeIssues,
+  filterExtensionIgnoredIssues,
   formatBadgeText,
+  shouldHideExtensionIssue,
+  shouldIgnoreExtensionIssue,
   utf8ByteLength,
 } = require("../src/shared.js");
 
@@ -31,4 +34,118 @@ test("badge text is capped for dense pages", () => {
   assert.equal(formatBadgeText(0), "");
   assert.equal(formatBadgeText(7), "7");
   assert.equal(formatBadgeText(125), "99+");
+});
+
+test("extension ignores configured punctuation-only patterns", () => {
+  const text = "流程...結束\n::: note\n這個軟件";
+  const scanResult = {
+    issues: [
+      {
+        offset: utf8ByteLength("流程"),
+        length: utf8ByteLength("..."),
+        found: "...",
+        severity: "warning",
+      },
+      {
+        offset: utf8ByteLength("流程...結束\n"),
+        length: utf8ByteLength(":::"),
+        found: ":::",
+        severity: "error",
+      },
+      {
+        offset: utf8ByteLength("流程...結束\n::: note\n這個"),
+        length: utf8ByteLength("軟件"),
+        found: "軟件",
+        severity: "warning",
+      },
+      {
+        offset: 0,
+        length: utf8ByteLength("流程"),
+        found: "流程",
+        severity: "info",
+      },
+    ],
+    issue_count: 4,
+    badge_count: 3,
+    severity_counts: { info: 1, warning: 2, error: 1 },
+  };
+
+  const filtered = filterExtensionIgnoredIssues(scanResult, text);
+
+  assert.deepEqual(
+    filtered.issues.map((issue) => issue.found),
+    ["軟件"],
+  );
+  assert.equal(filtered.issue_count, 1);
+  assert.equal(filtered.badge_count, 1);
+  assert.deepEqual(filtered.severity_counts, { info: 0, warning: 1, error: 0 });
+});
+
+test("extension ignores scanner issues inside configured pattern ranges", () => {
+  const text = "😀提示:::內容";
+  const issue = {
+    offset: utf8ByteLength("😀提示"),
+    length: utf8ByteLength(":"),
+    found: ":",
+    severity: "warning",
+  };
+
+  const filtered = filterExtensionIgnoredIssues({ issues: [issue] }, text);
+
+  assert.equal(shouldIgnoreExtensionIssue({ found: ":::" }), true);
+  assert.equal(filtered.issues.length, 0);
+});
+
+test("extension hides info issues without visible suggestions", () => {
+  const scanResult = {
+    issues: [
+      {
+        offset: 0,
+        length: utf8ByteLength("可以說是"),
+        found: "可以說是",
+        suggestions: [""],
+        rule_type: "ai_style",
+        severity: "info",
+      },
+      {
+        offset: utf8ByteLength("可以說是中文"),
+        length: 0,
+        found: "",
+        suggestions: [" "],
+        rule_type: "punctuation",
+        severity: "info",
+      },
+      {
+        offset: 0,
+        length: utf8ByteLength("軟件"),
+        found: "軟件",
+        suggestions: ["軟體"],
+        rule_type: "cross_strait",
+        severity: "warning",
+      },
+      {
+        offset: 0,
+        length: utf8ByteLength("刪"),
+        found: "刪",
+        suggestions: [""],
+        rule_type: "grammar",
+        severity: "warning",
+      },
+    ],
+    issue_count: 4,
+    badge_count: 2,
+    severity_counts: { info: 2, warning: 2, error: 0 },
+  };
+
+  const filtered = filterExtensionIgnoredIssues(scanResult, "可以說是中文軟件");
+
+  assert.equal(shouldHideExtensionIssue(scanResult.issues[0]), true);
+  assert.deepEqual(
+    filtered.issues.map((issue) => issue.found),
+    ["軟件", "刪"],
+  );
+  assert.deepEqual(filtered.issues[1].suggestions, []);
+  assert.equal(filtered.issue_count, 2);
+  assert.equal(filtered.badge_count, 2);
+  assert.deepEqual(filtered.severity_counts, { info: 0, warning: 2, error: 0 });
 });


### PR DESCRIPTION
## 變更摘要

本 PR 針對 Chrome extension 的後續整理與修正，包含 WASM 建置/載入流程、Chrome extension package layout，以及 extension-only 的掃描結果過濾。這些變更主要集中在 `extension/` 與 extension CI；其中 `...`、`:::` 忽略規則與 INFO 顯示過濾都只在瀏覽器 extension 層處理，不修改 Rust CLI / MCP server 的核心掃描邏輯。

## Commit 範圍

本 PR 目前包含 4 個 commits：

1. `build(extension): optimize WASM build process and refactor loader`
2. `Filter extension-only scan results`
3. `build(extension): fix Chrome package layout`
4. `build(extension): address review feedback`

## 詳細變更紀錄

### 1. 改善 extension WASM 建置與載入流程

- 調整 `extension/build-wasm.sh`，讓建置流程更適合 Chrome extension 使用。
- 更新 `extension/src/scanner.js` 的 WASM 載入方式，透過 extension 內的 WASM glue 與 `chrome.runtime.getURL()` 取得 `dist/zhtw_mcp_wasm_bg.wasm`。
- 降低 extension 載入 WASM 時因路徑、打包結構或 glue code 初始化順序造成失敗的機率。

### 2. 修正 Chrome extension package layout

- 更新 `.github/workflows/extension-ci.yml`，讓 CI 產出的 extension package 更符合 Chrome extension 載入需求。
- 確保 package 內包含 extension 執行所需檔案，同時避免不必要或錯置的建置產物影響載入。

### 3. 新增 extension-only 掃描結果過濾

- 在 extension 端新增 `filterExtensionIgnoredIssues()`，於 WASM 掃描結果回傳後、popup 顯示與 content highlight 前進行後處理。
- 忽略常見頁面/文件 markup pattern：
  - `...`
  - `:::`
- 若 scanner 回報的是 pattern 內部的局部 issue，例如 `:::` 內的單一 `:`，也會一併忽略。
- 過濾後會重新計算：
  - `issues`
  - `issue_count`
  - `badge_count`
  - `severity_counts`

### 4. 隱藏沒有可見建議的 INFO 項目

- 修正 popup 中出現空白 INFO 卡片的問題。
- 部分 INFO issue 屬於刪除、插入或結構提示型訊息，WASM 可能回傳 `suggestions: [""]` 或空白字串；舊版 popup 只檢查 `suggestions.length`，因此會顯示 `ai_style →`、`punctuation →` 這類沒有實質內容的項目。
- 現在 extension 端會：
  - 清除空白 suggestion。
  - 隱藏 `severity === "info"` 且沒有任何可見建議的 issue。
  - 保留 warning / error，即使 suggestion 為空也不自動隱藏，避免漏掉較高嚴重性的結果。

### 5. 文件與測試

- 更新 `extension/README.md`，說明 extension 有 browser-only result filtering，且不影響 Rust CLI / MCP server / WASM scanner 規則。
- 擴充 `extension/test/shared.test.js`，覆蓋：
  - `...` / `:::` pattern 忽略。
  - pattern 範圍內局部 issue 忽略。
  - 無可見建議的 INFO issue 隱藏。
  - 過濾後 badge / severity 統計重算。

## 驗證

```sh
npm test --prefix extension
```

測試結果：6 tests passed。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MV3 service worker WASM loading by switching to static imports with explicit init, and adds browser-only filtering to hide `...`, `:::` noise and empty INFOs. Scan results are cleaner and the build/package is more reliable.

- **New Features**
  - Ignore `...` and `:::` tokens and any issues in those ranges (extension-only).
  - Hide INFO issues without visible suggestions; keep warnings/errors. Recompute badge and severity counts.

- **Build/CI**
  - Update `build-wasm.sh`: auto-provision `wasm32-unknown-unknown` via `rustup`; use a temp symlink PATH with cleanup; instruct `cargo install wasm-pack`.
  - Replace forbidden dynamic `import()` with a static top-level import in `scanner.js` for MV3 service worker; init WASM with `chrome.runtime.getURL("dist/zhtw_mcp_wasm_bg.wasm")`.
  - Fix package layout and zip from the unpacked root; validate `manifest.json` and WASM assets in both the unpacked dir and the zip. Tests and README updated.

<sup>Written for commit 220f477dcab9e9595d6a5c76bb083475e967e0cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

