### PR TITLE
Migrate logging to tracing and add scan instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,25 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "env_filter"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
-dependencies = [
- "env_filter",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +587,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +609,15 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -929,6 +934,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +953,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spin"
@@ -1023,6 +1043,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1114,6 +1143,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1276,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "walkdir"
@@ -1628,9 +1724,7 @@ dependencies = [
  "criterion",
  "daachorse",
  "dirs",
- "env_logger",
  "fs2",
- "log",
  "postcard",
  "pulldown-cmark",
  "rayon",
@@ -1641,6 +1735,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "unicode-normalization",
  "ureq",
  "urlencoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ include = ["src/**/*", "assets/ruleset.json", "Cargo.toml", "LICENSE", "README.m
 default = ["native", "translate"]
 native = [
     "dep:dirs",
-    "dep:env_logger",
     "dep:fs2",
     "dep:rayon",
     "dep:tempfile",
@@ -45,8 +44,8 @@ rayon = { version = "1", optional = true }
 anyhow = "1"
 unicode-normalization = "0.1"
 pulldown-cmark = { version = "0.13", default-features = false }
-log = "0.4"
-env_logger = { version = "0.11", default-features = false, optional = true }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
 dirs = { version = "5.0", optional = true }
 tempfile = { version = "3.0", optional = true }
 toml = { version = "0.8", optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,11 +70,11 @@ impl ProjectConfig {
         let content = std::fs::read_to_string(&path).ok()?;
         match toml::from_str::<ProjectConfig>(&content) {
             Ok(cfg) => {
-                log::info!("loaded config from {}", path.display());
+                tracing::info!("loaded config from {}", path.display());
                 Some(cfg)
             }
             Err(e) => {
-                log::warn!("failed to parse {}: {}", path.display(), e);
+                tracing::warn!("failed to parse {}: {}", path.display(), e);
                 None
             }
         }

--- a/src/engine/scan/mod.rs
+++ b/src/engine/scan/mod.rs
@@ -885,6 +885,13 @@ impl Scanner {
         case_rules: Vec<CaseRule>,
         filter: &rule_ir::ProfileFilter,
     ) -> Self {
+        let started = std::time::Instant::now();
+        let _span = tracing::info_span!(
+            "build_ac",
+            spelling_rule_count = spelling_rules.len() as u64,
+            case_rule_count = case_rules.len() as u64
+        )
+        .entered();
         let case_rules: Vec<CaseRule> = case_rules.into_iter().filter(|r| !r.disabled).collect();
 
         // Build segmenter from the FULL rule set (before profile filtering)
@@ -895,7 +902,7 @@ impl Scanner {
         let spelling_db = match rule_ir::compile_spelling_rules_filtered(spelling_rules, filter) {
             Ok(db) => db,
             Err(e) => {
-                eprintln!("[zhtw-mcp] spelling rule compilation failed: {e}");
+                tracing::warn!("spelling rule compilation failed: {e}");
                 rule_ir::CompiledSpellingDb::empty()
             }
         };
@@ -909,10 +916,14 @@ impl Scanner {
         {
             Ok(ac) => Some(ac),
             Err(e) => {
-                eprintln!("[zhtw-mcp] case AC build failed: {e}");
+                tracing::warn!("case AC build failed: {e}");
                 None
             }
         };
+        tracing::info!(
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "build_ac completed"
+        );
 
         Self {
             spelling_db,
@@ -1065,6 +1076,13 @@ impl Scanner {
         cfg: ProfileConfig,
         content_type: ContentType,
     ) -> ScanOutput {
+        let started = std::time::Instant::now();
+        let _span = tracing::info_span!(
+            "scan",
+            content_length = text.len() as u64,
+            content_type = content_type.name()
+        )
+        .entered();
         let norm = normalize_nfc(text);
         let scan_text = &norm.text;
         let nfc_changed = !norm.offset_map.is_empty();
@@ -1131,6 +1149,11 @@ impl Scanner {
             }
         }
 
+        tracing::info!(
+            issue_count = output.issues.len() as u64,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "scan completed"
+        );
         output
     }
 

--- a/src/engine/scan/rule_ir.rs
+++ b/src/engine/scan/rule_ir.rs
@@ -773,7 +773,7 @@ pub fn compile_spelling_rules_filtered(
                 let idx = match u16::try_from(clue_vec.len()) {
                     Ok(i) => i,
                     Err(_) => {
-                        eprintln!(
+                        tracing::warn!(
                             "[zhtw-mcp] clue index overflow (>{} unique clues); \
                              remaining clues will be ignored",
                             u16::MAX
@@ -814,7 +814,7 @@ pub fn compile_spelling_rules_filtered(
             {
                 Ok(ac) => Some(ac),
                 Err(e) => {
-                    eprintln!("[zhtw-mcp] clue AC build failed: {e}");
+                    tracing::warn!("clue AC build failed: {e}");
                     None
                 }
             }
@@ -829,7 +829,7 @@ pub fn compile_spelling_rules_filtered(
         for (i, slot) in ids_vec.iter_mut().enumerate() {
             if let Some(ids) = slot {
                 if ids.len() > 32 {
-                    eprintln!(
+                    tracing::warn!(
                         "[zhtw-mcp] rule '{}' has {} {label} clues, \
                          exceeds bitset capacity 32; truncating",
                         spelling_rules[i].from,
@@ -860,9 +860,10 @@ pub fn compile_spelling_rules_filtered(
                     .filter_map(|s| {
                         let clue = PositionalClue::parse(s);
                         if clue.is_none() {
-                            eprintln!(
+                            tracing::warn!(
                                 "[zhtw-mcp] rule '{}': unrecognized positional clue '{}'",
-                                rule.from, s
+                                rule.from,
+                                s
                             );
                         }
                         clue
@@ -952,7 +953,7 @@ pub fn compile_spelling_rules_filtered(
         {
             Ok(ac) => Some(ac),
             Err(e) => {
-                eprintln!("[zhtw-mcp] charwise AC build failed, using bytewise fallback: {e}");
+                tracing::warn!("charwise AC build failed, using bytewise fallback: {e}");
                 None
             }
         }
@@ -965,7 +966,7 @@ pub fn compile_spelling_rules_filtered(
         {
             Ok(ac) => Some(ac),
             Err(e) => {
-                eprintln!("[zhtw-mcp] bytewise spelling AC build failed: {e}");
+                tracing::warn!("bytewise spelling AC build failed: {e}");
                 None
             }
         }

--- a/src/fixer.rs
+++ b/src/fixer.rs
@@ -113,8 +113,22 @@ pub fn apply_fixes_with_context(
     excluded_offsets: &[(usize, usize)],
     segmenter: Option<&Segmenter>,
 ) -> FixResult {
+    let started = std::time::Instant::now();
+    let _span = tracing::info_span!(
+        "fix",
+        content_length = text.len() as u64,
+        issue_count = issues.len() as u64,
+        mode = ?mode
+    )
+    .entered();
     // Lint-only mode: no fixes attempted, nothing to skip.
     if mode == FixMode::None {
+        tracing::info!(
+            fix_count = 0_u64,
+            skipped_count = 0_u64,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "fix completed"
+        );
         return FixResult {
             text: text.to_string(),
             applied: 0,
@@ -142,7 +156,7 @@ pub fn apply_fixes_with_context(
     // copying unchanged gaps and appending replacements.
     for issue in issues {
         let Some(end) = issue.offset.checked_add(issue.length) else {
-            log::warn!(
+            tracing::warn!(
                 "skipping malformed issue at offset {}: length overflow",
                 issue.offset
             );
@@ -292,6 +306,12 @@ pub fn apply_fixes_with_context(
     // no fixes were applied).
     out.push_str(&text[cursor..]);
 
+    tracing::info!(
+        fix_count = applied as u64,
+        skipped_count = skipped as u64,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "fix completed"
+    );
     FixResult {
         text: out,
         applied,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,7 @@ pub mod fixer;
 #[cfg(feature = "native")]
 pub mod mcp;
 pub mod rules;
+#[cfg(feature = "native")]
+pub mod trace;
 #[cfg(feature = "browser-wasm")]
 pub mod wasm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,9 +44,15 @@ const COLORS_OFF: Colors = Colors {
 };
 
 fn main() -> Result<()> {
-    env_logger::init();
-
     let args: Vec<String> = std::env::args().collect();
+    let default_log = if args.iter().any(|a| a == "--debug") {
+        "debug"
+    } else if args.iter().any(|a| a == "--verbose") {
+        "info"
+    } else {
+        "warn"
+    };
+    zhtw_mcp::trace::init(default_log);
 
     // Parse CLI args:
     //   zhtw-mcp                                — run MCP server (default paths)
@@ -312,6 +318,8 @@ fn main() -> Result<()> {
                         "--telemetry" => {
                             telemetry = true;
                         }
+                        "--verbose" => {}
+                        "--debug" => {}
                         _ => {
                             lint_files.push(args[i].clone());
                         }
@@ -481,6 +489,8 @@ fn main() -> Result<()> {
                     args.get(i).context("--config requires a path")?,
                 ));
             }
+            "--verbose" => {}
+            "--debug" => {}
             _ => {
                 anyhow::bail!("unknown argument: {}", args[i]);
             }
@@ -657,7 +667,7 @@ fn main() -> Result<()> {
         match zhtw_mcp::rules::store::TranslationMemoryStore::open(&tm_path) {
             Ok(store) => Some(store),
             Err(e) => {
-                log::warn!(
+                tracing::warn!(
                     "failed to open translation memory at {}: {e}",
                     tm_path.display()
                 );
@@ -674,11 +684,11 @@ fn main() -> Result<()> {
         tm_store,
     )?;
 
-    log::info!("zhtw-mcp server starting on stdio");
+    tracing::info!("zhtw-mcp server starting on stdio");
 
     #[cfg(feature = "async-transport")]
     {
-        log::info!("using async transport (tokio)");
+        tracing::info!("using async transport (tokio)");
         zhtw_mcp::mcp::transport_async::run_async_stdio(&mut server)?;
     }
     #[cfg(not(feature = "async-transport"))]
@@ -902,7 +912,7 @@ fn run_lint_batch(params: &LintBatchParams<'_>) -> Result<()> {
     // Open translation memory (if path provided and file exists/creatable).
     let tm_store = params.tm_path.as_ref().and_then(|p| {
         zhtw_mcp::rules::store::TranslationMemoryStore::open(p)
-            .map_err(|e| log::warn!("failed to open TM at {}: {e}", p.display()))
+            .map_err(|e| tracing::warn!("failed to open TM at {}: {e}", p.display()))
             .ok()
     });
 

--- a/src/mcp/sampling.rs
+++ b/src/mcp/sampling.rs
@@ -403,16 +403,16 @@ impl<'a> SamplingBridge<'a> {
 
             let resp_id = resp.get("id").and_then(|v| v.as_str());
             if resp_id.is_none() && resp.get("id").is_some() {
-                log::debug!("sampling: message has non-string id, stashing");
+                tracing::debug!("sampling: message has non-string id, stashing");
             }
             if resp_id != Some(expected_id) {
-                log::debug!("sampling: stashing message with id {:?}", resp_id);
+                tracing::debug!("sampling: stashing message with id {:?}", resp_id);
                 self.spillover.push(StdinMsg::Line(line));
                 continue;
             }
 
             if resp.get("error").is_some() {
-                log::warn!("sampling request returned error");
+                tracing::warn!("sampling request returned error");
                 return None;
             }
 
@@ -429,11 +429,11 @@ impl<'a> SamplingBridge<'a> {
                 Some(t) if !t.trim().is_empty() => return Some(t.trim().to_string()),
                 Some(_) => {
                     // Blank response: treat as failure but don't stash (consumed).
-                    log::debug!("sampling: blank response text, treating as failure");
+                    tracing::debug!("sampling: blank response text, treating as failure");
                     return None;
                 }
                 None => {
-                    log::debug!("sampling: id matched but payload shape unexpected, stashing");
+                    tracing::debug!("sampling: id matched but payload shape unexpected, stashing");
                     self.spillover.push(StdinMsg::Line(line));
                     return None;
                 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -113,6 +113,10 @@ impl Server {
         self.client_capabilities.sampling
     }
 
+    pub(crate) fn supports_logging(&self) -> bool {
+        self.client_capabilities.logging
+    }
+
     /// Handle pre-initialization routing shared between sync and async transports.
     ///
     /// Returns `Some(response)` if the method was handled (initialize, ping,
@@ -124,7 +128,7 @@ impl Server {
     ) -> Option<Option<JsonRpcResponse>> {
         // exit is always honored regardless of lifecycle state.
         if req.method == "exit" {
-            log::info!("exit notification, terminating");
+            tracing::info!("exit notification, terminating");
             // Flush judgment cache before exit (process::exit skips Drop).
             self.judgment_cache.flush();
             // MCP spec: unconditional process exit.
@@ -135,7 +139,7 @@ impl Server {
 
         // After shutdown, reject everything except exit (handled above).
         if self.shutdown_requested {
-            log::warn!("rejecting {} after shutdown", req.method);
+            tracing::warn!("rejecting {} after shutdown", req.method);
             return Some(if req.id.is_some() {
                 Some(JsonRpcResponse::error(
                     req.id.clone(),
@@ -150,11 +154,11 @@ impl Server {
         match req.method.as_str() {
             "initialize" => {
                 if req.id.is_none() {
-                    log::warn!("initialize sent as notification, ignoring");
+                    tracing::warn!("initialize sent as notification, ignoring");
                     return Some(None);
                 }
                 if self.initialized {
-                    log::warn!("duplicate initialize request, rejecting");
+                    tracing::warn!("duplicate initialize request, rejecting");
                     return Some(Some(JsonRpcResponse::error(
                         req.id.clone(),
                         INVALID_REQUEST,
@@ -164,7 +168,7 @@ impl Server {
                 Some(Some(self.handle_initialize(req)))
             }
             "notifications/cancelled" => {
-                log::info!("{}", req.method);
+                tracing::info!("{}", req.method);
                 if req.id.is_some() {
                     Some(Some(JsonRpcResponse::error(
                         req.id.clone(),
@@ -176,7 +180,7 @@ impl Server {
                 }
             }
             "notifications/initialized" => {
-                log::info!("{}", req.method);
+                tracing::info!("{}", req.method);
                 if req.id.is_some() {
                     Some(Some(JsonRpcResponse::error(
                         req.id.clone(),
@@ -188,7 +192,7 @@ impl Server {
                 }
             }
             "shutdown" => {
-                log::info!("shutdown requested");
+                tracing::info!("shutdown requested");
                 self.shutdown_requested = true;
                 if req.id.is_some() {
                     Some(Some(JsonRpcResponse::success(
@@ -207,12 +211,12 @@ impl Server {
                         serde_json::json!({}),
                     )))
                 } else {
-                    log::debug!("ping sent as notification, ignoring");
+                    tracing::debug!("ping sent as notification, ignoring");
                     Some(None)
                 }
             }
             _ if !self.initialized => {
-                log::warn!("rejecting {} before initialization", req.method);
+                tracing::warn!("rejecting {} before initialization", req.method);
                 Some(if req.id.is_some() {
                     Some(JsonRpcResponse::error(
                         req.id.clone(),
@@ -239,7 +243,7 @@ impl Server {
             "prompts/list" => Some(self.handle_prompts_list(req)),
             "prompts/get" => Some(self.handle_prompts_get(req)),
             _ => {
-                log::debug!("unhandled method: {}", req.method);
+                tracing::debug!("unhandled method: {}", req.method);
                 if req.id.is_some() {
                     Some(JsonRpcResponse::error(
                         req.id.clone(),
@@ -260,6 +264,7 @@ impl Server {
             Ok(p) => p,
             Err(resp) => return resp,
         };
+        let _span = tracing::info_span!("mcp_request", method = "initialize").entered();
 
         // Store parsed client capabilities for later use (e.g. sampling).
         self.client_capabilities = ClientCapabilities::from(&params.capabilities);
@@ -300,6 +305,7 @@ impl Server {
         req: &mut JsonRpcRequest,
         bridge: Option<&mut SamplingBridge<'_>>,
     ) -> JsonRpcResponse {
+        let _span = tracing::info_span!("mcp_request", method = "tools/call").entered();
         let params: CallToolParams = match parse_params(req, "tools/call") {
             Ok(p) => p,
             Err(resp) => return resp,
@@ -344,6 +350,7 @@ impl Server {
         mut bridge: Option<&mut SamplingBridge<'_>>,
         id: Option<super::types::RequestId>,
     ) -> Result<CallToolResult, JsonRpcResponse> {
+        let started = std::time::Instant::now();
         // Snapshot cache counters at start for per-request telemetry.
         let cache_hits_before = self.judgment_cache.hits;
         let cache_misses_before = self.judgment_cache.misses;
@@ -429,6 +436,13 @@ impl Server {
             .get("include_stats")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        let _span = tracing::info_span!(
+            "tool_check",
+            content_length = text.len() as u64,
+            content_type = content_type.name(),
+            profile = profile.name()
+        )
+        .entered();
 
         if include_telemetry && output_mode == OutputMode::Tabular {
             return Err(param_error(
@@ -543,7 +557,7 @@ impl Server {
             issues
         };
 
-        Ok(match fix_mode {
+        let result = match fix_mode {
             FixMode::None => {
                 // Lint-only path.
                 let output =
@@ -935,7 +949,12 @@ impl Server {
                     consistency: consistency_report.as_ref(),
                 })
             }
-        })
+        };
+        tracing::info!(
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "tool_check completed"
+        );
+        Ok(result)
     }
 
     /// Downgrade suppressed issues to Info severity.
@@ -1045,7 +1064,7 @@ fn json_response(
     match serde_json::to_value(result) {
         Ok(v) => JsonRpcResponse::success(id, v),
         Err(e) => {
-            log::error!("failed to serialize response: {e}");
+            tracing::error!("failed to serialize response: {e}");
             JsonRpcResponse::error(id, INTERNAL_ERROR, "internal server error".into())
         }
     }
@@ -1063,7 +1082,7 @@ fn parse_params<T: serde::de::DeserializeOwned>(
     method: &str,
 ) -> Result<T, JsonRpcResponse> {
     serde_json::from_value(std::mem::take(&mut req.params)).map_err(|e| {
-        log::warn!("bad {method} params: {e}");
+        tracing::warn!("bad {method} params: {e}");
         JsonRpcResponse::error(
             req.id.clone(),
             INVALID_PARAMS,
@@ -2381,7 +2400,7 @@ fn build_check_output(params: &CheckOutputParams<'_>) -> CallToolResult {
             }
         }
         Err(e) => {
-            log::error!("failed to serialize check output: {e}");
+            tracing::error!("failed to serialize check output: {e}");
             CallToolResult::error("internal server error".into())
         }
     }

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -113,6 +113,11 @@ fn drain_until_newline(reader: &mut impl BufRead) -> io::Result<()> {
 /// are returned as spillover and re-processed before reading new input.
 pub fn run_stdio(server: &mut Server) -> Result<()> {
     let (line_tx, line_rx) = mpsc::channel::<StdinMsg>();
+    // Unbounded by design: the tracing layer's on_event sends from this same
+    // thread during dispatch, and we drain on this thread between requests. A
+    // bounded channel would deadlock if it filled mid-dispatch (sender blocks,
+    // receiver can't run). Per-request log volume is small, so it can't grow.
+    let (log_tx, log_rx) = mpsc::channel::<crate::trace::McpLogMessage>();
 
     // Background stdin reader: reads bounded lines and sends them to the channel.
     // The raw buffer is allocated once and reused across reads.
@@ -144,7 +149,7 @@ pub fn run_stdio(server: &mut Server) -> Result<()> {
                     }
                 }
                 Err(e) => {
-                    log::warn!("stdin reader: {e}");
+                    tracing::warn!("stdin reader: {e}");
                     break;
                 }
             }
@@ -154,6 +159,7 @@ pub fn run_stdio(server: &mut Server) -> Result<()> {
     let stdout = io::stdout();
     let mut writer = stdout.lock();
     let mut pending: VecDeque<StdinMsg> = VecDeque::new();
+    let mut mcp_logging = false;
 
     // Drain spillover before blocking on the channel; a closed channel
     // produces None and breaks the loop (EOF).
@@ -161,19 +167,25 @@ pub fn run_stdio(server: &mut Server) -> Result<()> {
         let line = match msg {
             StdinMsg::Line(l) => l,
             StdinMsg::TooLong => {
-                log::warn!("line too long, returning error");
+                tracing::warn!("line too long, returning error");
                 let resp =
                     JsonRpcResponse::error(None, INVALID_REQUEST, "request too large".into());
+                if mcp_logging {
+                    drain_mcp_logs(&mut writer, &log_rx)?;
+                }
                 send(&mut writer, &resp)?;
                 continue;
             }
             StdinMsg::MalformedUtf8(e) => {
-                log::warn!("line contains malformed UTF-8 character(s), returning error: {e}");
+                tracing::warn!("line contains malformed UTF-8 character(s), returning error: {e}");
                 let resp = JsonRpcResponse::error(
                     None,
                     PARSE_ERROR,
                     "request contains malformed UTF-8 character(s)".into(),
                 );
+                if mcp_logging {
+                    drain_mcp_logs(&mut writer, &log_rx)?;
+                }
                 send(&mut writer, &resp)?;
                 continue;
             }
@@ -185,11 +197,14 @@ pub fn run_stdio(server: &mut Server) -> Result<()> {
         let mut req: JsonRpcRequest = match super::types::parse_jsonrpc_line(&line) {
             Ok(r) => r,
             Err(TransportError::StaleResponse) => {
-                log::debug!("discarding stale response-shaped message (no id)");
+                tracing::debug!("discarding stale response-shaped message (no id)");
                 continue;
             }
             Err(e) => {
-                log::warn!("{e}");
+                tracing::warn!("{e}");
+                if mcp_logging {
+                    drain_mcp_logs(&mut writer, &log_rx)?;
+                }
                 if let Some(resp) = e.into_response(None) {
                     send(&mut writer, &resp)?;
                 }
@@ -199,6 +214,14 @@ pub fn run_stdio(server: &mut Server) -> Result<()> {
 
         // Notifications (no id) get no response per JSON-RPC spec.
         let (resp, spillover) = dispatch(server, &mut req, &line_rx, &mut writer);
+        if server.supports_logging() && !mcp_logging {
+            crate::trace::set_mcp_log_sender(Some(log_tx.clone()));
+            mcp_logging = true;
+        }
+        // Logs accrue synchronously during dispatch on this same thread, so a
+        // single drain afterward catches everything; emit them before the
+        // response so clients see notifications in causal order.
+        drain_mcp_logs(&mut writer, &log_rx)?;
         if let Some(resp) = resp {
             send(&mut writer, &resp)?;
         }
@@ -207,6 +230,30 @@ pub fn run_stdio(server: &mut Server) -> Result<()> {
         }
     }
 
+    crate::trace::set_mcp_log_sender(None);
+    Ok(())
+}
+
+fn drain_mcp_logs(
+    out: &mut impl Write,
+    log_rx: &mpsc::Receiver<crate::trace::McpLogMessage>,
+) -> Result<()> {
+    let mut wrote = false;
+    while let Ok(msg) = log_rx.try_recv() {
+        serde_json::to_writer(
+            &mut *out,
+            &serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/message",
+                "params": msg,
+            }),
+        )?;
+        out.write_all(b"\n")?;
+        wrote = true;
+    }
+    if wrote {
+        out.flush()?;
+    }
     Ok(())
 }
 

--- a/src/mcp/transport_async.rs
+++ b/src/mcp/transport_async.rs
@@ -35,6 +35,11 @@ async fn async_stdio_loop(server: &mut Server) -> Result<()> {
     let mut raw_buf: Vec<u8> = Vec::new();
     let mut write_buf: Vec<u8> = Vec::new();
 
+    // See sync transport for why this is unbounded: on_event sends from this
+    // same thread during dispatch and we drain it here between requests.
+    let (log_tx, log_rx) = std::sync::mpsc::channel::<crate::trace::McpLogMessage>();
+    let mut mcp_logging = false;
+
     loop {
         raw_buf.clear();
         // Bounded read: read raw bytes up to the limit to avoid InvalidData
@@ -67,6 +72,9 @@ async fn async_stdio_loop(server: &mut Server) -> Result<()> {
                 }
             }
             let resp = JsonRpcResponse::error(None, INVALID_REQUEST, "request too large".into());
+            if mcp_logging {
+                drain_mcp_logs_async(&mut stdout, &log_rx, &mut write_buf).await?;
+            }
             send_async(&mut stdout, &resp, &mut write_buf).await?;
             continue;
         }
@@ -76,6 +84,9 @@ async fn async_stdio_loop(server: &mut Server) -> Result<()> {
                 PARSE_ERROR,
                 "request contains malformed UTF-8 character(s)".into(),
             );
+            if mcp_logging {
+                drain_mcp_logs_async(&mut stdout, &log_rx, &mut write_buf).await?;
+            }
             send_async(&mut stdout, &resp, &mut write_buf).await?;
             continue;
         };
@@ -88,11 +99,14 @@ async fn async_stdio_loop(server: &mut Server) -> Result<()> {
         let mut req = match super::types::parse_jsonrpc_line(line) {
             Ok(r) => r,
             Err(TransportError::StaleResponse) => {
-                log::debug!("discarding stale response-shaped message (no id)");
+                tracing::debug!("discarding stale response-shaped message (no id)");
                 continue;
             }
             Err(e) => {
-                log::warn!("{e}");
+                tracing::warn!("{e}");
+                if mcp_logging {
+                    drain_mcp_logs_async(&mut stdout, &log_rx, &mut write_buf).await?;
+                }
                 if let Some(resp) = e.into_response(None) {
                     send_async(&mut stdout, &resp, &mut write_buf).await?;
                 }
@@ -105,11 +119,45 @@ async fn async_stdio_loop(server: &mut Server) -> Result<()> {
         // The sampling bridge needs synchronous stdin access, so we use a
         // simple non-sampling dispatch for the async path.
         let resp = dispatch_async(server, &mut req);
+        if server.supports_logging() && !mcp_logging {
+            crate::trace::set_mcp_log_sender(Some(log_tx.clone()));
+            mcp_logging = true;
+        }
+        // Emit logs accrued during dispatch before the response, matching the
+        // sync transport's causal ordering.
+        drain_mcp_logs_async(&mut stdout, &log_rx, &mut write_buf).await?;
         if let Some(resp) = resp {
             send_async(&mut stdout, &resp, &mut write_buf).await?;
         }
     }
 
+    crate::trace::set_mcp_log_sender(None);
+    Ok(())
+}
+
+async fn drain_mcp_logs_async(
+    writer: &mut tokio::io::Stdout,
+    log_rx: &std::sync::mpsc::Receiver<crate::trace::McpLogMessage>,
+    buf: &mut Vec<u8>,
+) -> Result<()> {
+    let mut wrote = false;
+    while let Ok(msg) = log_rx.try_recv() {
+        buf.clear();
+        serde_json::to_writer(
+            &mut *buf,
+            &serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/message",
+                "params": msg,
+            }),
+        )?;
+        buf.push(b'\n');
+        writer.write_all(buf).await?;
+        wrote = true;
+    }
+    if wrote {
+        writer.flush().await?;
+    }
     Ok(())
 }
 

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -165,6 +165,8 @@ pub struct ClientCapabilitiesRaw {
     pub sampling: Option<Value>,
     #[serde(default)]
     pub roots: Option<Value>,
+    #[serde(default)]
+    pub logging: Option<Value>,
 }
 
 /// Parsed client capabilities stored by the server.
@@ -174,6 +176,8 @@ pub struct ClientCapabilities {
     pub sampling: bool,
     /// Client supports roots/list.
     pub roots: bool,
+    /// Client supports notifications/message.
+    pub logging: bool,
 }
 
 impl From<&ClientCapabilitiesRaw> for ClientCapabilities {
@@ -181,6 +185,7 @@ impl From<&ClientCapabilitiesRaw> for ClientCapabilities {
         Self {
             sampling: raw.sampling.is_some(),
             roots: raw.roots.is_some(),
+            logging: raw.logging.is_some(),
         }
     }
 }

--- a/src/rules/judgment_cache.rs
+++ b/src/rules/judgment_cache.rs
@@ -284,7 +284,7 @@ impl JudgmentCache {
                     }
                 }
             }
-            Err(e) => log::warn!("failed to serialize judgment cache: {e}"),
+            Err(e) => tracing::warn!("failed to serialize judgment cache: {e}"),
         }
     }
 }
@@ -313,9 +313,9 @@ fn load_or_reset(path: &Path) -> CacheStore {
         result => {
             // Schema mismatch or parse error: backup and reset.
             if let Err(ref e) = result {
-                log::warn!("failed to parse judgment cache: {e}, resetting");
+                tracing::warn!("failed to parse judgment cache: {e}, resetting");
             } else {
-                log::info!("judgment cache schema mismatch, backing up and resetting");
+                tracing::info!("judgment cache schema mismatch, backing up and resetting");
             }
             let backup = path.with_extension("json.bak");
             let _ = std::fs::rename(path, &backup);

--- a/src/rules/loader.rs
+++ b/src/rules/loader.rs
@@ -7,8 +7,18 @@ use super::ruleset::Ruleset;
 /// Postcard deserialization is ~10x faster than serde_json and zero-alloc for
 /// the parse step itself (allocations come from owned String fields).
 pub fn load_embedded_ruleset() -> Result<Ruleset> {
+    let started = std::time::Instant::now();
+    let _span = tracing::info_span!("load_ruleset").entered();
     static RULESET_POSTCARD: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/ruleset.postcard"));
-    postcard::from_bytes(RULESET_POSTCARD).context("parse embedded ruleset (postcard)")
+    let ruleset: Ruleset =
+        postcard::from_bytes(RULESET_POSTCARD).context("parse embedded ruleset (postcard)")?;
+    tracing::info!(
+        spelling_rule_count = ruleset.spelling_rules.len() as u64,
+        case_rule_count = ruleset.case_rules.len() as u64,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "load_ruleset completed"
+    );
+    Ok(ruleset)
 }
 
 /// Compute a combined hash of all rules (spelling + case) for reproducibility tracking.

--- a/src/rules/store.rs
+++ b/src/rules/store.rs
@@ -101,7 +101,7 @@ impl OverrideStore {
                 Ok(ov) if ov.schema_version == SCHEMA_VERSION => ov,
                 Ok(ov) => {
                     let ext = format!("v{}.bak", ov.schema_version);
-                    log::warn!(
+                    tracing::warn!(
                         "override schema version mismatch (stored={}, expected={}); \
                          backing up and resetting",
                         ov.schema_version,
@@ -110,7 +110,7 @@ impl OverrideStore {
                     backup_and_reset(path, &ext)
                 }
                 Err(e) => {
-                    log::warn!("corrupt overrides JSON ({e}); backing up and resetting");
+                    tracing::warn!("corrupt overrides JSON ({e}); backing up and resetting");
                     backup_and_reset(path, "corrupt.bak")
                 }
             }
@@ -365,7 +365,7 @@ impl SuppressionStore {
             match serde_json::from_str::<Suppressions>(&content) {
                 Ok(s) if s.schema_version == SCHEMA_VERSION => s,
                 Ok(s) => {
-                    log::warn!(
+                    tracing::warn!(
                         "suppression schema mismatch (stored={}, expected={}); \
                          backing up and resetting",
                         s.schema_version,
@@ -375,7 +375,7 @@ impl SuppressionStore {
                     Suppressions::default()
                 }
                 Err(e) => {
-                    log::warn!("corrupt suppressions JSON ({e}); backing up and resetting");
+                    tracing::warn!("corrupt suppressions JSON ({e}); backing up and resetting");
                     backup_file(path, "corrupt.bak");
                     Suppressions::default()
                 }
@@ -542,7 +542,7 @@ impl TranslationMemoryStore {
             match serde_json::from_str::<TranslationMemory>(&content) {
                 Ok(tm) if tm.schema_version == TM_SCHEMA_VERSION => tm,
                 Ok(tm) => {
-                    log::warn!(
+                    tracing::warn!(
                         "TM schema version mismatch (stored={}, expected={}); \
                          backing up and resetting",
                         tm.schema_version,
@@ -552,7 +552,7 @@ impl TranslationMemoryStore {
                     TranslationMemory::default()
                 }
                 Err(e) => {
-                    log::warn!("corrupt TM JSON ({e}); backing up and resetting");
+                    tracing::warn!("corrupt TM JSON ({e}); backing up and resetting");
                     backup_file(path, "corrupt.bak");
                     TranslationMemory::default()
                 }
@@ -672,7 +672,7 @@ impl TranslationMemoryStore {
                 updated += 1;
             } else {
                 if self.memory.entries.len() >= TM_MAX_ENTRIES {
-                    log::warn!(
+                    tracing::warn!(
                         "TM entry cap ({TM_MAX_ENTRIES}) reached during import; \
                          skipping new entries (updates still applied)"
                     );
@@ -985,7 +985,7 @@ pub fn build_merged_rules(
                 case_layers.push(pack.case);
             }
             Err(e) => {
-                log::warn!("failed to load pack '{}': {}", pack_name, e);
+                tracing::warn!("failed to load pack '{}': {}", pack_name, e);
             }
         }
     }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,0 +1,108 @@
+use std::collections::BTreeMap;
+use std::sync::{mpsc, Mutex, OnceLock};
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use tracing::field::Field;
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::field::Visit;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{EnvFilter, Layer};
+
+static MCP_LOG_TX: OnceLock<Mutex<Option<mpsc::Sender<McpLogMessage>>>> = OnceLock::new();
+
+#[derive(Clone, Debug, Serialize)]
+pub struct McpLogMessage {
+    pub level: &'static str,
+    pub logger: &'static str,
+    pub data: Value,
+}
+
+pub fn init(default_level: &str) {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+    let subscriber = tracing_subscriber::registry()
+        .with(filter)
+        .with(McpLogLayer)
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr));
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+pub fn set_mcp_log_sender(tx: Option<mpsc::Sender<McpLogMessage>>) {
+    *MCP_LOG_TX.get_or_init(|| Mutex::new(None)).lock().unwrap() = tx;
+}
+
+struct McpLogLayer;
+
+impl<S> Layer<S> for McpLogLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let level = match *event.metadata().level() {
+            Level::ERROR => "error",
+            Level::WARN => "warning",
+            Level::INFO => "info",
+            _ => return,
+        };
+        let Some(tx) = MCP_LOG_TX
+            .get()
+            .and_then(|slot| slot.lock().ok().and_then(|guard| guard.clone()))
+        else {
+            return;
+        };
+
+        let mut visitor = EventVisitor::default();
+        event.record(&mut visitor);
+        let data = json!({
+            "message": visitor.message.unwrap_or_else(|| event.metadata().target().to_string()),
+            "target": event.metadata().target(),
+            "fields": visitor.fields,
+        });
+        let _ = tx.send(McpLogMessage {
+            level,
+            logger: "zhtw-mcp",
+            data,
+        });
+    }
+}
+
+#[derive(Default)]
+struct EventVisitor {
+    message: Option<String>,
+    fields: BTreeMap<String, Value>,
+}
+
+impl Visit for EventVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let value = format!("{value:?}");
+        if field.name() == "message" {
+            self.message = Some(value);
+        } else {
+            self.fields
+                .insert(field.name().to_string(), Value::String(value));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_string());
+        } else {
+            self.fields
+                .insert(field.name().to_string(), Value::String(value.to_string()));
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields.insert(field.name().to_string(), json!(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields.insert(field.name().to_string(), json!(value));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields.insert(field.name().to_string(), json!(value));
+    }
+}

--- a/tests/cli-lint.rs
+++ b/tests/cli-lint.rs
@@ -24,6 +24,7 @@ fn run_lint_stdin(extra_args: &[&str], input: &str) -> Output {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .env_remove("RUST_LOG")
         .spawn()
         .and_then(|mut child| {
             child
@@ -35,6 +36,45 @@ fn run_lint_stdin(extra_args: &[&str], input: &str) -> Output {
             child.wait_with_output()
         })
         .unwrap()
+}
+
+#[test]
+fn cli_lint_json_clean_default_has_empty_stderr() {
+    let output = run_lint_stdin(&["--format", "json"], "正確的軟體");
+    assert!(output.status.success(), "clean JSON lint should exit 0");
+    assert!(
+        output.stderr.is_empty(),
+        "default tracing should not write stderr on clean JSON runs: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn cli_lint_rust_log_debug_emits_scan_trace() {
+    let bin = binary_path();
+    let output = Command::new(&bin)
+        .args(["lint", "--", "--format", "json"])
+        .env("RUST_LOG", "debug")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all("正確的軟體".as_bytes())
+                .unwrap();
+            child.wait_with_output()
+        })
+        .unwrap();
+    assert!(output.status.success(), "debug lint should exit 0");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("scan") && stderr.contains("elapsed_ms"),
+        "debug tracing should include scan timing fields: {stderr}"
+    );
 }
 
 #[test]

--- a/tests/e2e-mcp.rs
+++ b/tests/e2e-mcp.rs
@@ -19,6 +19,27 @@ fn send_recv(stdin: &mut impl Write, stdout: &mut impl BufRead, request: &Value)
     serde_json::from_str(line.trim()).expect("response should be valid JSON")
 }
 
+fn send_recv_skip_notifications(
+    stdin: &mut impl Write,
+    stdout: &mut impl BufRead,
+    request: &Value,
+) -> (Vec<Value>, Value) {
+    let line = serde_json::to_string(request).unwrap();
+    writeln!(stdin, "{line}").unwrap();
+    stdin.flush().unwrap();
+    let id = request.get("id").cloned();
+    let mut notifications = Vec::new();
+    loop {
+        let mut line = String::new();
+        stdout.read_line(&mut line).unwrap();
+        let value: Value = serde_json::from_str(line.trim()).unwrap();
+        if value.get("id") == id.as_ref() {
+            return (notifications, value);
+        }
+        notifications.push(value);
+    }
+}
+
 /// Send a notification (no response expected).
 fn send_notification(stdin: &mut impl Write, request: &Value) {
     let msg = serde_json::to_string(request).unwrap();
@@ -706,6 +727,165 @@ fn e2e_initialize_and_tools_list() {
     let status = child.wait().unwrap();
     assert!(status.success());
     // tmp_dir auto-cleaned on drop
+}
+
+#[test]
+fn e2e_mcp_logging_capability_receives_message_notifications() {
+    let bin = binary_path();
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mut child = Command::new(&bin)
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join(".config"))
+        .env("XDG_CACHE_HOME", tmp.path().join(".cache"))
+        .env("RUST_LOG", "info")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn zhtw-mcp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    let init = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "logging": {} },
+                "clientInfo": { "name": "test", "version": "1.0" }
+            }
+        }),
+    );
+    assert!(
+        init.get("result").is_some(),
+        "initialize should succeed: {init}"
+    );
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({"jsonrpc": "2.0", "method": "notifications/initialized"})
+    )
+    .unwrap();
+    stdin.flush().unwrap();
+
+    let (notifications, resp) = send_recv_skip_notifications(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "zhtw",
+                "arguments": { "text": "這個軟件很好用", "output": "summary" }
+            }
+        }),
+    );
+    assert!(
+        resp.get("result").is_some(),
+        "tools/call should succeed: {resp}"
+    );
+    assert!(
+        notifications.iter().any(|n| {
+            n["method"] == "notifications/message"
+                && n["params"]["logger"] == "zhtw-mcp"
+                && n["params"]["level"] == "info"
+        }),
+        "expected MCP log notification before response, got {notifications:?}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn e2e_mcp_logging_parse_error_is_not_stale() {
+    let bin = binary_path();
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mut child = Command::new(&bin)
+        .env("HOME", tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path().join(".config"))
+        .env("XDG_CACHE_HOME", tmp.path().join(".cache"))
+        .env("RUST_LOG", "info")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn zhtw-mcp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    let init = send_recv(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "logging": {} },
+                "clientInfo": { "name": "test", "version": "1.0" }
+            }
+        }),
+    );
+    assert!(
+        init.get("result").is_some(),
+        "initialize should succeed: {init}"
+    );
+
+    writeln!(stdin, "{{not-json").unwrap();
+    stdin.flush().unwrap();
+
+    let mut line = String::new();
+    stdout.read_line(&mut line).unwrap();
+    let notification: Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(notification["method"], "notifications/message");
+    assert!(
+        notification["params"]["data"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("JSON parse"),
+        "parse warning should be emitted before parse response: {notification}"
+    );
+
+    line.clear();
+    stdout.read_line(&mut line).unwrap();
+    let parse_resp: Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(parse_resp["error"]["code"], -32700, "{parse_resp}");
+
+    let (notifications, resp) = send_recv_skip_notifications(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list"
+        }),
+    );
+    assert!(
+        resp.get("result").is_some(),
+        "tools/list should succeed: {resp}"
+    );
+    assert!(
+        notifications.iter().all(|n| {
+            !n["params"]["data"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("JSON parse")
+        }),
+        "parse warning leaked into later request: {notifications:?}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 #[test]


### PR DESCRIPTION
env_logger gave us level-filtered stderr and nothing else. An MCP server talking JSON-RPC over stdio needs structured logs the client can consume, plus timing on the hot paths so future optimization work has ground truth instead of guesses.

Replace log/env_logger/eprintln! with tracing. A custom subscriber layer forwards INFO/WARN/ERROR events to the MCP client as notifications/message when the client advertises the logging capability; everything still mirrors to stderr via the fmt layer. Forwarding is gated by EnvFilter (default warn), so the scan path pays nothing unless logging is turned up.

Add timing spans to scan, build_ac, fix, load_ruleset, and the per-request dispatch. The completion events carry elapsed_ms and result counts; the spans themselves stay field-light to keep disabled-callsite cost near zero.

Both stdio transports drain accrued logs before each response so clients see notifications in causal order. The log channel is unbounded by necessity: the subscriber sends from the same thread that drains, so a bounded channel could deadlock mid-dispatch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated logging from `log`/`env_logger` to `tracing` and added timing spans on hot paths to improve observability. MCP clients that advertise logging now receive structured INFO/WARN/ERROR notifications in order, without extra cost by default.

- New Features
  - Added a `tracing` subscriber that forwards logs as `notifications/message` when the client declares `logging`; still mirrors to stderr and drains before each response in both stdio transports to keep causal order (uses an unbounded channel to avoid deadlock).
  - Added spans and completion events with elapsed_ms and counts for: scan, build_ac, fix, load_ruleset, and per-request/tool dispatch.
  - Logging level controlled by `RUST_LOG` or CLI flags (`--verbose`, `--debug`); defaults to warn.

- Dependencies
  - Removed `log` and `env_logger`; added `tracing` and `tracing-subscriber`.

<sup>Written for commit 2a8dcdd2fd69064e94a5599275d916da5077be7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/zhtw-mcp/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

