### PR TITLE
feat: add Nix package for zhtw-mcp

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/result
 externals/
 rules.sled/
 *.sled/

--- a/README.md
+++ b/README.md
@@ -98,6 +98,46 @@ make
 
 The binary is at `target/release/zhtw-mcp`.
 
+### Nix
+
+With Nix flakes enabled, run the package directly:
+
+```bash
+nix run github:sysprog21/zhtw-mcp -- lint README.md
+```
+
+To register the MCP server without installing the binary globally:
+
+```bash
+# Claude Code
+claude mcp add zhtw-mcp -- nix run github:sysprog21/zhtw-mcp --
+
+# OpenCode
+opencode mcp add zhtw-mcp nix run github:sysprog21/zhtw-mcp --
+```
+
+Codex CLI or other MCP clients can use `nix run` as the server command:
+
+```json
+{
+  "mcpServers": {
+    "zhtw-mcp": {
+      "command": "nix",
+      "args": ["run", "github:sysprog21/zhtw-mcp", "--"]
+    }
+  }
+}
+```
+
+If you prefer a persistent command on `PATH`, install the flake package:
+
+```bash
+nix profile install github:sysprog21/zhtw-mcp
+claude mcp add zhtw-mcp -- zhtw-mcp
+```
+
+From a local checkout, replace `github:sysprog21/zhtw-mcp` with `.`.
+
 ### Installing
 
 The quickest way to build, install to `~/.local/bin`, and register with Claude Code:

--- a/README.md
+++ b/README.md
@@ -109,11 +109,7 @@ nix run github:sysprog21/zhtw-mcp -- lint README.md
 To register the MCP server without installing the binary globally:
 
 ```bash
-# Claude Code
 claude mcp add zhtw-mcp -- nix run github:sysprog21/zhtw-mcp --
-
-# OpenCode
-opencode mcp add zhtw-mcp nix run github:sysprog21/zhtw-mcp --
 ```
 
 Codex CLI or other MCP clients can use `nix run` as the server command:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1777624102,
