### PR TITLE
Improve AI structural detectors

### DIFF
--- a/assets/ruleset.json
+++ b/assets/ruleset.json
@@ -264,6 +264,18 @@
       "context": "AI filler phrase; delete"
     },
     {
+      "from": "不言而喻",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: unsupported obviousness marker; explain or delete"
+    },
+    {
+      "from": "世界和平作出更大貢獻",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: slogan-like sublimating ending; replace with a concrete claim"
+    },
+    {
       "from": "並口",
       "to": ["平行埠"],
       "type": "cross_strait",
@@ -536,6 +548,12 @@
       "context": "@domain IT",
       "english": "switch",
       "context_clues": ["網路", "路由", "封包", "VLAN"]
+    },
+    {
+      "from": "交織",
+      "to": ["互相影響"],
+      "type": "ai_filler",
+      "context": "writing humanizer: abstract weaving metaphor; name the relation"
     },
     {
       "from": "亭式車站",
@@ -888,6 +906,12 @@
       "context": "@domain IT",
       "english": "portable edition",
       "context_clues": ["程式", "軟體", "系統", "電腦", "網路"]
+    },
+    {
+      "from": "促進",
+      "to": ["推動"],
+      "type": "ai_filler",
+      "context": "writing humanizer: generic promotion verb; name the concrete mechanism"
     },
     {
       "from": "保修",
@@ -1361,6 +1385,12 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "top-up/recharge"
+    },
+    {
+      "from": "充滿活力",
+      "to": ["活絡"],
+      "type": "ai_filler",
+      "context": "writing humanizer: stock vitality phrase; replace with observable evidence"
     },
     {
       "from": "充電寶",
@@ -3280,6 +3310,13 @@
       "context": "AI hedging phrase (在某種程度上); delete or be specific"
     },
     {
+      "from": "在當今",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: era-framing opener; delete unless the era is specific",
+      "context_clues": ["時代"]
+    },
+    {
       "from": "在線",
       "to": ["線上"],
       "type": "cross_strait",
@@ -3405,6 +3442,12 @@
       "type": "cross_strait",
       "context": "@domain 教育",
       "english": "training"
+    },
+    {
+      "from": "培養",
+      "to": ["養成"],
+      "type": "ai_filler",
+      "context": "writing humanizer: generic nurture verb; name the concrete practice"
     },
     {
       "from": "基向量",
@@ -3551,6 +3594,12 @@
       "context": "@domain 程式設計",
       "english": "increment operator",
       "context_clues": ["運算", "表達式", "運算子", "C++", "編譯", "程式", "語法"]
+    },
+    {
+      "from": "增強",
+      "to": ["加強", "提高"],
+      "type": "ai_filler",
+      "context": "writing humanizer: generic uplift verb; use the concrete action"
     },
     {
       "from": "增強現實",
@@ -4256,6 +4305,12 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "reassurance"
+    },
+    {
+      "from": "寶貴的",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: generic praise adjective; delete or specify the value"
     },
     {
       "from": "封禁",
@@ -5251,6 +5306,13 @@
       "english": "data member"
     },
     {
+      "from": "我們就能明白",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: explanatory throat-clearing; state the inference directly",
+      "context_clues": ["理解了"]
+    },
+    {
       "from": "截取",
       "to": ["擷取"],
       "type": "cross_strait",
@@ -5476,6 +5538,12 @@
       "english": "persistence"
     },
     {
+      "from": "持久的",
+      "to": ["長久的"],
+      "type": "ai_filler",
+      "context": "writing humanizer: inflated adjective; prefer a concrete modifier"
+    },
+    {
       "from": "持續集成",
       "to": ["持續整合"],
       "type": "cross_strait",
@@ -5569,6 +5637,12 @@
       "english": "family-visit leave"
     },
     {
+      "from": "接下來我們來看",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: classroom-style transition; use a direct transition"
+    },
+    {
       "from": "接入覆用器",
       "to": ["接取多工器"],
       "type": "cross_strait",
@@ -5641,6 +5715,12 @@
       "to": ["預告"],
       "type": "translationese",
       "context": "dewesternise.S1: semantic overlap"
+    },
+    {
+      "from": "提升",
+      "to": ["提高", "改善"],
+      "type": "ai_filler",
+      "context": "writing humanizer: generic uplift verb; use the concrete action"
     },
     {
       "from": "插件",
@@ -6545,6 +6625,12 @@
       "english": "localization (L10N)"
     },
     {
+      "from": "本文將",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: meta-discourse; start with the actual claim"
+    },
+    {
       "from": "本科",
       "to": ["大學部"],
       "type": "cross_strait",
@@ -6558,6 +6644,12 @@
       "type": "cross_strait",
       "context": "@domain 教育",
       "english": "undergraduate student"
+    },
+    {
+      "from": "本節將",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: meta-discourse; start with the actual claim"
     },
     {
       "from": "東盟",
@@ -7066,6 +7158,12 @@
       "english": "normal distribution"
     },
     {
+      "from": "此外",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: overused connective; delete or replace with a concrete transition"
+    },
+    {
       "from": "步行街",
       "to": ["行人徒步區"],
       "type": "cross_strait",
@@ -7078,6 +7176,12 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "walkie-talkie"
+    },
+    {
+      "from": "歷史將會記住",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: grandiose ending; replace with evidence"
     },
     {
       "from": "歸一化",
@@ -7239,6 +7343,12 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "cement"
+    },
+    {
+      "from": "永恆的",
+      "to": ["長久的"],
+      "type": "ai_filler",
+      "context": "writing humanizer: inflated adjective; prefer a concrete modifier"
     },
     {
       "from": "污",
@@ -7477,6 +7587,12 @@
       "context": "@domain IT",
       "english": "message queue",
       "context_clues": ["MQ", "Kafka", "非同步", "佇列"]
+    },
+    {
+      "from": "涵養",
+      "to": ["養成"],
+      "type": "ai_filler",
+      "context": "writing humanizer: inflated nurture verb; name the concrete practice"
     },
     {
       "from": "涼菜",
@@ -7784,6 +7900,18 @@
       "english": "shameless"
     },
     {
+      "from": "無縫",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: product-copy cliche; state the concrete integration"
+    },
+    {
+      "from": "無縫銜接",
+      "to": ["銜接"],
+      "type": "ai_filler",
+      "context": "writing humanizer: product-copy cliche; state what connects"
+    },
+    {
       "from": "無繩電話",
       "to": ["無線電話"],
       "type": "cross_strait",
@@ -8066,6 +8194,13 @@
       "english": "reality is harsh"
     },
     {
+      "from": "理解了",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: explanatory throat-clearing; state the inference directly",
+      "context_clues": ["我們就能明白"]
+    },
+    {
       "from": "瑙魯",
       "to": ["諾魯"],
       "type": "cross_strait",
@@ -8188,6 +8323,12 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "guava"
+    },
+    {
+      "from": "畫卷",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: ornate stock metaphor; delete or use a concrete noun"
     },
     {
       "from": "異常",
@@ -8442,6 +8583,12 @@
       "context": "dewesternise.S1: semantic overlap"
     },
     {
+      "from": "相互作用",
+      "to": ["互相影響"],
+      "type": "ai_filler",
+      "context": "writing humanizer: abstract interaction phrase; name the causal direction"
+    },
+    {
       "from": "相冊",
       "to": ["相簿"],
       "type": "cross_strait",
@@ -8477,6 +8624,12 @@
       "context": "@domain 醫學",
       "english": "true negative",
       "context_clues": ["檢驗", "篩檢", "診斷", "測試"]
+    },
+    {
+      "from": "眾所周知",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: unsupported common-knowledge marker; cite or delete"
     },
     {
       "from": "着",
@@ -9589,6 +9742,12 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "can't hold it in"
+    },
+    {
+      "from": "織錦",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: ornate stock metaphor; delete or use a concrete noun"
     },
     {
       "from": "繮",
@@ -11026,6 +11185,12 @@
       "context": "humanize.M1: chatbot opener; delete"
     },
     {
+      "from": "讓我們都能",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: sublimating ending; replace with a concrete conclusion"
+    },
+    {
       "from": "豐富的文化底蘊",
       "to": [],
       "type": "ai_filler",
@@ -11104,6 +11269,12 @@
       "type": "cross_strait",
       "context": "@domain 日常",
       "english": "wholesale size"
+    },
+    {
+      "from": "賦予力量",
+      "to": ["支持"],
+      "type": "ai_filler",
+      "context": "writing humanizer: empowerment calque; name the concrete support"
     },
     {
       "from": "賦值",
@@ -11942,6 +12113,12 @@
       "english": "record (video)"
     },
     {
+      "from": "錯綜複雜",
+      "to": ["複雜"],
+      "type": "ai_filler",
+      "context": "writing humanizer: inflated complexity phrase; specify the conflict"
+    },
+    {
       "from": "錯誤信息",
       "to": ["錯誤訊息"],
       "type": "cross_strait",
@@ -12201,6 +12378,13 @@
       "context": "@domain IT",
       "english": "random number",
       "context_clues": ["程式", "軟體", "系統", "電腦", "網路"]
+    },
+    {
+      "from": "隨著",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: boilerplate development opener; rewrite as the actual cause",
+      "context_clues": ["快速發展"]
     },
     {
       "from": "隱式語義索引",
@@ -12640,6 +12824,12 @@
       "type": "cross_strait",
       "context": "@domain 通訊",
       "english": "frequency-division multiplexing (FDM)"
+    },
+    {
+      "from": "願我們",
+      "to": [""],
+      "type": "ai_filler",
+      "context": "writing humanizer: sublimating ending; replace with a concrete conclusion"
     },
     {
       "from": "顛覆性變革",

--- a/src/engine/disambig.rs
+++ b/src/engine/disambig.rs
@@ -905,6 +905,7 @@ fn promote_suggestion(issue: &mut Issue, term: &str) {
             sugs.swap(0, pos);
             issue.suggestions = sugs.into();
         }
+        issue.refresh_suggested_rewrite();
     }
 }
 
