### PR TITLE
feat: add Nix package for zhtw-mcp

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/result
 externals/
 rules.sled/
 *.sled/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1777624102,
+        "narHash": "sha256-thSyElkje577x/kAbP72nHlfiFc1a+tCudskLPHXe9s=",
+        "rev": "4d81601e0b73f20d81d066754ad0e7d1e7f75a06",
+        "revCount": 2646,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2646%2Brev-4d81601e0b73f20d81d066754ad0e7d1e7f75a06/019de2eb-4157-78e2-99a4-47e0ab7416f5/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/nix-community/fenix/0.1"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
+        "revCount": 1003640,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1003640%2Brev-29916453413845e54a65b8a1cf996842300cd299/019e5626-8c96-7cc1-83dd-de1831a60fd0/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
+      }
+    },
+    "opencc-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779550076,
+        "narHash": "sha256-1DKcihwGvqvFnSjHt5vghwwHiOrhTP1yiouWqUi8TtQ=",
+        "owner": "BYVoid",
+        "repo": "OpenCC",
+        "rev": "c2ce81bf9af90f7e667c9da1d32e960dd79f9771",
+        "type": "github"
+      },
+      "original": {
+        "owner": "BYVoid",
+        "repo": "OpenCC",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs",
+        "opencc-src": "opencc-src"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777583169,
+        "narHash": "sha256-dVJ4+wrRKc8oIgp3rLOFSq1obt/sCKlXy3h47qof/w0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "aa64e4828a2bbba44463c1229a81c748d3cce583",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,130 @@
+{
+  description = "Nix package for zhtw-mcp";
+
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
+    fenix = {
+      url = "https://flakehub.com/f/nix-community/fenix/0.1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    opencc-src = {
+      url = "github:BYVoid/OpenCC";
+      flake = false;
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      fenix,
+      opencc-src,
+    }:
+
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSupportedSystem =
+        f:
+        nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            inherit system;
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [ self.overlays.default ];
+            };
+          }
+        );
+    in
+    {
+      overlays.default = final: prev: {
+        rustToolchain =
+          with fenix.packages.${final.stdenv.hostPlatform.system};
+          combine (
+            with stable;
+            [
+              cargo
+              clippy
+              rust-src
+              rustc
+              rustfmt
+            ]
+          );
+
+        zhtw-mcp =
+          let
+            cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
+            rustPlatform = final.makeRustPlatform {
+              cargo = final.rustToolchain;
+              rustc = final.rustToolchain;
+            };
+          in
+          rustPlatform.buildRustPackage {
+            pname = "zhtw-mcp";
+            inherit (cargoToml.package) version;
+
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            nativeBuildInputs = [
+              final.python3
+              final.rustToolchain
+            ];
+
+            preBuild = ''
+              mkdir -p data/opencc
+              cp ${opencc-src}/data/dictionary/STPhrases.txt data/opencc/STPhrases.txt
+              cp ${opencc-src}/data/dictionary/STCharacters.txt data/opencc/STCharacters.txt
+              cp ${opencc-src}/data/dictionary/TWVariants.txt data/opencc/TWVariants.txt
+              python3 scripts/gen-s2t-tables.py
+              rustfmt src/engine/s2t_data.rs
+            '';
+
+            cargoTestFlags = [
+              "--lib"
+              "--bins"
+            ];
+
+            meta = with final.lib; {
+              description = "MCP server for Traditional Chinese (zh-TW) text linting and normalization";
+              homepage = "https://github.com/sysprog21/zhtw-mcp";
+              license = licenses.mit;
+              mainProgram = "zhtw-mcp";
+            };
+          };
+      };
+
+      packages = forEachSupportedSystem (
+        { pkgs, ... }:
+        {
+          inherit (pkgs) zhtw-mcp;
+          default = pkgs.zhtw-mcp;
+        }
+      );
+
+      devShells = forEachSupportedSystem (
+        { pkgs, system }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              rustToolchain
+              openssl
+              pkg-config
+              python3
+              self.formatter.${system}
+            ];
+          };
+        }
+      );
+
+      formatter = forEachSupportedSystem ({ pkgs, ... }: pkgs.nixfmt);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,6 @@
       supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
       forEachSupportedSystem =


