### PR TITLE
fix(extension): replace dynamic import() with static import in scanner

### DIFF
--- a/extension/src/scanner.js
+++ b/extension/src/scanner.js
@@ -1,20 +1,18 @@
-let wasmModulePromise;
-let scanTextBinding;
+import init, { scan_text } from "../dist/zhtw_mcp_wasm.js";
+
+let initPromise;
 
 async function loadWasmModule() {
-  if (!wasmModulePromise) {
-    wasmModulePromise = (async () => {
-      const wasmModule = await import("../dist/zhtw_mcp_wasm.js");
+  if (!initPromise) {
+    initPromise = (async () => {
       const wasmUrl = chrome.runtime.getURL("dist/zhtw_mcp_wasm_bg.wasm");
-      await wasmModule.default(wasmUrl);
-      scanTextBinding = wasmModule.scan_text;
+      await init({ module_or_path: wasmUrl });
     })();
   }
   try {
-    return await wasmModulePromise;
+    await initPromise;
   } catch (error) {
-    wasmModulePromise = undefined;
-    scanTextBinding = undefined;
+    initPromise = undefined;
     throw error;
   }
 }
@@ -28,6 +26,6 @@ export async function scanText(text, options = {}) {
     );
   }
 
-  const resultJson = scanTextBinding(text, JSON.stringify(options));
+  const resultJson = scan_text(text, JSON.stringify(options));
   return JSON.parse(resultJson);
 }


### PR DESCRIPTION
## Problem

Clicking the extension icon fails with:

```
WASM scanner is not built. Run "sh extension/build-wasm.sh" before loading the extension.
import() is disallowed on ServiceWorkerGlobalScope by the HTML specification.
```

This happens even after a successful WASM build.

## Root Cause

`src/scanner.js` loaded the WASM ES module via a dynamic `import()`:

```js
const wasmModule = await import("../dist/zhtw_mcp_wasm.js");
```

The HTML specification forbids dynamic `import()` inside a Service Worker global scope. Since `background.js` runs as an MV3 module service worker, this call fails at runtime.

## Fix

Replace the runtime dynamic `import()` with a static top-level `import`, which is permitted in module service workers declared with `"type": "module"`:

```js
// Before — dynamic, forbidden in SW
const wasmModule = await import("../dist/zhtw_mcp_wasm.js");
await wasmModule.default(wasmUrl);
scanTextBinding = wasmModule.scan_text;

// After — static, allowed in module SW
import init, { scan_text } from "../dist/zhtw_mcp_wasm.js";
await init({ module_or_path: wasmUrl });
```

The `scanTextBinding` indirection is removed since `scan_text` is now a direct static import.

Closes #83