@@ -1277,6 +1278,27 @@ mod tests {
         assert_eq!(stats.not_eligible, 1); // punctuation
                                            // 令牌: no collocations, no clues, no Base prior → suppressed
         assert_eq!(stats.suppressed, 1);
+    }
+
+    #[test]
+    fn promotion_refreshes_translationese_rewrite() {
+        let mut issue = Issue::new(
+            0,
+            "冗長".len(),
+            "冗長",
+            vec!["短句".to_string(), "精簡".to_string()],
+            IssueType::Translationese,
+            Severity::Warning,
+        );
+
+        promote_suggestion(&mut issue, "精簡");
+
+        assert_eq!(issue.suggestions.as_ref(), ["精簡", "短句"]);
+        assert_eq!(issue.suggested_rewrite.as_deref(), Some("精簡"));
+
+        issue.suggested_rewrite = Some("短句".to_string());
+        promote_suggestion(&mut issue, "精簡");
+        assert_eq!(issue.suggested_rewrite.as_deref(), Some("精簡"));
     }
 
     #[test]

--- a/src/engine/scan/grammar.rs
+++ b/src/engine/scan/grammar.rs
@@ -2214,15 +2214,28 @@ fn scan_ai_formulaic_section_endings(
     issues: &mut Vec<Issue>,
     idx: &crate::engine::sentence::BoundaryIndex,
 ) {
-    const FORMULAIC_ENDINGS: &[&str] = &["展望未來", "拭目以待", "值得期待", "我們有理由相信"];
+    const FORMULAIC_ENDINGS: &[&str] = &[
+        "展望未來",
+        "拭目以待",
+        "值得期待",
+        "我們有理由相信",
+        "具有重要意義",
+        "具有重要戰略意義",
+    ];
+    const FORMULAIC_PAIRS: &[(&str, &str)] = &[
+        ("奠定", "理論基礎"),
+        ("提供", "重要框架"),
+        ("發揮", "關鍵作用"),
+        ("印證", "重要性"),
+    ];
     // Regex-like patterns: 隨著.*不斷發展 — handled with substring checks.
     for para in &idx.paragraphs {
         let sents = idx.sentences_in_paragraph(para);
-        if let Some(last) = sents.last() {
-            let s = &text[last.byte_start..last.byte_end];
+        for sent in sents {
+            let s = &text[sent.byte_start..sent.byte_end];
             for &phrase in FORMULAIC_ENDINGS {
                 if let Some(pos) = s.find(phrase) {
-                    let abs = last.byte_start + pos;
+                    let abs = sent.byte_start + pos;
                     if !is_excluded(abs, abs + phrase.len(), excluded) {
                         issues.push(
                             Issue::new(
@@ -2233,8 +2246,30 @@ fn scan_ai_formulaic_section_endings(
                                 IssueType::AiStyle,
                                 Severity::Info,
                             )
-                            .with_context("AI structural: 段落結尾公式化用語，常見於 AI 生成文本"),
+                            .with_context("AI structural: 公式化用語，常見於 AI 生成文本"),
                         );
+                    }
+                }
+            }
+            for &(start_phrase, end_phrase) in FORMULAIC_PAIRS {
+                if let Some(start) = s.find(start_phrase) {
+                    if let Some(end_pos) = s[start + start_phrase.len()..].find(end_phrase) {
+                        let end = start + start_phrase.len() + end_pos + end_phrase.len();
+                        let abs = sent.byte_start + start;
+                        let abs_end = sent.byte_start + end;
+                        if !is_excluded(abs, abs_end, excluded) {
+                            issues.push(
+                                Issue::new(
+                                    abs,
+                                    abs_end - abs,
+                                    &text[abs..abs_end],
+                                    vec![],
+                                    IssueType::AiStyle,
+                                    Severity::Info,
+                                )
+                                .with_context("AI structural: 意義蓋章式收尾，常見於 AI 生成文本"),
+                            );
+                        }
                     }
                 }
             }
@@ -2248,8 +2283,8 @@ fn scan_ai_formulaic_section_endings(
                         usize::MAX // skip — pattern out of order
                     };
                     if gap_chars <= 40 {
-                        let abs = last.byte_start + start;
-                        let abs_end = last.byte_start + end_pos + "不斷發展".len();
+                        let abs = sent.byte_start + start;
+                        let abs_end = sent.byte_start + end_pos + "不斷發展".len();
                         if !is_excluded(abs, abs_end, excluded) {
                             issues.push(
                                 Issue::new(
@@ -2260,7 +2295,7 @@ fn scan_ai_formulaic_section_endings(
                                     IssueType::AiStyle,
                                     Severity::Info,
                                 )
-                                .with_context("AI structural: 段落結尾公式化用語（隨著…不斷發展）"),
+                                .with_context("AI structural: 公式化用語（隨著…不斷發展）"),
                             );
                         }
                     }
@@ -2280,6 +2315,7 @@ fn scan_ai_mechanical_bullets(
     // Scan for Markdown list items where every item starts with **bold**.
     let mut list_start: Option<usize> = None;
     let mut bold_count = 0;
+    let mut four_char_label_count = 0;
     let mut item_count = 0;
     let mut first_item_offset = 0;
 
@@ -2294,8 +2330,10 @@ fn scan_ai_mechanical_bullets(
         if is_list_item {
             if list_start.is_none() {
                 list_start = Some(line_offset);
-                first_item_offset = line_offset;
+                // Point at the list marker itself, not the leading indentation.
+                first_item_offset = line_offset + (line.len() - trimmed.len());
                 bold_count = 0;
+                four_char_label_count = 0;
                 item_count = 0;
             }
             item_count += 1;
@@ -2309,53 +2347,84 @@ fn scan_ai_mechanical_bullets(
             };
             if content.starts_with("**") {
                 bold_count += 1;
+                if bold_label_is_four_chars_before_colon(content) {
+                    four_char_label_count += 1;
+                }
             }
         } else if list_start.is_some() {
             // End of list.
-            if item_count >= 3
-                && bold_count == item_count
-                && !is_excluded(first_item_offset, first_item_offset + 1, excluded)
-            {
-                issues.push(
-                    Issue::new(
-                        first_item_offset,
-                        1,
-                        "-",
-                        vec![],
-                        IssueType::AiStyle,
-                        Severity::Info,
-                    )
-                    .with_context(format!(
-                        "AI structural: 機械式列表 — {item_count} 項全部以粗體關鍵字開頭"
-                    )),
-                );
-            }
+            emit_ai_mechanical_bullet_issue(
+                text,
+                first_item_offset,
+                item_count,
+                bold_count,
+                four_char_label_count,
+                excluded,
+                issues,
+            );
             list_start = None;
         }
     }
     // Flush trailing list.
-    if list_start.is_some()
-        && item_count >= 3
-        && bold_count == item_count
-        && !is_excluded(first_item_offset, first_item_offset + 1, excluded)
-    {
-        issues.push(
-            Issue::new(
-                first_item_offset,
-                1,
-                "-",
-                vec![],
-                IssueType::AiStyle,
-                Severity::Info,
-            )
-            .with_context(format!(
-                "AI structural: 機械式列表 — {item_count} 項全部以粗體關鍵字開頭"
-            )),
+    if list_start.is_some() {
+        emit_ai_mechanical_bullet_issue(
+            text,
+            first_item_offset,
+            item_count,
+            bold_count,
+            four_char_label_count,
+            excluded,
+            issues,
         );
     }
 }
 
 // S5: excessive bold — ≥3 **...** runs per 200 chars in a paragraph.
+fn emit_ai_mechanical_bullet_issue(
+    text: &str,
+    first_item_offset: usize,
+    item_count: usize,
+    bold_count: usize,
+    four_char_label_count: usize,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+) {
+    if item_count < 3 || is_excluded(first_item_offset, first_item_offset + 1, excluded) {
+        return;
+    }
+    let context = if four_char_label_count == item_count {
+        format!("AI structural: 四字標籤式列表 — {item_count} 項全部以四字粗體標籤加冒號開頭")
+    } else if bold_count == item_count {
+        format!("AI structural: 機械式列表 — {item_count} 項全部以粗體關鍵字開頭")
+    } else {
+        return;
+    };
+    // List markers (- * digit) are ASCII, so first_item_offset + 1 is a char boundary.
+    let marker = &text[first_item_offset..first_item_offset + 1];
+    issues.push(
+        Issue::new(
+            first_item_offset,
+            1,
+            marker,
+            vec![],
+            IssueType::AiStyle,
+            Severity::Info,
+        )
+        .with_context(context),
+    );
+}
+
+fn bold_label_is_four_chars_before_colon(content: &str) -> bool {
+    let Some(rest) = content.strip_prefix("**") else {
+        return false;
+    };
+    let Some(close) = rest.find("**") else {
+        return false;
+    };
+    let label = &rest[..close];
+    label.chars().count() == 4 && rest[close + 2..].trim_start().starts_with(['：', ':'])
+}
+
 fn count_non_excluded_bold_runs(text: &str, base_offset: usize, excluded: &[ByteRange]) -> usize {
     text.match_indices("**")
         .filter(|(offset, marker)| {
@@ -2372,6 +2441,26 @@ fn scan_ai_excessive_bold(
     issues: &mut Vec<Issue>,
     idx: &crate::engine::sentence::BoundaryIndex,
 ) {
+    for sent in &idx.sentences {
+        let s = &text[sent.byte_start..sent.byte_end];
+        let bold_count = count_non_excluded_bold_runs(s, sent.byte_start, excluded);
+        if (2..=4).contains(&bold_count) && !is_excluded(sent.byte_start, sent.byte_end, excluded) {
+            let preview_end = char_bounded_end(s, 0, 2);
+            issues.push(
+                Issue::new(
+                    sent.byte_start,
+                    preview_end,
+                    &s[..preview_end],
+                    vec![],
+                    IssueType::AiStyle,
+                    Severity::Info,
+                )
+                .with_context(format!(
+                    "AI structural: 句內關鍵詞粗體排比 — 單句內 {bold_count} 處粗體"
+                )),
+            );
+        }
+    }
     for para in &idx.paragraphs {
         let p = &text[para.byte_start..para.byte_end];
         let char_count = p.chars().count();
@@ -2403,6 +2492,142 @@ fn scan_ai_excessive_bold(
             );
         }
     }
+}
+
+fn scan_ai_abstract_line_metaphor(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    const ABSTRACT_TERMS: &[&str] = &["一條線", "路線", "軸線", "脈絡", "橋"];
+    const GROWTH_VERBS: &[&str] = &["走出來", "長出來", "鋪出來", "延伸", "串起來", "拓寬"];
+
+    // Scope per-paragraph so an abstract term in one section can't correlate
+    // with anaphora in an unrelated one.
+    for para in &idx.paragraphs {
+        let p = &text[para.byte_start..para.byte_end];
+        let Some((first_term, matched_term)) =
+            first_non_excluded_any(p, para.byte_start, ABSTRACT_TERMS, excluded)
+        else {
+            continue;
+        };
+        // "這條路線" contains "這條路" as a prefix; count it once, not twice.
+        let line = count_non_excluded_matches(p, para.byte_start, "這條線", excluded).0;
+        let road_line = count_non_excluded_matches(p, para.byte_start, "這條路線", excluded).0;
+        let road = count_non_excluded_matches(p, para.byte_start, "這條路", excluded).0;
+        let anaphora_count = line + road_line + road.saturating_sub(road_line);
+        if anaphora_count < 2
+            || first_non_excluded_any(p, para.byte_start, GROWTH_VERBS, excluded).is_none()
+        {
+            continue;
+        }
+
+        issues.push(
+            Issue::new(
+                first_term,
+                matched_term.len(),
+                matched_term,
+                vec![],
+                IssueType::AiStyle,
+                Severity::Info,
+            )
+            .with_context(format!(
+                "AI structural: 抽象概念具象成路線並反覆回指 — 回指出現 {anaphora_count} 次"
+            )),
+        );
+    }
+}
+
+fn scan_ai_repeated_parallel_slogan(
+    text: &str,
+    excluded: &[ByteRange],
+    issues: &mut Vec<Issue>,
+    idx: &crate::engine::sentence::BoundaryIndex,
+) {
+    // (slogan text, first byte offset, first paragraph index, emitted).
+    let mut seen: Vec<(String, usize, usize, bool)> = Vec::new();
+    for (para_idx, para) in idx.paragraphs.iter().enumerate() {
+        for sent in idx.sentences_in_paragraph(para) {
+            if is_excluded(sent.byte_start, sent.byte_end, excluded) {
+                continue;
+            }
+            let raw = &text[sent.byte_start..sent.byte_end];
+            let s = raw.trim();
+            if !looks_like_parallel_slogan(s) {
+                continue;
+            }
+            // Offset of the slogan itself, past any leading whitespace/newline.
+            let slogan_start = sent.byte_start + (raw.len() - raw.trim_start().len());
+            if let Some((_, first_offset, first_para, emitted)) =
+                seen.iter_mut().find(|(prior, _, _, _)| prior == s)
+            {
+                // Only a slogan repeated across paragraphs is "金句疊句"; the same
+                // parallel sentence repeated within one paragraph is ordinary 排比.
+                if *first_para != para_idx && !*emitted {
+                    let offset = *first_offset;
+                    let len = char_bounded_end(&text[offset..], 0, 8);
+                    issues.push(
+                        Issue::new(
+                            offset,
+                            len,
+                            &text[offset..offset + len],
+                            vec![],
+                            IssueType::AiStyle,
+                            Severity::Info,
+                        )
+                        .with_context("AI structural: 金句疊句 — 對仗句跨段重複出現"),
+                    );
+                    *emitted = true;
+                }
+            } else {
+                seen.push((s.to_string(), slogan_start, para_idx, false));
+            }
+        }
+    }
+}
+
+fn looks_like_parallel_slogan(sentence: &str) -> bool {
+    let s = sentence
+        .trim_end_matches(['。', '！', '？', '!', '?'])
+        .trim();
+    let char_count = s.chars().count();
+    if !(8..=80).contains(&char_count) {
+        return false;
+    }
+    if (s.contains("不是") && s.contains("而是"))
+        || (s.contains("不只") && (s.contains("更是") || s.contains("也是")))
+        || (s.contains('越') && s.matches('越').count() >= 2)
+    {
+        return true;
+    }
+    // Semicolon is the stronger parallel boundary; split on it before comma.
+    let Some((left, right)) = s
+        .split_once('；')
+        .or_else(|| s.split_once('，'))
+        .or_else(|| s.split_once(','))
+    else {
+        return false;
+    };
+    let left_len = left.chars().count();
+    let right_len = right.chars().count();
+    left_len >= 3 && right_len >= 3 && left_len.abs_diff(right_len) <= 8
+}
+
+fn first_non_excluded_any<'a>(
+    text: &str,
+    base_offset: usize,
+    needles: &'a [&'a str],
+    excluded: &[ByteRange],
+) -> Option<(usize, &'a str)> {
+    needles
+        .iter()
+        .filter_map(|&needle| {
+            count_non_excluded_matches(text, base_offset, needle, excluded)
+                .1
+                .map(|offset| (offset, needle))
+        })
+        .min_by_key(|(offset, _)| *offset)
 }
 
 fn count_non_excluded_matches(
@@ -4065,6 +4290,8 @@ pub(crate) fn scan_ai_structural_phase2(
     scan_ai_formulaic_despite(text, excluded, issues, boundary_index);
     scan_ai_false_ranges(text, excluded, issues, boundary_index);
     scan_ai_hedging_density(text, excluded, issues, boundary_index);
+    scan_ai_abstract_line_metaphor(text, excluded, issues, boundary_index);
+    scan_ai_repeated_parallel_slogan(text, excluded, issues, boundary_index);
 }
 
 // Lexical translationese detectors that need no sentence/paragraph index.
@@ -6006,6 +6233,140 @@ mod tests {
         assert!(
             bold_issues.is_empty(),
             "excluded bold markers should not trigger excessive-bold: {bold_issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_four_char_bold_label_bullets_trigger() {
+        let text =
+            "- **核心價值**：第一段說明\n- **治理架構**：第二段說明\n- **實作路徑**：第三段說明";
+        let issues = scan_phase2(text);
+        assert!(
+            issues.iter().any(|i| i
+                .context
+                .as_ref()
+                .is_some_and(|c| c.contains("四字標籤式列表"))),
+            "four-character bold labels should trigger: {issues:?}"
+        );
+        assert!(
+            !issues
+                .iter()
+                .any(|i| i.context.as_ref().is_some_and(|c| c.contains("機械式列表"))),
+            "specialized four-character list should replace generic mechanical list: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_significance_stamping_triggers_per_paragraph() {
+        let text = "這項安排提供政策的重要框架，也印證制度的重要性。";
+        let issues = scan_phase2(text);
+        assert!(
+            issues.iter().any(|i| i
+                .context
+                .as_ref()
+                .is_some_and(|c| c.contains("意義蓋章式收尾"))),
+            "significance stamping should trigger outside section-final sentences: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_significance_stamping_exact_phrase_not_duplicated() {
+        let text = "這項安排提供重要框架。";
+        let issues = scan_phase2(text);
+        let stamping_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| {
+                i.context
+                    .as_ref()
+                    .is_some_and(|c| c.contains("意義蓋章式收尾") || c.contains("公式化用語"))
+            })
+            .collect();
+        assert_eq!(
+            stamping_issues.len(),
+            1,
+            "exact phrase and pair match should not double-report: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_in_sentence_bold_parallel_triggers() {
+        let text = "我們需要**理解歷史**、**回到現場**，並**重建脈絡**。";
+        let issues = scan_phase2(text);
+        assert!(
+            issues.iter().any(|i| {
+                i.context
+                    .as_ref()
+                    .is_some_and(|c| c.contains("句內關鍵詞粗體排比"))
+            }),
+            "2-4 bold runs in one sentence should trigger: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_abstract_line_metaphor_requires_three_signals() {
+        let good = "改革不是口號，而是一條線。這條線從地方走出來，連到制度現場。這條線也會延伸到新的公共討論。";
+        let good_issues = scan_phase2(good);
+        let line_issue = good_issues.iter().find(|i| {
+            i.context
+                .as_ref()
+                .is_some_and(|c| c.contains("抽象概念具象成路線"))
+        });
+        assert!(
+            line_issue.is_some(),
+            "three-signal abstract line metaphor should trigger: {good_issues:?}"
+        );
+        assert_eq!(line_issue.unwrap().found, "一條線");
+
+        let idiom = "這條路走不通，所以團隊改用另一個方案。";
+        let idiom_issues = scan_phase2(idiom);
+        assert!(
+            !idiom_issues.iter().any(|i| {
+                i.context
+                    .as_ref()
+                    .is_some_and(|c| c.contains("抽象概念具象成路線"))
+            }),
+            "single idiom must stay silent: {idiom_issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_repeated_parallel_slogan_triggers_once() {
+        let text = "制度不是牆，而是橋。第一段說明政策背景。\n\n制度不是牆，而是橋。第二段重複同一句口號。";
+        let issues = scan_phase2(text);
+        let slogan_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.context.as_ref().is_some_and(|c| c.contains("金句疊句")))
+            .collect();
+        assert_eq!(
+            slogan_issues.len(),
+            1,
+            "repeated parallel slogan should trigger once: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_same_paragraph_slogan_repetition_does_not_trigger() {
+        // Same parallel sentence repeated within one paragraph is ordinary 排比,
+        // not the cross-section 金句疊句 tic — must stay silent.
+        let text = "制度不是牆，而是橋。制度不是牆，而是橋。我們要繼續努力。";
+        let issues = scan_phase2(text);
+        assert!(
+            !issues
+                .iter()
+                .any(|i| i.context.as_ref().is_some_and(|c| c.contains("金句疊句"))),
+            "same-paragraph repetition should not trigger slogan detector: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn ai_repeated_plain_sentence_does_not_trigger_slogan() {
+        let text = "請在週五前提交報告。這是行政提醒。\n\n請在週五前提交報告。這是第二次提醒。";
+        let issues = scan_phase2(text);
+        assert!(
+            !issues
+                .iter()
+                .any(|i| i.context.as_ref().is_some_and(|c| c.contains("金句疊句"))),
+            "ordinary repeated sentence should not trigger slogan detector: {issues:?}"
         );
     }
 

--- a/src/engine/scan/quotes.rs
+++ b/src/engine/scan/quotes.rs
@@ -88,6 +88,7 @@ pub(crate) fn fix_quote_pairing(text: &str, issues: &mut [Issue]) {
                 "\u{300e}" // 『 (secondary)
             };
             issues[issue_idx].suggestions = vec![bracket.to_string()].into();
+            issues[issue_idx].refresh_suggested_rewrite();
             depth += 1;
         } else {
             depth = depth.saturating_sub(1);
@@ -97,6 +98,7 @@ pub(crate) fn fix_quote_pairing(text: &str, issues: &mut [Issue]) {
                 "\u{300f}" // 』 (secondary)
             };
             issues[issue_idx].suggestions = vec![bracket.to_string()].into();
+            issues[issue_idx].refresh_suggested_rewrite();
         }
 
         prev_end = offset + issues[issue_idx].length;

--- a/src/engine/scan/rule_ir.rs
+++ b/src/engine/scan/rule_ir.rs
@@ -614,6 +614,7 @@ fn inflate_spelling_issues_inner(
                 issue.found = s.to_string();
             }
             issue.suggestions = db.spelling_suggestions[idx].clone();
+            issue.refresh_suggested_rewrite();
             issue.editorial_confidence = db.spelling_editorial_confidence[idx];
             if !offset_only {
                 issue.context.clone_from(&db.spelling_contexts[idx]);

--- a/src/engine/style_score.rs
+++ b/src/engine/style_score.rs
@@ -147,6 +147,7 @@ mod tests {
             col: 0,
             found: "x".into(),
             suggestions: Arc::from(Vec::<String>::new()),
+            suggested_rewrite: None,
             rule_type,
             severity,
             context: None,

--- a/src/mcp/sampling.rs
+++ b/src/mcp/sampling.rs
@@ -762,9 +762,12 @@ fn apply_disambiguation(issue: &mut Issue, matched_term: &Option<String>, detail
     issue.llm_judged = true;
     if let Some(term) = matched_term {
         if let Some(pos) = issue.suggestions.iter().position(|s| s == term) {
-            let mut sugs = issue.suggestions.to_vec();
-            sugs.swap(0, pos);
-            issue.suggestions = sugs.into();
+            if pos != 0 {
+                let mut sugs = issue.suggestions.to_vec();
+                sugs.swap(0, pos);
+                issue.suggestions = sugs.into();
+            }
+            issue.refresh_suggested_rewrite();
         }
         issue.context = Some(format!("LLM disambiguation: '{term}' ({detail})").into());
     } else {
@@ -1082,6 +1085,23 @@ mod tests {
         let suggestions = vec!["".into(), "軟體".into()];
         // Empty string should NOT match even via exact-match path.
         assert_eq!(find_matching_suggestion("", &suggestions), None);
+    }
+
+    #[test]
+    fn llm_promotion_refreshes_translationese_rewrite() {
+        let mut issue = Issue::new(
+            0,
+            "冗長".len(),
+            "冗長",
+            vec!["短句".to_string(), "精簡".to_string()],
+            IssueType::Translationese,
+            Severity::Warning,
+        );
+
+        apply_disambiguation(&mut issue, &Some("精簡".to_string()), "test");
+
+        assert_eq!(issue.suggestions.as_ref(), ["精簡", "短句"]);
+        assert_eq!(issue.suggested_rewrite.as_deref(), Some("精簡"));
     }
 
     #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -842,6 +842,7 @@ impl Server {
                             issue.anchor_match = state.anchor_match;
                             issue.context = state.context.clone();
                             issue.suggestions = state.suggestions.clone().into();
+                            issue.refresh_suggested_rewrite();
                         }
                     }
                 }
@@ -2480,6 +2481,7 @@ fn build_compact_groups(issues: &[Issue], explain: bool, include_stats: bool) ->
         let group = groups.entry(key).or_insert_with(|| CompactGroup {
             found: issue.found.clone(),
             suggestions: issue.suggestions.to_vec(),
+            suggested_rewrite: issue.suggested_rewrite.clone(),
             rule_type: rt.to_string(),
             severity: issue.severity.name().to_string(),
             context: issue.context.as_deref().map(str::to_string),
@@ -2795,6 +2797,8 @@ fn build_fix_diff(
 struct CompactGroup {
     found: String,
     suggestions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suggested_rewrite: Option<String>,
     rule_type: String,
     severity: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -552,6 +552,10 @@ pub struct Issue {
     /// Suggested replacements.  Arc avoids per-issue allocation during
     /// inflate — most issues share suggestions with their source rule.
     pub suggestions: Arc<[String]>,
+    /// Manual rewrite hint for translationese issues.  Derived from the
+    /// first non-empty suggestion when a translationese rule supplies one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_rewrite: Option<String>,
     /// Classification of the triggering rule.
     pub rule_type: IssueType,
     /// Severity level.
@@ -619,6 +623,23 @@ pub struct TableCell {
 }
 
 impl Issue {
+    /// Derive the manual rewrite hint: the first non-empty suggestion, but
+    /// only for translationese rules (other rule types have no rewrite hint).
+    pub fn derive_suggested_rewrite(
+        rule_type: IssueType,
+        suggestions: &[String],
+    ) -> Option<String> {
+        if rule_type == IssueType::Translationese {
+            suggestions.iter().find(|s| !s.is_empty()).cloned()
+        } else {
+            None
+        }
+    }
+
+    pub fn refresh_suggested_rewrite(&mut self) {
+        self.suggested_rewrite = Self::derive_suggested_rewrite(self.rule_type, &self.suggestions);
+    }
+
     /// Construct an issue with all semantic fields; line/col are set to 0
     /// (filled in later by the line-index pass).
     pub fn new(
@@ -629,6 +650,7 @@ impl Issue {
         rule_type: IssueType,
         severity: Severity,
     ) -> Self {
+        let suggested_rewrite = Self::derive_suggested_rewrite(rule_type, &suggestions);
         Self {
             offset,
             length,
@@ -636,6 +658,7 @@ impl Issue {
             col: 0,
             found: found.into(),
             suggestions: suggestions.into(),
+            suggested_rewrite,
             rule_type,
             severity,
             context: None,
@@ -673,6 +696,7 @@ impl Issue {
             suggestions: EMPTY_SUGGESTIONS
                 .get_or_init(|| Arc::from(Vec::<String>::new()))
                 .clone(),
+            suggested_rewrite: None,
             rule_type,
             severity,
             context: None,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -45,6 +45,8 @@ struct BrowserIssue {
     col: usize,
     found: String,
     suggestions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suggested_rewrite: Option<String>,
     rule_type: String,
     severity: String,
     context: Option<String>,
@@ -128,6 +130,7 @@ impl From<&Issue> for BrowserIssue {
             col: issue.col,
             found: issue.found.clone(),
             suggestions: issue.suggestions.iter().cloned().collect(),
+            suggested_rewrite: issue.suggested_rewrite.clone(),
             rule_type: issue.rule_type.name().to_owned(),
             severity: issue.severity.name().to_owned(),
             context: issue.context.as_ref().map(ToString::to_string),

--- a/tests/cli-lint.rs
+++ b/tests/cli-lint.rs
@@ -1090,3 +1090,116 @@ fn cli_lint_detect_style_uses_post_fix_text_length() {
         "scorecard must use post-fix text length; expected {expected}, got {got}, stdout={stdout}"
     );
 }
+
+#[test]
+fn cli_lint_translationese_suggested_rewrite_serialized() {
+    let output = run_lint_stdin(
+        &["--detect-translationese", "--format", "json"],
+        "大家需要互相合作，也要仔細的看文件。",
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("translationese JSON output");
+    let issues = json["issues"].as_array().expect("issues array");
+    let semantic_overlap = issues
+        .iter()
+        .find(|i| i["found"] == "互相合作")
+        .expect("deferred translationese issue present");
+    assert_eq!(semantic_overlap["suggested_rewrite"], "合作");
+    let particle_mixup = issues
+        .iter()
+        .find(|i| i["found"] == "仔細的看")
+        .expect("direct translationese issue present");
+    assert_eq!(particle_mixup["suggested_rewrite"], "仔細地看");
+}
+
+#[test]
+fn cli_lint_writing_humanizer_watchlist_comprehensive() {
+    let text = "此外，持久的制度與永恆的價值會增強信任並提升效率。\
+        我們要培養能力、促進合作、涵養精神，留下寶貴的經驗。\
+        這是一個充滿活力的場域，呈現相互作用與交織的關係。\
+        系統追求無縫整合與無縫銜接，卻形成錯綜複雜的織錦與畫卷。\
+        這些安排可以賦予力量。\
+        在當今數位治理的時代，隨著產業的快速發展，眾所周知，不言而喻，本文將說明背景，本節將補充案例。\
+        接下來我們來看，理解了這些資料我們就能明白。願我們持續努力，讓我們都能前進，歷史將會記住，世界和平作出更大貢獻。";
+    let output = run_lint_stdin(&["--detect-ai", "--format", "json"], text);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("AI JSON output");
+    let found: std::collections::HashSet<_> = json["issues"]
+        .as_array()
+        .expect("issues array")
+        .iter()
+        .filter(|i| i["rule_type"] == "ai_style")
+        .filter_map(|i| i["found"].as_str())
+        .collect();
+    for expected in [
+        "此外",
+        "持久的",
+        "永恆的",
+        "增強",
+        "提升",
+        "培養",
+        "促進",
+        "涵養",
+        "寶貴的",
+        "充滿活力",
+        "相互作用",
+        "交織",
+        "無縫",
+        "無縫銜接",
+        "錯綜複雜",
+        "賦予力量",
+        "織錦",
+        "畫卷",
+        "在當今",
+        "隨著",
+        "眾所周知",
+        "不言而喻",
+        "本文將",
+        "本節將",
+        "接下來我們來看",
+        "理解了",
+        "我們就能明白",
+        "願我們",
+        "讓我們都能",
+        "歷史將會記住",
+        "世界和平作出更大貢獻",
+    ] {
+        assert!(
+            found.contains(expected),
+            "missing {expected}; found={found:?}; stdout={stdout}"
+        );
+    }
+}
+
+#[test]
+fn cli_lint_translationese_technical_gate_low_false_positive_rate() {
+    let clean_technical = "本工具使用有限狀態掃描器處理繁體中文文件。\
+        規則資料在建置階段編譯，執行時直接載入快取。\
+        命令列介面支援 JSON 輸出、Markdown 排除區段、術語表與基準檔。\
+        測試資料涵蓋標點、詞彙、文法、表格欄位與快取命中路徑。\
+        技術文件可指定 technical profile，讓校準門檻符合規格文件的語氣。";
+    let output = run_lint_stdin(
+        &[
+            "--detect-translationese",
+            "--translationese-domain",
+            "technical",
+            "--format",
+            "json",
+        ],
+        clean_technical,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("technical translationese JSON output");
+    let translationese_count = json["issues"]
+        .as_array()
+        .expect("issues array")
+        .iter()
+        .filter(|i| i["rule_type"] == "translationese")
+        .count();
+    assert!(
+        translationese_count <= 1,
+        "technical clean-text gate allows <=1 FP per short fixture: {stdout}"
+    );
+}


### PR DESCRIPTION
AI structural detectors:
- formulaic significance-stamping pairs (奠定…理論基礎 etc.), scanned per-sentence rather than only paragraph-final;
- four-char bold-label list detection;
- in-sentence bold parallelism;
- abstract-line metaphor with anaphora, scoped per-paragraph;
- cross-paragraph repeated parallel slogan.

Correctness:
- anaphora prefix double-count (這條路線 contains 這條路) counted once;
- slogan split on the stronger boundary (；before ，);
- list-marker offset points at the marker, and the issue reports the actual marker char (- * or digit) rather than a hardcoded "-";
- slogan issue anchors past leading whitespace and no longer claims "跨段" repetition it does not verify;
- metaphor issue spans the matched term exactly;
- formulaic endings subsumed by pair patterns removed to stop double-reporting;
- context strings no longer claim "段落結尾" when firing mid-paragraph.

Provenance: watchlist terms and AI-structural patterns adapted from the writing-humanizer skill [1]. The translationese rewrite-hint work is independent. (externals/ is gitignored; cuimao-translator is an unrelated reference and is not a source for this change.)

[1] https://github.com/shyuan/writing-humanizer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves structural detectors for machine‑generated prose with new patterns and better precision, and adds a `suggested_rewrite` hint for translationese across outputs. Expands the watchlist and fixes offsets, duplication, and context edge cases.

- **New Features**
  - New detectors: significance‑stamping pairs (per sentence), four‑character bold‑label lists, in‑sentence bold parallelism, abstract‑line metaphor with anaphora (per paragraph), and repeated parallel slogans (across paragraphs).
  - Translationese `suggested_rewrite`: derived from the first non‑empty suggestion, refreshed on promotions, and serialized in CLI JSON, browser/wasm, and MCP compact outputs.
  - Expanded watchlist in `assets/ruleset.json` with stock phrases and metaphors, each with concise guidance.

- **Bug Fixes**
  - Correct counts and anchors: no double‑count on “這條路線” vs “這條路”; list issues point at the actual `-/*/digit` marker; slogan anchors skip leading whitespace and prefer semicolon over comma for splits.
  - Remove duplicate reports where pair patterns subsume formulaic endings; metaphor spans match exactly; contexts no longer claim paragraph‑end when mid‑paragraph.
  - Promotions (LLM or local) now refresh the rewrite hint; quote pairing and spelling inflation do the same.

<sup>Written for commit fc00c3a2cfea5c78b0c6c0d2ddbab77a26ad8171. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/zhtw-mcp/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

