### PR TITLE
Narrow 聯繫 cross_strait flagging to contact-copy

### DIFF
--- a/assets/ruleset.json
+++ b/assets/ruleset.json
@@ -3769,6 +3769,13 @@
       "context": "humanize.C7: sycophantic chatbot opener; delete"
     },
     {
+      "from": "如需協助請聯繫",
+      "to": ["如需協助請聯絡"],
+      "type": "cross_strait",
+      "context": "@domain IT。客服 CTA；避免把日常用法「聯繫」一概改寫",
+      "english": "if you need help, please contact"
+    },
+    {
       "from": "委託",
       "to": ["委派"],
       "type": "cross_strait",
@@ -9686,11 +9693,25 @@
       "context_clues": ["程式", "軟體", "系統", "電腦", "網路"]
     },
     {
-      "from": "聯繫",
-      "to": ["聯絡"],
+      "from": "聯繫客服",
+      "to": ["聯絡客服"],
       "type": "cross_strait",
-      "context": "@domain IT",
-      "english": "contact"
+      "context": "@domain IT。客服 CTA；避免把日常用法「聯繫」一概改寫",
+      "english": "contact support"
+    },
+    {
+      "from": "聯繫我們",
+      "to": ["聯絡我們"],
+      "type": "cross_strait",
+      "context": "@domain IT。客服 CTA / contact us copy；避免把日常用法「聯繫」一概改寫",
+      "english": "contact us"
+    },
+    {
+      "from": "聯繫方式",
+      "to": ["聯絡方式"],
+      "type": "cross_strait",
+      "context": "@domain IT。聯絡資訊欄位標籤；避免把日常用法「聯繫」一概改寫",
+      "english": "contact method"
     },
     {
       "from": "聯繫歷史",
@@ -9698,6 +9719,27 @@
       "type": "cross_strait",
       "context": "@domain 通訊",
       "english": "call history"
+    },
+    {
+      "from": "聯繫管道",
+      "to": ["聯絡管道"],
+      "type": "cross_strait",
+      "context": "@domain IT。聯絡資訊欄位標籤；避免把日常用法「聯繫」一概改寫",
+      "english": "contact channel"
+    },
+    {
+      "from": "聯繫資訊",
+      "to": ["聯絡資訊"],
+      "type": "cross_strait",
+      "context": "@domain IT。聯絡資訊欄位標籤；避免把日常用法「聯繫」一概改寫",
+      "english": "contact information"
+    },
+    {
+      "from": "聯繫電話",
+      "to": ["聯絡電話"],
+      "type": "cross_strait",
+      "context": "@domain IT。聯絡資訊欄位標籤；避免把日常用法「聯繫」一概改寫",
+      "english": "contact phone"
     },
     {
       "from": "聲卡",

--- a/src/engine/scan/mod.rs
+++ b/src/engine/scan/mod.rs
@@ -2076,6 +2076,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn contact_cta_rules_do_not_force_low_editorial_confidence() {
+        let ruleset = crate::rules::loader::load_embedded_ruleset().unwrap();
+        let scanner = Scanner::new(ruleset.spelling_rules, ruleset.case_rules);
+
+        let issues = scanner.scan("如需協助請聯繫客服").issues;
+        assert_eq!(
+            issues.len(),
+            1,
+            "expected CTA phrase to match once: {issues:?}"
+        );
+        assert_eq!(issues[0].found, "如需協助請聯繫");
+        assert_eq!(issues[0].editorial_confidence, None);
+
+        let issues = scanner.scan("歡迎聯繫我們").issues;
+        assert_eq!(
+            issues.len(),
+            1,
+            "expected contact-us phrase to match once: {issues:?}"
+        );
+        assert_eq!(issues[0].found, "聯繫我們");
+        assert_eq!(issues[0].editorial_confidence, None);
+    }
+
     // --- positional_clues tests ---
 
     #[test]
@@ -2479,6 +2503,79 @@ mod tests {
         assert!(
             issues.is_empty(),
             "adjacent: must not match term inside excluded region: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn lian_xi_contact_copy_uses_phrase_rules_without_general_prose_fp() {
+        let rules = vec![
+            SpellingRule::new("聯繫我們", vec!["聯絡我們".into()], RuleType::CrossStrait),
+            SpellingRule::new("聯繫方式", vec!["聯絡方式".into()], RuleType::CrossStrait),
+            SpellingRule::new("聯繫資訊", vec!["聯絡資訊".into()], RuleType::CrossStrait),
+            SpellingRule::new("聯繫管道", vec!["聯絡管道".into()], RuleType::CrossStrait),
+            SpellingRule::new("聯繫電話", vec!["聯絡電話".into()], RuleType::CrossStrait),
+            SpellingRule::new("聯繫客服", vec!["聯絡客服".into()], RuleType::CrossStrait),
+            SpellingRule::new(
+                "如需協助請聯繫",
+                vec!["如需協助請聯絡".into()],
+                RuleType::CrossStrait,
+            ),
+        ];
+        let scanner = Scanner::new(rules, vec![]);
+
+        let issues = scanner.scan("歡迎聯繫我們").issues;
+        assert_eq!(issues.len(), 1, "should flag contact CTA: {issues:?}");
+
+        let issues = scanner.scan("請查看聯繫方式").issues;
+        assert_eq!(issues.len(), 1, "should flag contact label: {issues:?}");
+
+        let issues = scanner.scan("最新聯繫資訊如下").issues;
+        assert_eq!(
+            issues.len(),
+            1,
+            "should flag contact info label: {issues:?}"
+        );
+
+        let issues = scanner.scan("若需協助可參考聯繫管道").issues;
+        assert_eq!(
+            issues.len(),
+            1,
+            "should flag contact channel label: {issues:?}"
+        );
+
+        let issues = scanner.scan("聯繫電話：02-1234-5678").issues;
+        assert_eq!(
+            issues.len(),
+            1,
+            "should flag contact phone label: {issues:?}"
+        );
+
+        let issues = scanner.scan("請聯繫客服取得協助").issues;
+        assert_eq!(issues.len(), 1, "should flag support CTA: {issues:?}");
+
+        let issues = scanner.scan("如需協助請聯繫").issues;
+        assert_eq!(
+            issues.len(),
+            1,
+            "should flag imperative support CTA: {issues:?}"
+        );
+
+        let issues = scanner.scan("我們與學界保持密切聯繫").issues;
+        assert!(
+            issues.is_empty(),
+            "should not flag ordinary prose: {issues:?}"
+        );
+
+        let issues = scanner.scan("請加強國際聯繫").issues;
+        assert!(
+            issues.is_empty(),
+            "should not flag ordinary prose: {issues:?}"
+        );
+
+        let issues = scanner.scan("我們透過電話聯繫對方").issues;
+        assert!(
+            issues.is_empty(),
+            "should not flag ordinary prose: {issues:?}"
         );
     }
 


### PR DESCRIPTION
The previous standalone "聯繫 → 聯絡" rule treated a word that the MoE concise dictionary records as valid zh-TW as a blanket cross-strait term, producing false positives on general prose such as "民間文化聯繫", "國際聯繫", and "保持聯繫".

Replace it with explicit compound rules covering the UI/customer-service phrases where 聯絡 is the idiomatic TW form: 聯繫我們, 聯繫方式, 聯繫資訊, 聯繫管道, 聯繫電話, 聯繫客服, 如需協助請聯繫.
聯繫歷史 → 通話記錄 is unchanged.

Add scanner regression test that locks both directions of the behavior: the new compounds fire exactly once on contact-copy spans, and ordinary prose containing 聯繫 stays silent.

Close #89

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed cross-strait flagging for 聯繫 to only contact-copy phrases, preventing false positives in general prose. Added tests to ensure contact CTAs are flagged once and do not lower editorial confidence.

- **Bug Fixes**
  - Replaced blanket rule with phrase rules: 聯繫我們, 聯繫方式, 聯繫資訊, 聯繫管道, 聯繫電話, 聯繫客服, 如需協助請聯繫.
  - Kept 聯繫歷史 → 通話記錄 unchanged.
  - Added scanner tests: each phrase flags once; ordinary prose with 聯繫 is ignored; matches keep editorial_confidence unset.

<sup>Written for commit b5432dda403fc7a0f1e7280f34b6fd6ddadbc92b. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/zhtw-mcp/pull/90?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

