### PR TITLE
Make nix build work for new gen-s2t-tables

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,12 +8,12 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1777624102,
-        "narHash": "sha256-thSyElkje577x/kAbP72nHlfiFc1a+tCudskLPHXe9s=",
-        "rev": "4d81601e0b73f20d81d066754ad0e7d1e7f75a06",
-        "revCount": 2646,
+        "lastModified": 1782900513,
+        "narHash": "sha256-GHrsl1+ysDFgmDQtQSqWS7TiYD2Q58VlwLvnf1+crJM=",
+        "rev": "16810aa8f4ad89ca480b1513774e8b6f485fe368",
+        "revCount": 2708,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2646%2Brev-4d81601e0b73f20d81d066754ad0e7d1e7f75a06/019de2eb-4157-78e2-99a4-47e0ab7416f5/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2708%2Brev-16810aa8f4ad89ca480b1513774e8b6f485fe368/019f1d68-8b55-7783-bed1-d5926f21ae52/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -22,12 +22,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779508470,
-        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
-        "rev": "29916453413845e54a65b8a1cf996842300cd299",
-        "revCount": 1003640,
+        "lastModified": 1786247143,
+        "narHash": "sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ=",
+        "rev": "279b4a8275f032c566576b3f181fa0f27197f588",
+        "revCount": 1050399,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1003640%2Brev-29916453413845e54a65b8a1cf996842300cd299/019e5626-8c96-7cc1-83dd-de1831a60fd0/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.1050399%2Brev-279b4a8275f032c566576b3f181fa0f27197f588/019fef1d-180e-7420-ad78-d4b69fb2fb24/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -37,16 +37,17 @@
     "opencc-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779550076,
-        "narHash": "sha256-1DKcihwGvqvFnSjHt5vghwwHiOrhTP1yiouWqUi8TtQ=",
+        "lastModified": 1786023992,
+        "narHash": "sha256-amxRrJ6u+mKaUciHhry2K1qs+elww1m1hAhta/+YBGI=",
         "owner": "BYVoid",
         "repo": "OpenCC",
-        "rev": "c2ce81bf9af90f7e667c9da1d32e960dd79f9771",
+        "rev": "5249273a3e5606852f088c9a8b23522145d94f78",
         "type": "github"
       },
       "original": {
         "owner": "BYVoid",
         "repo": "OpenCC",
+        "rev": "5249273a3e5606852f088c9a8b23522145d94f78",
         "type": "github"
       }
     },
@@ -60,11 +61,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1777583169,
-        "narHash": "sha256-dVJ4+wrRKc8oIgp3rLOFSq1obt/sCKlXy3h47qof/w0=",
+        "lastModified": 1782864348,
+        "narHash": "sha256-NVYhLbaefeIUftPlo3kS6qr0xd8eFJRodEiaHrvFKR4=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "aa64e4828a2bbba44463c1229a81c748d3cce583",
+        "rev": "0d381ca097a8e0375a19387874d952c0a230ac4f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,10 @@
       url = "https://flakehub.com/f/nix-community/fenix/0.1";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # Must match OPENCC_COMMIT in scripts/gen-s2t-tables.py; pinned in the URL
+    # so `nix flake update` cannot move the conversion tables.
     opencc-src = {
-      url = "github:BYVoid/OpenCC";
+      url = "github:BYVoid/OpenCC/5249273a3e5606852f088c9a8b23522145d94f78";
       flake = false;
     };
   };
@@ -78,11 +80,26 @@
               final.rustToolchain
             ];
 
+            # The sandbox has no network, so seed the generator's cache from
+            # the pinned input.  Its path is keyed by OPENCC_COMMIT, read from
+            # the script rather than hardcoded: a copy landing anywhere else is
+            # ignored and the build falls through to a download that must fail.
             preBuild = ''
-              mkdir -p data/opencc
-              cp ${opencc-src}/data/dictionary/STPhrases.txt data/opencc/STPhrases.txt
-              cp ${opencc-src}/data/dictionary/STCharacters.txt data/opencc/STCharacters.txt
-              cp ${opencc-src}/data/dictionary/TWVariants.txt data/opencc/TWVariants.txt
+              pinned=$(sed -n 's/^OPENCC_COMMIT = "\(.*\)"$/\1/p' scripts/gen-s2t-tables.py)
+              if [ "$pinned" != "${opencc-src.rev}" ]; then
+                echo "error: flake.lock pins OpenCC ${opencc-src.rev}, but" >&2
+                echo "  scripts/gen-s2t-tables.py pins $pinned." >&2
+                echo "  Re-pin inputs.opencc-src.url in flake.nix, then run:" >&2
+                echo "    nix flake lock --override-input opencc-src github:BYVoid/OpenCC/$pinned" >&2
+                exit 1
+              fi
+
+              cache=data/opencc/''${pinned:0:12}
+              mkdir -p "$cache"
+              for dict in STPhrases STCharacters TWVariants; do
+                cp ${opencc-src}/data/dictionary/$dict.txt "$cache/$dict.txt"
+              done
+
               python3 scripts/gen-s2t-tables.py
               rustfmt src/engine/s2t_data.rs
             '';

--- a/scripts/gen-s2t-tables.py
+++ b/scripts/gen-s2t-tables.py
@@ -33,6 +33,10 @@ OUTPUT = REPO / "src" / "engine" / "s2t_data.rs"
 # To bump: change OPENCC_COMMIT, run this script, and paste the printed
 # source hash into EXPECTED_SOURCE_HASH.  The check below refuses to
 # generate if only one of the two moved, so a bump cannot be half-applied.
+#
+# Re-pin flake.nix and flake.lock to the same commit, because the Nix build
+# fills this cache from that input instead of downloading:
+#   nix flake lock --override-input opencc-src github:BYVoid/OpenCC/<commit>
 OPENCC_COMMIT = "5249273a3e5606852f088c9a8b23522145d94f78"
 EXPECTED_SOURCE_HASH = "959b88f60c9dcc0d"
 


### PR DESCRIPTION
新的 `gen-s2t-tables` 鎖了 Git commit，跟 flake.lock 的對不上。這裡把 Flake 改成固定 Git commit，然後在 `gen-s2t-tables` 的更新流程補充這部分的更新。