### PR TITLE
Reject malformed JSON-RPC messages carrying an ID

### DIFF
--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -549,11 +549,10 @@ pub fn parse_jsonrpc_line(line: &str) -> Result<JsonRpcRequest, TransportError> 
     // Step 3: handle messages without a method field.
     if obj.is_object() && obj.get("method").is_none() {
         let is_response = obj.get("result").is_some() || obj.get("error").is_some();
-        if is_response {
-            // Response-shaped (has result/error, no method): silently discard.
+        if is_response && !id_present {
+            // Response-shaped (has result/error, no method, no id): silently discard.
             // JSON-RPC 2.0: "The Server MUST NOT reply to a Response."
-            // Covers late sampling responses (with id) and orphaned responses
-            // (without id).
+            // Covers orphaned responses (without id).
             return Err(TransportError::StaleResponse);
         }
         if id_present {
@@ -819,15 +818,16 @@ mod tests {
     }
 
     #[test]
-    fn parse_response_shaped_with_id_returns_stale() {
-        // JSON-RPC 2.0: "The Server MUST NOT reply to a Response."
-        // Response-shaped messages (has result/error, no method) are silently
-        // discarded regardless of whether they carry an id.
+    fn parse_response_shaped_with_id_without_method_returns_invalid_request() {
         let line = r#"{"jsonrpc":"2.0","id":1,"result":"ok"}"#;
         let err = parse_jsonrpc_line(line).unwrap_err();
-        assert!(matches!(err, TransportError::StaleResponse));
-        assert_eq!(err.error_code(), None);
-        assert!(err.into_response(None).is_none());
+        assert!(matches!(err, TransportError::InvalidRequest(..)));
+        assert_eq!(err.error_code(), Some(INVALID_REQUEST));
+        let resp = err.into_response(None).expect("should produce response");
+        match &resp.id {
+            Some(RequestId::Int(1)) => {}
+            other => panic!("expected id=1, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tests/e2e-mcp.rs
+++ b/tests/e2e-mcp.rs
@@ -1446,29 +1446,18 @@ fn e2e_not_json_returns_parse_error() {
 }
 
 #[test]
-fn e2e_response_shaped_with_id_discarded() {
+fn e2e_response_shaped_with_id_rejected() {
     let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
 
-    // Response-shaped message WITH id: silently discarded per JSON-RPC 2.0
-    // ("The Server MUST NOT reply to a Response").
+    // Reject response-shaped messages with an ID but no method with INVALID_REQUEST (-32600)
     let response_msg = r#"{"jsonrpc":"2.0","id":999,"result":"stale"}"#;
     writeln!(stdin, "{response_msg}").unwrap();
     stdin.flush().unwrap();
 
-    // No error response expected — verify the server is still alive by
-    // sending a real request and getting a valid response.
-    let resp = send_recv(
-        &mut stdin,
-        &mut stdout,
-        &json!({
-            "jsonrpc": "2.0",
-            "method": "tools/list",
-            "id": 105,
-            "params": {}
-        }),
-    );
-    assert_eq!(resp["id"], 105);
-    assert!(resp["result"].is_object(), "server should still be alive");
+    let mut line = String::new();
+    stdout.read_line(&mut line).unwrap();
+    let resp: Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(resp["error"]["code"].as_i64().unwrap(), -32600);
 
     drop(stdin);
     let status = child.wait().unwrap();


### PR DESCRIPTION
This PR fixes issue #6.

If anything is missed or can be improved, please provide guidance. Thank you.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed JSON-RPC messages that include an id but no method by returning INVALID_REQUEST (-32600) with the same id. Messages without a method and without an id remain silently discarded.

- **Bug Fixes**
  - Treat response-shaped messages with an id and no method as InvalidRequest (-32600) and reply with that id; keep discarding id-less responses.
  - Updated unit and e2e tests to assert the new behavior.

<sup>Written for commit 8cc1d72b0b9cd549d1d7be60571ad72c6b73a199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/zhtw-mcp/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