+        "narHash": "sha256-thSyElkje577x/kAbP72nHlfiFc1a+tCudskLPHXe9s=",
+        "rev": "4d81601e0b73f20d81d066754ad0e7d1e7f75a06",
+        "revCount": 2646,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2646%2Brev-4d81601e0b73f20d81d066754ad0e7d1e7f75a06/019de2eb-4157-78e2-99a4-47e0ab7416f5/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/nix-community/fenix/0.1"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "revCount": 995699,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.995699%2Brev-da5ad661ba4e5ef59ba743f0d112cbc30e474f32/019e1cce-50fe-7f80-9c18-f129a8d93b7c/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777583169,
+        "narHash": "sha256-dVJ4+wrRKc8oIgp3rLOFSq1obt/sCKlXy3h47qof/w0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "aa64e4828a2bbba44463c1229a81c748d3cce583",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,154 @@
+{
+  description = "MCP server for Traditional Chinese (zh-TW) text linting and normalization";
+
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1"; # unstable Nixpkgs
+    fenix = {
+      url = "https://flakehub.com/f/nix-community/fenix/0.1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { self, ... }@inputs:
+
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSupportedSystem =
+        f:
+        inputs.nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            inherit system;
+            pkgs = import inputs.nixpkgs {
+              inherit system;
+              overlays = [
+                inputs.self.overlays.default
+              ];
+            };
+          }
+        );
+    in
+    {
+      overlays.default = final: prev: {
+        rustToolchain =
+          with inputs.fenix.packages.${prev.stdenv.hostPlatform.system};
+          combine (
+            with stable;
+            [
+              clippy
+              rustc
+              cargo
+              rustfmt
+              rust-src
+            ]
+          );
+
+        zhtw-mcp =
+          let
+            openccRev = "0ad13e022313ab62daf9b7ef79047b2d084a8868";
+            openccDictUrl =
+              file: "https://raw.githubusercontent.com/BYVoid/OpenCC/${openccRev}/data/dictionary/${file}";
+            openccDicts = final.linkFarm "opencc-dictionaries" [
+              {
+                name = "STPhrases.txt";
+                path = final.fetchurl {
+                  url = openccDictUrl "STPhrases.txt";
+                  hash = "sha256-nC1CoWSP9+x+d003fHpz9yECr6TmGMLZ3dlfkvq2lgA=";
+                };
+              }
+              {
+                name = "STCharacters.txt";
+                path = final.fetchurl {
+                  url = openccDictUrl "STCharacters.txt";
+                  hash = "sha256-nO37i/E6IgCHED2altn1YFDDQcJKgJy85chckEVFZVc=";
+                };
+              }
+              {
+                name = "TWVariants.txt";
+                path = final.fetchurl {
+                  url = openccDictUrl "TWVariants.txt";
+                  hash = "sha256-iUc+luP2HpvT8uMDudiKycqmHv+x+q3O+U/15luO1Us=";
+                };
+              }
+            ];
+            rustPlatform = final.makeRustPlatform {
+              cargo = final.rustToolchain;
+              rustc = final.rustToolchain;
+            };
+          in
+          rustPlatform.buildRustPackage (finalAttrs: {
+            pname = "zhtw-mcp";
+            version = "0.1.0";
+
+            src = final.lib.cleanSource ./.;
+
+            cargoHash = "sha256-vwguHA1z9ne6P8Q+JBMafAIkhihMgBOdxbHF0HrWLes=";
+
+            nativeBuildInputs = [
+              final.python3
+            ];
+
+            preBuild = ''
+              mkdir -p data/opencc
+              cp ${openccDicts}/STPhrases.txt data/opencc/STPhrases.txt
+              cp ${openccDicts}/STCharacters.txt data/opencc/STCharacters.txt
+              cp ${openccDicts}/TWVariants.txt data/opencc/TWVariants.txt
+              python3 scripts/gen-s2t-tables.py
+              ${final.rustToolchain}/bin/rustfmt src/engine/s2t_data.rs
+            '';
+
+            cargoTestFlags = [
+              "--lib"
+              "--bins"
+            ];
+
+            meta = {
+              description = "MCP server for Traditional Chinese (zh-TW) text linting and normalization";
+              homepage = "https://github.com/sysprog21/zhtw-mcp";
+              license = final.lib.licenses.mit;
+              mainProgram = "zhtw-mcp";
+              maintainers = [ ];
+            };
+          });
+      };
+
+      packages = forEachSupportedSystem (
+        { pkgs, ... }:
+        {
+          inherit (pkgs) zhtw-mcp;
+          default = pkgs.zhtw-mcp;
+        }
+      );
+
+      devShells = forEachSupportedSystem (
+        { pkgs, system }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              rustToolchain
+              openssl
+              pkg-config
+              cargo-deny
+              cargo-edit
+              cargo-watch
+              rust-analyzer
+              self.formatter.${system}
+            ];
+
+            env = {
+              # Required by rust-analyzer
+              RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+            };
+          };
+        }
+      );
+
+      formatter = forEachSupportedSystem ({ pkgs, ... }: pkgs.nixfmt);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
             pkgs = import inputs.nixpkgs {
               inherit system;
               overlays = [
-                inputs.self.overlays.default
+                self.overlays.default
               ];
             };
           }