### PR DESCRIPTION
重新實作 #88，解決了最大的「維護開銷」問題：

- 用 flake input 引入 OpenCC，而不是手動 fetchurl + 算 hash。日後如果需要更新 OpenCC，執行 `nix flake update` 即可更新。
- 直接引用 [Cargo.lock](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#importing-a-cargolock-file-importing-a-cargolock-file) 檔案，免除掉每次更新依賴後重算 Cargo lock hash 的困擾。

合併這個 Nix flake 後，這個 flake 會自動隨著 `Cargo.toml` 更新版本號，並隨著 `Cargo.lock` 更新依賴。OpenCC 則可以再定期執行 `nix flake update` 來更新到較新的詞庫，但不更新也能正常編譯。另外 Nix 的特性使得目前的 commit 產出的 binary 必定可以被復現（不用擔心因為系統依賴或 OpenCC 端的更新，導致目前的套件版本無法編譯）。

測試：

```bash
$ nix build .
$ ./result/bin/zhtw-mcp lint README.md
31:17: warning [cross_strait] '並發' -> 並行
31:35: warning [punctuation] ',' -> ，
32:56: warning [punctuation] ',' -> ，
33:18: warning [cross_strait] '進程' -> 行程
33:28: warning [cross_strait] '進程' -> 行程
34:26: warning [cross_strait] '文檔' -> 文件
36:14: warning [cross_strait] '遍歷' -> 走訪
36:24: warning [cross_strait] '遍歷' -> 走訪
36:69: warning [cross_strait] '遍歷' -> 走訪
45:26: warning [cross_strait] '軟件' -> 軟體
45:31: warning [punctuation] ',' -> ，
45:33: warning [cross_strait] '內存' -> 記憶體
45:39: warning [punctuation] ',' -> ，
45:41: warning [cross_strait] '默認' -> 預設
45:46: warning [punctuation] ',' -> ，
46:41: warning [punctuation] ',' -> ，
47:32: error [political_coloring] '祖國' -> 中國
47:34: warning [punctuation] ',' -> ，
47:36: error [political_coloring] '內地' -> 中國大陸, 中國

19 issue(s) found.
AI score: 0.00 (low)
翻譯腔 score: 0.00 (low)
```

用法與 https://github.com/pan93412/zhtw-mcp-nix 一致，日後再用其他 PR 補上各種 Nix flake 的使用方式。

---

Tested platforms:

- [x] x86_64-linux
- [x] aarch64-linux
- [x] aarch64-darwin


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Nix flake that packages `zhtw-mcp` for reproducible builds with low maintenance for `OpenCC` and Rust deps. Supports Linux and Apple Silicon macOS, and includes a ready-to-use dev shell.

- **New Features**
  - Add `flake.nix`/`flake.lock` with `nixpkgs` and `fenix` inputs; builds on `x86_64`/`aarch64` Linux and `aarch64-darwin` (drops `x86_64-darwin`).
  - Pull `OpenCC` via the `opencc-src` flake input; update with `nix flake update`.
  - Read version from `Cargo.toml` and import `Cargo.lock` directly (no cargo hash churn).
  - Expose `packages.default` and `devShell`; dev shell includes stable Rust toolchain (`cargo`, `rustc`, `clippy`, `rustfmt`, `rust-src`), `python3`, `openssl`, `pkg-config`, and `nixfmt`.
  - Build generates S2T tables from `OpenCC` data for consistent, reproducible outputs.
  - Add `.envrc` for `direnv` (`use flake`) and ignore `/result` in `.gitignore`.

<sup>Written for commit 9b407b7bce3c603a0ade221d248eec1a0f531335. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/zhtw-mcp/pull/91?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



