### PR TITLE
Add profiler and cut scanner build time ~40%

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,10 @@ criterion = { version = "0.5", default-features = false }
 name = "scanner"
 harness = false
 
+[[bench]]
+name = "startup"
+harness = false
+
 [profile.release]
 lto = true
 strip = true

--- a/benches/startup.rs
+++ b/benches/startup.rs
@@ -1,0 +1,95 @@
+// Startup / cold-first-request profiler for zhtw-mcp.
+//
+// Not a criterion benchmark: cold-start is a once-per-process event. Criterion
+// runs many iterations, so its lazy statics (grammar AC, zhtype char tables,
+// clue index) are warm after iteration 1 -- it structurally cannot see the
+// cold cost. This binary measures each phase exactly once, in order:
+//
+//   ruleset_load  postcard deserialize of the embedded artifact
+//   scanner_build Aho-Corasick + segmenter construction (what Server::new does)
+//   [server ready = load + build]
+//   first_scan    first tools/call scan -- pays lazy init of grammar AC etc.
+//   warm_scan     steady-state scan (min of a few iters)
+//   [cold overhead = first_scan - warm_scan]
+//
+// Run: cargo run --release --bench startup
+// The 50ms cold-start budget is checked against `server ready + first_scan`;
+// above it, prewarming the lazy first-hit structures during init pays off.
+
+use std::time::Instant;
+
+use zhtw_mcp::engine::scan::Scanner;
+use zhtw_mcp::rules::loader::load_embedded_ruleset;
+use zhtw_mcp::rules::ruleset::Profile;
+
+// Representative first-request text: mixed CJK prose with flaggable Mainland
+// terms plus ASCII, sized like a typical paragraph a client sends first.
+const FIRST_REQUEST: &str = "\
+台灣的軟件工程師使用人工智能技術開發應用程序，\
+他們的網絡質量很高，信息安全也很重要。\
+The server handles HTTP requests via async runtime.\n\
+數據庫中存儲了用戶的個人信息和視頻文件。";
+
+fn ms(d: std::time::Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+fn main() {
+    let t_load = Instant::now();
+    let ruleset = load_embedded_ruleset().expect("load embedded ruleset");
+    let load = t_load.elapsed();
+
+    let t_build = Instant::now();
+    let scanner = Scanner::new(ruleset.spelling_rules, ruleset.case_rules);
+    let build = t_build.elapsed();
+
+    // First cold scan: identical code path to a tools/call, so it triggers
+    // every first-hit lazy structure (grammar AC, SIMPLIFIED/TRADITIONAL char
+    // sets, clue index) exactly as the first real request would.
+    let t_first = Instant::now();
+    let first = scanner.scan_profiled(FIRST_REQUEST, Profile::Base);
+    let first_scan = t_first.elapsed();
+    if first.issues.is_empty() {
+        // Not a failure -- the scanner works, the sample text just stopped
+        // hitting any rule. Warn so the cold measurement isn't trusted blindly.
+        eprintln!("warning: FIRST_REQUEST produced no issues; sample text may be stale");
+    }
+
+    // Warm steady state: min of a handful of iterations, statics now hot.
+    let mut warm = std::time::Duration::MAX;
+    for _ in 0..64 {
+        let t = Instant::now();
+        let out = scanner.scan_profiled(FIRST_REQUEST, Profile::Base);
+        warm = warm.min(t.elapsed());
+        std::hint::black_box(&out);
+    }
+
+    let ready = load + build;
+    let cold_overhead = first_scan.saturating_sub(warm);
+    let cold_first_request = ready + first_scan;
+
+    println!(
+        "startup profile ({} bytes first request)",
+        FIRST_REQUEST.len()
+    );
+    println!("  ruleset_load        {:>8.3} ms", ms(load));
+    println!("  scanner_build       {:>8.3} ms", ms(build));
+    println!("  = server ready      {:>8.3} ms", ms(ready));
+    println!("  first_scan (cold)   {:>8.3} ms", ms(first_scan));
+    println!("  warm_scan           {:>8.3} ms", ms(warm));
+    println!(
+        "  = cold init overhead{:>8.3} ms  (first_scan - warm)",
+        ms(cold_overhead)
+    );
+    println!(
+        "  = cold 1st request  {:>8.3} ms  (ready + first_scan)",
+        ms(cold_first_request)
+    );
+
+    let gate = 50.0;
+    if ms(cold_first_request) > gate {
+        println!("\nover {gate:.0}ms gate -> prewarming worth it");
+    } else {
+        println!("\nunder {gate:.0}ms gate -> prewarming not justified");
+    }
+}

--- a/src/engine/scan/rule_ir.rs
+++ b/src/engine/scan/rule_ir.rs
@@ -11,8 +11,9 @@
 // confirmation, and TM suppression operate at different granularity
 // and are explicitly excluded.
 
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 use daachorse::{CharwiseDoubleArrayAhoCorasickBuilder, MatchKind as DaacMatchKind};
@@ -692,15 +693,22 @@ pub fn compile_spelling_rules_filtered(
         spelling_rules.into_iter().filter(|r| !r.disabled).collect();
 
     // Deduplicate by `from` key (last wins; overrides come after embedded).
+    // Borrow the keys instead of cloning ~1.8k Strings, and mark-then-retain
+    // instead of repeated O(n) Vec::remove.
     {
-        let mut seen = HashSet::new();
-        let mut i = spelling_rules.len();
-        while i > 0 {
-            i -= 1;
-            if !seen.insert(spelling_rules[i].from.clone()) {
-                spelling_rules.remove(i);
+        let mut seen: FxHashSet<&str> = FxHashSet::default();
+        let mut keep = vec![true; spelling_rules.len()];
+        for i in (0..spelling_rules.len()).rev() {
+            if !seen.insert(spelling_rules[i].from.as_str()) {
+                keep[i] = false;
             }
         }
+        let mut i = 0;
+        spelling_rules.retain(|_| {
+            let k = keep[i];
+            i += 1;
+            k
+        });
     }
 
     // Profile-aware filtering: exclude rule types that the target profile
@@ -724,11 +732,11 @@ pub fn compile_spelling_rules_filtered(
     // Deduplicate context clues within each rule.
     for rule in &mut spelling_rules {
         if let Some(ref mut clues) = rule.context_clues {
-            let mut seen = HashSet::new();
+            let mut seen = FxHashSet::default();
             clues.retain(|c| seen.insert(c.clone()));
         }
         if let Some(ref mut clues) = rule.negative_context_clues {
-            let mut seen = HashSet::new();
+            let mut seen = FxHashSet::default();
             clues.retain(|c| seen.insert(c.clone()));
         }
     }
@@ -763,7 +771,7 @@ pub fn compile_spelling_rules_filtered(
     // Build clue AC: intern all unique clue strings, map per-rule clue
     // lists to indices, build a bytewise AC for windowed lookups.
     let (clue_ac, mut rule_pos_clue_ids, mut rule_neg_clue_ids) = {
-        let mut clue_map: HashMap<String, u16> = HashMap::new();
+        let mut clue_map: FxHashMap<String, u16> = FxHashMap::default();
         let mut clue_vec: Vec<String> = Vec::new();
 
         let mut intern_clue = |s: &String| -> Option<u16> {
@@ -884,9 +892,9 @@ pub fn compile_spelling_rules_filtered(
     // injected into the AC so LeftmostLongest suppresses shorter `from`
     // matches.  Indices >= spelling_rules.len() act as sentinels.
     let absorber_strings: Vec<String> = {
-        let from_set: HashSet<&str> = spelling_patterns.iter().copied().collect();
+        let from_set: FxHashSet<&str> = spelling_patterns.iter().copied().collect();
         let mut candidates: Vec<(String, &str)> = Vec::new();
-        let mut dedup = HashSet::new();
+        let mut dedup = FxHashSet::default();
         for rule in &spelling_rules {
             if let Some(ref exceptions) = rule.exceptions {
                 for exc in exceptions {
@@ -908,28 +916,57 @@ pub fn compile_spelling_rules_filtered(
                 }
             }
         }
+        // Index froms by first char.  Both shadow conditions below --
+        // containment (`absorber.contains(f)`) and right-boundary overlap
+        // (a suffix of the absorber is a prefix of f) -- require f's first
+        // char to occur in the absorber.  So only froms bucketed under a
+        // char the absorber actually contains can shadow it; the rest are
+        // skipped.  Exact same result as scanning all patterns, ~50x fewer
+        // comparisons on the ~1.8k-rule ruleset.
+        let mut from_by_first: FxHashMap<char, Vec<&str>> = FxHashMap::default();
+        let mut has_empty_from = false;
+        for &f in &spelling_patterns {
+            match f.chars().next() {
+                Some(c) => from_by_first.entry(c).or_default().push(f),
+                None => has_empty_from = true,
+            }
+        }
+
         // Reject absorbers that would shadow a different rule's `from`.
         candidates
             .into_iter()
             .filter(|(absorber, orig_from)| {
-                !spelling_patterns.iter().any(|&f| {
-                    if f == *orig_from {
-                        return false;
+                // An empty `from` (deduped, so at most one) has no first char
+                // and is thus unbucketed, but it is a substring of every
+                // absorber -- so unless it *is* orig_from, it shadows
+                // unconditionally, exactly as the old full scan did.
+                if has_empty_from && !orig_from.is_empty() {
+                    return false;
+                }
+                let mut chars_seen = FxHashSet::default();
+                !absorber.chars().any(|c| {
+                    if !chars_seen.insert(c) {
+                        return false; // bucket already tested for this absorber
                     }
-                    if absorber.contains(f) {
-                        return true;
-                    }
-                    // Right-boundary overlap: proper suffix of absorber
-                    // is a prefix of f.
-                    let mut chars = absorber.char_indices();
-                    chars.next(); // skip position 0 (full string)
-                    for (byte_idx, _) in chars {
-                        let suffix = &absorber[byte_idx..];
-                        if f.starts_with(suffix) {
+                    from_by_first.get(&c).into_iter().flatten().any(|&f| {
+                        if f == *orig_from {
+                            return false;
+                        }
+                        if absorber.contains(f) {
                             return true;
                         }
-                    }
-                    false
+                        // Right-boundary overlap: proper suffix of absorber
+                        // is a prefix of f.
+                        let mut ci = absorber.char_indices();
+                        ci.next(); // skip position 0 (full string)
+                        for (byte_idx, _) in ci {
+                            let suffix = &absorber[byte_idx..];
+                            if f.starts_with(suffix) {
+                                return true;
+                            }
+                        }
+                        false
+                    })
                 })
             })
             .map(|(s, _)| s)

--- a/src/engine/segment.rs
+++ b/src/engine/segment.rs
@@ -19,7 +19,9 @@
 // of common function words and particles.
 // Freq weights: rule terms=1, general vocab=5, stop words=10.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
+
+use rustc_hash::FxHashMap;
 
 // ---------------------------------------------------------------------------
 // CharTrie — character-indexed trie for O(L) dict lookups
@@ -33,7 +35,10 @@ struct TrieNode {
     freq: u32,
     /// Whether this word is a rule 'from' term (excluded from boundary checks).
     is_rule_from: bool,
-    children: HashMap<char, TrieNode>,
+    // FxHashMap: char keys don't need SipHash's DoS resistance, and this map
+    // is probed once per character on the scan hot path (~56% of spelling-only
+    // time) as well as filled on every startup.
+    children: FxHashMap<char, TrieNode>,
 }
 
 /// Character-indexed trie built from the segmenter dictionary.
@@ -41,13 +46,13 @@ struct TrieNode {
 /// Provides O(L) lookup per position by walking one trie edge per character,
 /// eliminating per-substring hashing in bitmap construction and MMSEG probing.
 struct CharTrie {
-    root: HashMap<char, TrieNode>,
+    root: FxHashMap<char, TrieNode>,
 }
 
 impl CharTrie {
     fn new() -> Self {
         Self {
-            root: HashMap::new(),
+            root: FxHashMap::default(),
         }
     }
 


### PR DESCRIPTION
This adds a startup/cold-first-request profiler measuring ruleset load, scanner build, and first cold scan in one process -- a job criterion cannot do since it warms lazy statics after iteration 1.

Cut scanner_build from ~22ms to ~13ms on the reference target:
- Absorber shadow-check was an O(candidates x rules) scan over all ~1.8k `from` patterns. Both shadow conditions require the pattern's first char to occur in the absorber, so bucket patterns by first char and test only the relevant buckets. An empty `from` has no first char and matches every absorber, so it keeps an explicit unconditional-shadow guard to preserve identical output.
- Swap SipHash for FxHash on the transient build-time maps/sets (trusted ruleset input, built once) and on the segmenter CharTrie, which is also probed once per char on the scan hot path.
- Deduplicate `from` keys by borrowing instead of cloning ~1.8k Strings, and mark-then-retain instead of repeated O(n) Vec::remove.

Close #5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a startup/cold-first-request profiler and cuts scanner build time by ~40% (≈22ms → ≈13ms) on the reference target. Closes #5.

- **New Features**
  - Startup profiler for ruleset_load, scanner_build, first cold scan, and warm scan; run with `cargo run --release --bench startup` and see a 50ms gate hint.

- **Refactors**
  - Bucket `from` patterns by first char for absorber shadow checks; treat empty `from` as unconditional shadow to keep output identical.
  - Replace SipHash with `rustc_hash` (`FxHashMap`/`FxHashSet`) in transient build-time maps/sets and the segmenter `CharTrie`.
  - Deduplicate `from` keys by borrowing and mark-then-retain to avoid cloning ~1.8k strings and repeated O(n) removes.

<sup>Written for commit fa5992023254f9f0d14acffc1c834024817658c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/zhtw-mcp/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

