### PR TITLE
fix(extension): replace broken wasm-pack installer URL with cargo install

### DIFF
--- a/extension/build-wasm.sh
+++ b/extension/build-wasm.sh
@@ -4,7 +4,7 @@ set -eu
 cd "$(dirname "$0")/.."
 
 if ! command -v wasm-pack >/dev/null 2>&1; then
-  echo "wasm-pack is required. Install it from https://rustwasm.github.io/wasm-pack/installer/" >&2
+  echo "wasm-pack is required. Install it with: cargo install wasm-pack" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

`extension/build-wasm.sh` points users to a broken URL when `wasm-pack` is not found:

```
wasm-pack is required. Install it from https://rustwasm.github.io/wasm-pack/installer/
```

That URL returns 404. The alternative `https://wasm-bindgen.github.io/wasm-pack/installer/` resolves but its shell installer script is broken:

```
sh: line 35: ORIG_ARGS[@]: unbound variable
```

## Fix

Since Rust (and therefore `cargo`) is already a prerequisite for building this project, `cargo install wasm-pack` is the most reliable installation method and requires no extra tooling. The extension README already uses this exact command.

Change the error message to:

```
wasm-pack is required. Install it with: cargo install wasm-pack
```

Closes #85

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the broken `wasm-pack` installer URL in `extension/build-wasm.sh` with a direct `cargo` install command to give a reliable setup path and match the README. Prevents build failures when `wasm-pack` is missing.

- **Bug Fixes**
  - On missing `wasm-pack`, print: "wasm-pack is required. Install it with: cargo install wasm-pack"

<sup>Written for commit e905b6364a4720e6d58ae6ed856625a682b79335. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

