### PR TITLE
Add E2E test for invalid request-shaped messages

### DIFF
--- a/tests/e2e-mcp.rs
+++ b/tests/e2e-mcp.rs
@@ -1504,6 +1504,26 @@ fn e2e_response_shaped_without_id_discarded() {
 }
 
 #[test]
+fn e2e_request_with_id_without_method_rejected() {
+    let (mut stdin, mut stdout, mut child, _tmp) = spawn_initialized_child();
+
+    // Request-shaped message WITH id but WITHOUT method: should be rejected with INVALID_REQUEST.
+    let request_msg = r#"{"jsonrpc":"2.0","id":999}"#;
+    writeln!(stdin, "{request_msg}").unwrap();
+    stdin.flush().unwrap();
+
+    let mut line = String::new();
+    stdout.read_line(&mut line).unwrap();
+    let resp: Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(resp["id"], 999);
+    assert_eq!(resp["error"]["code"].as_i64().unwrap(), -32600);
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "child exited with {status}");
+}
+
+#[test]
 fn e2e_notification_with_id_no_response() {
     let bin = binary_path();
     let tmp_dir = tempfile::tempdir().expect("create temp dir");


### PR DESCRIPTION
This PR fixes #6 by enhancing test coverage for invalid request-shaped messages (requests with `id` but missing `method`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an E2E test to enforce JSON-RPC 2.0: request-shaped messages with an `id` but no `method` are rejected with INVALID_REQUEST (-32600). Fixes #6 and prevents regressions in invalid request handling.

<sup>Written for commit 5a2ebdb36ed35ea819b482a96c2249865c4d18ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/zhtw-mcp/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