@@ -37,7 +37,7 @@
     {
       overlays.default = final: prev: {
         rustToolchain =
-          with inputs.fenix.packages.${prev.stdenv.hostPlatform.system};
+          with inputs.fenix.packages.${final.stdenv.hostPlatform.system};
           combine (
             with stable;
             [
@@ -84,7 +84,7 @@
           in
           rustPlatform.buildRustPackage (finalAttrs: {
             pname = "zhtw-mcp";
-            version = "0.1.0";
+            version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
 
             src = final.lib.cleanSource ./.;
 
@@ -92,6 +92,7 @@
 
             nativeBuildInputs = [
               final.python3
+              final.rustToolchain
             ];
 
             preBuild = ''
@@ -100,7 +101,7 @@
               cp ${openccDicts}/STCharacters.txt data/opencc/STCharacters.txt
               cp ${openccDicts}/TWVariants.txt data/opencc/TWVariants.txt
               python3 scripts/gen-s2t-tables.py
-              ${final.rustToolchain}/bin/rustfmt src/engine/s2t_data.rs
+              rustfmt src/engine/s2t_data.rs
             '';
 
             cargoTestFlags = [
@@ -108,12 +109,12 @@
               "--bins"
             ];
 
-            meta = {
+            meta = with final.lib; {
               description = "MCP server for Traditional Chinese (zh-TW) text linting and normalization";
               homepage = "https://github.com/sysprog21/zhtw-mcp";
-              license = final.lib.licenses.mit;
+              license = licenses.mit;
               mainProgram = "zhtw-mcp";
-              maintainers = [ ];
+              platforms = platforms.unix;
             };
           });
       };


### PR DESCRIPTION
增加 Nix 套件，在有安裝 Nix 的情況下，可以使用 `nix run sysprog21/zhtw-mcp` 來執行 `zhtw-mcp`（而且不會影響到現有 `$PATH` 裡面的內容）：

```bash
$ claude mcp add zhtw-mcp -- nix run github:pan93412/zhtw-mcp/add-nix-package --
Added stdio MCP server zhtw-mcp with command: nix run github:pan93412/zhtw-mcp/add-nix-package -- to local config
File modified: /Users/yjpan/.claude.json [project: /Volumes/Dev/tmp/clawd-on-desk]

❯ /mcp
  Manage MCP servers
  9 servers

    Local MCPs (/Users/yjpan/.claude.json [project: /Volumes/Dev/tmp/clawd-on-desk])
  ❯ zhtw-mcp · ✔ connected · 1 tool
```

<img width="1902" height="716" alt="CleanShot 2026-05-13 at 13 43 07@2x" src="https://github.com/user-attachments/assets/df379c7b-4018-444d-baf2-adbaacfa2403" />

<img width="1290" height="828" alt="CleanShot 2026-05-13 at 13 56 17@2x" src="https://github.com/user-attachments/assets/082c214d-b47d-4323-b020-0a066e3711b5" />

> [!NOTE]
> *AI Disclosure*: `buildRustPackage` 的啟發式探索（包括 `doCheck`、OpenCC 等等的版本固定）均由 Codex 完成。Nix 更新教學和 README 也是由 Codex 更新，但人類有確認可以編譯。

---

Nix 套件的維護略顯複雜。它為了達到可復現編譯 (reproducible build)，要求把 `Cargo.lock` 以及 OpenCC 的 hash 定義上去。因此，如果 `Cargo.lock` 有更新，或者是想要更新 `flake.nix` 中 OpenCC 的修訂版本，就需要另外開一個 PR 來更新 Nix 上面的 Hash。

之後可以另外寫一個 GitHub Actions 來自動執行下面的任務（類似於 [cc-statusline](https://github.com/rileychh/cc-statusline/blob/main/.github/workflows/autoupdate.yml) 的做法），在此之前應該是需要「如果壞了，再讓有興趣的人上去修 PR」的形式，而使用者則需要做好 Git 版本的鎖定（而不能盲目跟著主幹更新 Nix 套件）。

<details>

<summary>Nix 更新教學</summary>

## 1. Enter the Nix development shell

If the repository has `flake.nix`, run all project commands through
`nix develop`.

```bash
nix develop
```

For one-off commands, prefer:

```bash
nix develop -c <command>
```

## 2. Update package metadata

The package definition lives in `flake.nix` under:

```nix
overlays.default = final: prev: {
  zhtw-mcp = ...
};
```

When the Rust crate version changes, update both:

- `Cargo.toml`: `package.version`
- `flake.nix`: `zhtw-mcp.version`

Keep package metadata in sync with `Cargo.toml`, especially:

- `description`
- `homepage`
- `license`
- `mainProgram`

## 3. Refresh `cargoHash`

If `Cargo.lock` changes, the vendored Cargo dependency hash must be refreshed.

Temporarily replace the existing `cargoHash` in `flake.nix` with:

```nix
cargoHash = final.lib.fakeHash;
```

Then run:

```bash
nix develop -c nix build .#zhtw-mcp
```

The build should fail with a fixed-output hash mismatch and print a `got:`
hash. Copy that value back into `cargoHash`.

Example:

```nix
cargoHash = "sha256-...";
```

Re-run the package build after updating the hash.

## 4. Refresh OpenCC dictionary inputs

`zhtw-mcp` generates `src/engine/s2t_data.rs` from three OpenCC dictionary
files during the Nix build:

- `STPhrases.txt`
- `STCharacters.txt`
- `TWVariants.txt`

The Nix package pins these files through:

```nix
openccRev = "...";
openccDicts = final.linkFarm "opencc-dictionaries" [ ... ];
```

To update the OpenCC source revision:

```bash
nix develop -c git ls-remote https://github.com/BYVoid/OpenCC.git refs/heads/master
```

Copy the commit hash into `openccRev`.

Then prefetch each dictionary at the new revision:

```bash
nix develop -c nix store prefetch-file --json \
  https://raw.githubusercontent.com/BYVoid/OpenCC/<openccRev>/data/dictionary/STPhrases.txt

nix develop -c nix store prefetch-file --json \
  https://raw.githubusercontent.com/BYVoid/OpenCC/<openccRev>/data/dictionary/STCharacters.txt

nix develop -c nix store prefetch-file --json \
  https://raw.githubusercontent.com/BYVoid/OpenCC/<openccRev>/data/dictionary/TWVariants.txt
```

Copy each returned `hash` into the matching `fetchurl` entry in `flake.nix`.

## 5. Format the flake

After editing `flake.nix`, run:

```bash
nix develop -c nixfmt flake.nix
```

## 6. Build and verify

Build the named package:

```bash
nix develop -c nix build .#zhtw-mcp
```

Build the default package:

```bash
nix develop -c nix build .
```

Run the built binary:

```bash
./result/bin/zhtw-mcp --version
```

Remove the local `result` symlink before committing:

```bash
rm result
```

## 7. Optional flake input updates

If you need newer `nixpkgs` or `fenix` inputs, update `flake.lock`:

```bash
nix develop -c nix flake update
```

Then rebuild:

```bash
nix develop -c nix build .#zhtw-mcp
nix develop -c nix build .
```

Review `flake.lock` carefully before committing. Input updates can change the
Rust toolchain, dependency build hooks, or platform behavior.

## Troubleshooting

### Missing `src/engine/s2t_data.rs`

The generated S2T table is intentionally ignored by Git. The Nix package
creates it in `preBuild` from the fixed OpenCC dictionary inputs. If the build
fails with a missing `s2t_data.rs`, check that `preBuild` still runs:

```nix
python3 scripts/gen-s2t-tables.py
```

### Cargo vendor hash mismatch

This is expected after changing Rust dependencies. Use the fake-hash workflow
in "Refresh `cargoHash`".

### CLI integration tests fail in the Nix check phase

The package check phase is limited to:

```nix
cargoTestFlags = [
  "--lib"
  "--bins"
];
```

Some CLI integration tests derive a binary path from Cargo's local `target`
layout and are not reliable inside the Nix build sandbox. Run the full test
suite from the development shell when changing application behavior:

```bash
nix develop -c make check
```

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Nix flake for `zhtw-mcp` so it can be run with `nix run` or installed with `nix profile`, plus a dev shell for contributors. Also fixes toolchain selection and build metadata to improve cross-compilation, reproducibility, and docs.

- **New Features**
  - Flake exposes `zhtw-mcp` as the default package; run with `nix run github:sysprog21/zhtw-mcp --` or install via `nix profile`.
  - Dev shell with `fenix` Rust toolchain and common Cargo tools; `.envrc` enables `use flake`.
  - Reproducible build with pinned `cargoHash` and OpenCC dictionaries; `s2t_data.rs` generated in `preBuild`; pins `nixpkgs`/`fenix` in `flake.lock`.

- **Bug Fixes**
  - Toolchain and build: select `fenix` via `final.stdenv` for correct system/cross builds; read version from `Cargo.toml` using `builtins.fromTOML`; include `rustToolchain` in `nativeBuildInputs` and use PATH `rustfmt`.
  - Metadata and docs: update `meta` (adds Unix platforms), remove incorrect `opencode mcp add` example, and ignore `/result`.

<sup>Written for commit 54de53d88e26820214ae915d53d89428a7145788. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

